### PR TITLE
feat: ハートビート & セルフヘルスチェック機能を追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -9,7 +9,7 @@ license = "MIT"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "time"] }
 toml = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,3 +8,9 @@ log_level = "info"
 [modules]
 # 各モジュールの有効/無効を設定する
 # (モジュールが実装され次第、ここに項目が追加される)
+
+[health]
+# ハートビート（定期的なヘルスチェックログ出力）の有効/無効
+enabled = true
+# ハートビートのインターバル（秒）
+heartbeat_interval_secs = 60

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,10 @@ pub struct AppConfig {
     /// モジュール設定
     #[serde(default)]
     pub modules: ModulesConfig,
+
+    /// ヘルスチェック設定
+    #[serde(default)]
+    pub health: HealthConfig,
 }
 
 /// 一般設定
@@ -25,6 +29,37 @@ pub struct GeneralConfig {
 /// モジュール設定（将来の拡張用）
 #[derive(Debug, Default, Deserialize)]
 pub struct ModulesConfig {}
+
+/// ヘルスチェック設定
+#[derive(Debug, Deserialize)]
+pub struct HealthConfig {
+    /// ハートビートを有効にするか
+    #[serde(default = "HealthConfig::default_enabled")]
+    pub enabled: bool,
+
+    /// ハートビートのインターバル（秒）
+    #[serde(default = "HealthConfig::default_interval")]
+    pub heartbeat_interval_secs: u64,
+}
+
+impl HealthConfig {
+    fn default_enabled() -> bool {
+        true
+    }
+
+    fn default_interval() -> u64 {
+        60
+    }
+}
+
+impl Default for HealthConfig {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            heartbeat_interval_secs: Self::default_interval(),
+        }
+    }
+}
 
 impl GeneralConfig {
     fn default_log_level() -> String {
@@ -94,6 +129,25 @@ log_level = "debug"
         write!(tmpfile, "invalid = [[[toml").unwrap();
         let result = AppConfig::load(tmpfile.path());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_health_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(config.health.enabled);
+        assert_eq!(config.health.heartbeat_interval_secs, 60);
+    }
+
+    #[test]
+    fn test_health_config_custom() {
+        let toml_str = r#"
+[health]
+enabled = false
+heartbeat_interval_secs = 30
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.health.enabled);
+        assert_eq!(config.health.heartbeat_interval_secs, 30);
     }
 
     #[test]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -1,16 +1,18 @@
 use crate::config::AppConfig;
+use crate::core::health::HealthChecker;
 use crate::error::AppError;
+use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
 
 /// デーモンプロセスを管理する
 pub struct Daemon {
-    _config: AppConfig,
+    config: AppConfig,
 }
 
 impl Daemon {
     /// 新しいデーモンインスタンスを作成する
     pub fn new(config: AppConfig) -> Self {
-        Self { _config: config }
+        Self { config }
     }
 
     /// デーモンを起動し、シグナルを受信するまでブロックする
@@ -18,7 +20,21 @@ impl Daemon {
         let mut sigterm = signal(SignalKind::terminate()).map_err(AppError::SignalHandler)?;
         let mut sighup = signal(SignalKind::hangup()).map_err(AppError::SignalHandler)?;
 
+        let health_checker = HealthChecker::new();
+        let health_enabled = self.config.health.enabled;
+        let heartbeat_interval = Duration::from_secs(self.config.health.heartbeat_interval_secs);
+        let mut heartbeat = tokio::time::interval(heartbeat_interval);
+        // 最初の tick は即座に発火するのでスキップ
+        heartbeat.tick().await;
+
         tracing::info!("デーモンを起動しました");
+
+        if health_enabled {
+            tracing::info!(
+                interval_secs = self.config.health.heartbeat_interval_secs,
+                "ハートビートを有効化しました"
+            );
+        }
 
         loop {
             tokio::select! {
@@ -32,6 +48,25 @@ impl Daemon {
                 }
                 _ = sighup.recv() => {
                     tracing::info!("SIGHUP を受信しました。ホットリロードは未実装です");
+                }
+                _ = heartbeat.tick(), if health_enabled => {
+                    let status = health_checker.status();
+                    match status.memory_rss_kb {
+                        Some(rss_kb) => {
+                            let rss_mb = rss_kb as f64 / 1024.0;
+                            tracing::info!(
+                                uptime_secs = status.uptime_secs,
+                                memory_rss_mb = format!("{rss_mb:.1}"),
+                                "ハートビート"
+                            );
+                        }
+                        None => {
+                            tracing::info!(
+                                uptime_secs = status.uptime_secs,
+                                "ハートビート（メモリ情報取得不可）"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/core/health.rs
+++ b/src/core/health.rs
@@ -1,0 +1,94 @@
+use std::fs;
+use std::time::Instant;
+
+/// デーモンの健全性情報
+#[derive(Debug)]
+pub struct HealthStatus {
+    /// 稼働時間（秒）
+    pub uptime_secs: u64,
+    /// メモリ使用量（KB）。取得できない場合は None。
+    pub memory_rss_kb: Option<u64>,
+}
+
+/// デーモンのヘルスチェックを行う
+pub struct HealthChecker {
+    started_at: Instant,
+}
+
+impl HealthChecker {
+    /// 新しいヘルスチェッカーを作成する
+    pub fn new() -> Self {
+        Self {
+            started_at: Instant::now(),
+        }
+    }
+
+    /// 現在のヘルスステータスを取得する
+    pub fn status(&self) -> HealthStatus {
+        HealthStatus {
+            uptime_secs: self.started_at.elapsed().as_secs(),
+            memory_rss_kb: read_vm_rss_kb(),
+        }
+    }
+}
+
+impl Default for HealthChecker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `/proc/self/status` から VmRSS（物理メモリ使用量）を読み取る
+fn read_vm_rss_kb() -> Option<u64> {
+    let content = fs::read_to_string("/proc/self/status").ok()?;
+    for line in content.lines() {
+        if let Some(value) = line.strip_prefix("VmRSS:") {
+            let value = value.trim().trim_end_matches("kB").trim();
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_health_checker_uptime() {
+        let checker = HealthChecker::new();
+        thread::sleep(Duration::from_millis(100));
+        let status = checker.status();
+        // 少なくとも 0 秒以上（ミリ秒単位のスリープなので 0 または 1）
+        assert!(status.uptime_secs < 5);
+    }
+
+    #[test]
+    fn test_health_checker_memory() {
+        let checker = HealthChecker::new();
+        let status = checker.status();
+        // Linux 環境では /proc/self/status が存在するので Some が返る
+        if cfg!(target_os = "linux") {
+            assert!(status.memory_rss_kb.is_some());
+            assert!(status.memory_rss_kb.unwrap() > 0);
+        }
+    }
+
+    #[test]
+    fn test_read_vm_rss_kb() {
+        let rss = read_vm_rss_kb();
+        if cfg!(target_os = "linux") {
+            assert!(rss.is_some());
+            assert!(rss.unwrap() > 0);
+        }
+    }
+
+    #[test]
+    fn test_health_checker_default() {
+        let checker = HealthChecker::default();
+        let status = checker.status();
+        assert!(status.uptime_secs < 5);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod daemon;
 pub mod event;
+pub mod health;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use zettai_mamorukun::config::AppConfig;
+use zettai_mamorukun::core::health::HealthChecker;
 
 #[test]
 fn test_config_default_when_file_missing() {
@@ -16,6 +17,38 @@ fn test_binary_help() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("サイバー攻撃防御デーモン"));
+}
+
+#[test]
+fn test_health_checker_integration() {
+    let checker = HealthChecker::new();
+    let status = checker.status();
+    // 統合テストでの基本的な動作確認
+    assert!(status.uptime_secs < 60);
+    // Linux 環境では VmRSS が取得できる
+    assert!(status.memory_rss_kb.is_some());
+    assert!(status.memory_rss_kb.unwrap() > 0);
+}
+
+#[test]
+fn test_config_with_health_section() {
+    use std::io::Write;
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        tmpfile,
+        r#"
+[general]
+log_level = "debug"
+
+[health]
+enabled = true
+heartbeat_interval_secs = 10
+"#
+    )
+    .unwrap();
+    let config = AppConfig::load(tmpfile.path()).unwrap();
+    assert!(config.health.enabled);
+    assert_eq!(config.health.heartbeat_interval_secs, 10);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- デーモンが定期的に自身の健全性をチェックし、稼働時間とメモリ使用量をログに記録するハートビート機能を追加
- `/proc/self/status` から VmRSS を読み取り、プロセスのメモリ使用量を監視
- 設定ファイル (`[health]` セクション) でハートビートの有効/無効、インターバルを制御可能

Closes #3

## 変更内容

| ファイル | 変更 |
|---------|------|
| `src/core/health.rs` | `HealthChecker` / `HealthStatus` 構造体を新規追加 |
| `src/config.rs` | `HealthConfig` を追加（`enabled`, `heartbeat_interval_secs`） |
| `src/core/daemon.rs` | `tokio::select!` ループにハートビートタイマーを統合 |
| `config.example.toml` | `[health]` セクションを追加 |
| `Cargo.toml` | tokio に `time` feature 追加、バージョン 0.2.0 に更新 |

## Test plan

- [x] 単体テスト: HealthChecker の稼働時間・メモリ取得
- [x] 単体テスト: HealthConfig のデフォルト値・カスタム値
- [x] 統合テスト: HealthChecker の基本動作
- [x] 統合テスト: health セクション付き設定ファイルの読み込み
- [x] 統合テスト: デーモン SIGTERM シャットダウン（既存テスト維持）
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo fmt --check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)