### PR TITLE
feat: プロセス異常検知モジュールを追加 (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ src/
   modules/
     mod.rs             # モジュールトレイト・レジストリ
     file_integrity.rs  # ファイル整合性監視モジュール
+    process_monitor.rs # プロセス異常検知モジュール
 tests/
   integration_test.rs  # 統合テスト
 config.example.toml    # 設定ファイルサンプル

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -13,6 +13,14 @@ scan_interval_secs = 300
 # 監視対象パスのリスト
 watch_paths = []
 
+[modules.process_monitor]
+# プロセス異常検知モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+scan_interval_secs = 60
+# 不審とみなすパスのリスト
+suspicious_paths = ["/tmp", "/dev/shm", "/var/tmp"]
+
 [health]
 # ハートビート（定期的なヘルスチェックログ出力）の有効/無効
 enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,10 @@ pub struct ModulesConfig {
     /// ファイル整合性監視モジュールの設定
     #[serde(default)]
     pub file_integrity: FileIntegrityConfig,
+
+    /// プロセス異常検知モジュールの設定
+    #[serde(default)]
+    pub process_monitor: ProcessMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -62,6 +66,46 @@ impl Default for FileIntegrityConfig {
             enabled: false,
             scan_interval_secs: Self::default_scan_interval_secs(),
             watch_paths: Vec::new(),
+        }
+    }
+}
+
+/// プロセス異常検知モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct ProcessMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "ProcessMonitorConfig::default_scan_interval_secs")]
+    pub scan_interval_secs: u64,
+
+    /// 不審とみなすパスのリスト
+    #[serde(default = "ProcessMonitorConfig::default_suspicious_paths")]
+    pub suspicious_paths: Vec<PathBuf>,
+}
+
+impl ProcessMonitorConfig {
+    fn default_scan_interval_secs() -> u64 {
+        60
+    }
+
+    fn default_suspicious_paths() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/tmp"),
+            PathBuf::from("/dev/shm"),
+            PathBuf::from("/var/tmp"),
+        ]
+    }
+}
+
+impl Default for ProcessMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_interval_secs: Self::default_scan_interval_secs(),
+            suspicious_paths: Self::default_suspicious_paths(),
         }
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -3,6 +3,7 @@ use crate::core::health::HealthChecker;
 use crate::error::AppError;
 use crate::modules::Module;
 use crate::modules::file_integrity::FileIntegrityModule;
+use crate::modules::process_monitor::ProcessMonitorModule;
 use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
 
@@ -36,6 +37,18 @@ impl Daemon {
             let cancel_token = fim.cancel_token();
             fim.start().await?;
             tracing::info!("ファイル整合性監視モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
+        // プロセス異常検知モジュールの初期化と起動
+        let pm_cancel_token = if self.config.modules.process_monitor.enabled {
+            let mut pm = ProcessMonitorModule::new(self.config.modules.process_monitor.clone());
+            pm.init()?;
+            let cancel_token = pm.cancel_token();
+            pm.start().await?;
+            tracing::info!("プロセス異常検知モジュールを起動しました");
             Some(cancel_token)
         } else {
             None
@@ -89,6 +102,10 @@ impl Daemon {
         if let Some(cancel_token) = fim_cancel_token {
             cancel_token.cancel();
             tracing::info!("ファイル整合性監視モジュールを停止しました");
+        }
+        if let Some(cancel_token) = pm_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("プロセス異常検知モジュールを停止しました");
         }
 
         tracing::info!("シャットダウン完了");

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_integrity;
+pub mod process_monitor;
 
 use crate::error::AppError;
 

--- a/src/modules/process_monitor.rs
+++ b/src/modules/process_monitor.rs
@@ -1,0 +1,444 @@
+//! プロセス異常検知モジュール
+//!
+//! `/proc` ファイルシステムを定期的にスキャンし、不審なプロセスを検知する。
+//!
+//! 検知対象:
+//! - 削除済みバイナリからの実行（`/proc/<pid>/exe` が `(deleted)` を含む）
+//! - 不審なパスからの実行（`/tmp`, `/dev/shm` など一時ディレクトリ）
+//! - 隠しディレクトリからの実行（パスに `.` で始まるコンポーネントが含まれる）
+
+use crate::config::ProcessMonitorConfig;
+use crate::error::AppError;
+use crate::modules::Module;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use tokio_util::sync::CancellationToken;
+
+/// プロセスの異常種別
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum AnomalyKind {
+    /// 削除済みバイナリから実行されている
+    DeletedBinary,
+    /// 不審なパスから実行されている
+    SuspiciousPath,
+    /// 隠しディレクトリから実行されている
+    HiddenDirectory,
+}
+
+impl std::fmt::Display for AnomalyKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AnomalyKind::DeletedBinary => write!(f, "deleted_binary"),
+            AnomalyKind::SuspiciousPath => write!(f, "suspicious_path"),
+            AnomalyKind::HiddenDirectory => write!(f, "hidden_directory"),
+        }
+    }
+}
+
+/// 検知されたプロセスの異常情報
+#[derive(Debug)]
+struct ProcessAnomaly {
+    pid: u32,
+    exe_path: String,
+    kind: AnomalyKind,
+}
+
+/// プロセス異常検知モジュール
+///
+/// `/proc` を定期スキャンし、不審なプロセスを検知してログに記録する。
+pub struct ProcessMonitorModule {
+    config: ProcessMonitorConfig,
+    cancel_token: CancellationToken,
+}
+
+impl ProcessMonitorModule {
+    /// 新しいプロセス異常検知モジュールを作成する
+    pub fn new(config: ProcessMonitorConfig) -> Self {
+        Self {
+            config,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// `/proc` からプロセス一覧を取得し、各プロセスの実行パスを返す
+    fn scan_processes() -> Vec<(u32, String)> {
+        let mut processes = Vec::new();
+        let proc_dir = match std::fs::read_dir("/proc") {
+            Ok(dir) => dir,
+            Err(e) => {
+                tracing::warn!(error = %e, "/proc の読み取りに失敗しました");
+                return processes;
+            }
+        };
+
+        for entry in proc_dir {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            // PID（数字のみ）のディレクトリをフィルタ
+            let pid: u32 = match name_str.parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            // /proc/<pid>/exe の readlink で実行パスを取得
+            let exe_link = PathBuf::from(format!("/proc/{pid}/exe"));
+            match std::fs::read_link(&exe_link) {
+                Ok(exe_path) => {
+                    processes.push((pid, exe_path.to_string_lossy().into_owned()));
+                }
+                Err(_) => {
+                    // 権限不足やプロセス終了により読めない場合はスキップ
+                    continue;
+                }
+            }
+        }
+
+        processes
+    }
+
+    /// プロセスの異常を検査する
+    fn check_anomalies(
+        processes: &[(u32, String)],
+        suspicious_paths: &[PathBuf],
+    ) -> Vec<ProcessAnomaly> {
+        let mut anomalies = Vec::new();
+
+        for (pid, exe_path) in processes {
+            // 1. 削除済みバイナリの検知
+            if exe_path.contains(" (deleted)") {
+                anomalies.push(ProcessAnomaly {
+                    pid: *pid,
+                    exe_path: exe_path.clone(),
+                    kind: AnomalyKind::DeletedBinary,
+                });
+                continue;
+            }
+
+            let path = Path::new(exe_path);
+
+            // 2. 不審なパスからの実行検知
+            if is_under_suspicious_path(path, suspicious_paths) {
+                anomalies.push(ProcessAnomaly {
+                    pid: *pid,
+                    exe_path: exe_path.clone(),
+                    kind: AnomalyKind::SuspiciousPath,
+                });
+                continue;
+            }
+
+            // 3. 隠しディレクトリからの実行検知
+            if is_in_hidden_directory(path) {
+                anomalies.push(ProcessAnomaly {
+                    pid: *pid,
+                    exe_path: exe_path.clone(),
+                    kind: AnomalyKind::HiddenDirectory,
+                });
+            }
+        }
+
+        anomalies
+    }
+}
+
+/// パスが不審なディレクトリ配下にあるかを判定する
+fn is_under_suspicious_path(exe_path: &Path, suspicious_paths: &[PathBuf]) -> bool {
+    suspicious_paths
+        .iter()
+        .any(|suspicious| exe_path.starts_with(suspicious))
+}
+
+/// パスに隠しディレクトリ（`.` で始まるコンポーネント）が含まれるかを判定する
+fn is_in_hidden_directory(exe_path: &Path) -> bool {
+    exe_path.components().any(|component| {
+        if let std::path::Component::Normal(name) = component {
+            name.to_string_lossy().starts_with('.')
+        } else {
+            false
+        }
+    })
+}
+
+impl Module for ProcessMonitorModule {
+    fn name(&self) -> &str {
+        "process_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.scan_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "scan_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        tracing::info!(
+            scan_interval_secs = self.config.scan_interval_secs,
+            suspicious_paths = ?self.config.suspicious_paths,
+            "プロセス異常検知モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        // 初回スキャンで動作確認
+        let processes = Self::scan_processes();
+        tracing::info!(
+            process_count = processes.len(),
+            "初回プロセススキャンが完了しました"
+        );
+
+        let suspicious_paths = self.config.suspicious_paths.clone();
+        let scan_interval_secs = self.config.scan_interval_secs;
+        let cancel_token = self.cancel_token.clone();
+
+        // 既知の PID を記録し、同じ PID の同じ異常を繰り返し警告しない
+        let mut known_anomalies: HashSet<(u32, String)> = HashSet::new();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
+            // 最初の tick は即座に発火するのでスキップ
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("プロセス異常検知モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let processes = ProcessMonitorModule::scan_processes();
+                        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious_paths);
+
+                        // 現在の PID セットを構築（終了済みプロセスを known から除去）
+                        let current_pids: HashSet<u32> = processes.iter().map(|(pid, _)| *pid).collect();
+                        known_anomalies.retain(|(pid, _)| current_pids.contains(pid));
+
+                        for anomaly in &anomalies {
+                            let key = (anomaly.pid, anomaly.kind.to_string());
+                            if known_anomalies.insert(key) {
+                                tracing::warn!(
+                                    pid = anomaly.pid,
+                                    exe_path = %anomaly.exe_path,
+                                    anomaly_kind = %anomaly.kind,
+                                    "不審なプロセスを検知しました"
+                                );
+                            }
+                        }
+
+                        if anomalies.is_empty() {
+                            tracing::debug!("不審なプロセスは検知されませんでした");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_under_suspicious_path() {
+        let suspicious = vec![
+            PathBuf::from("/tmp"),
+            PathBuf::from("/dev/shm"),
+            PathBuf::from("/var/tmp"),
+        ];
+
+        assert!(is_under_suspicious_path(
+            Path::new("/tmp/malware"),
+            &suspicious
+        ));
+        assert!(is_under_suspicious_path(
+            Path::new("/dev/shm/payload"),
+            &suspicious
+        ));
+        assert!(is_under_suspicious_path(
+            Path::new("/var/tmp/backdoor"),
+            &suspicious
+        ));
+        assert!(!is_under_suspicious_path(
+            Path::new("/usr/bin/bash"),
+            &suspicious
+        ));
+        assert!(!is_under_suspicious_path(
+            Path::new("/home/user/app"),
+            &suspicious
+        ));
+    }
+
+    #[test]
+    fn test_is_under_suspicious_path_empty() {
+        let suspicious: Vec<PathBuf> = vec![];
+        assert!(!is_under_suspicious_path(
+            Path::new("/tmp/something"),
+            &suspicious
+        ));
+    }
+
+    #[test]
+    fn test_is_in_hidden_directory() {
+        assert!(is_in_hidden_directory(Path::new(
+            "/home/user/.hidden/malware"
+        )));
+        assert!(is_in_hidden_directory(Path::new("/opt/.secret/bin/app")));
+        assert!(is_in_hidden_directory(Path::new(
+            "/tmp/.X11-unix/something"
+        )));
+        assert!(!is_in_hidden_directory(Path::new("/usr/bin/bash")));
+        assert!(!is_in_hidden_directory(Path::new("/home/user/normal/app")));
+    }
+
+    #[test]
+    fn test_is_in_hidden_directory_root() {
+        assert!(!is_in_hidden_directory(Path::new("/usr/bin/ls")));
+        assert!(!is_in_hidden_directory(Path::new("/")));
+    }
+
+    #[test]
+    fn test_check_anomalies_deleted_binary() {
+        let processes = vec![(1234, "/usr/bin/test (deleted)".to_string())];
+        let suspicious = vec![PathBuf::from("/tmp")];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].pid, 1234);
+        assert_eq!(anomalies[0].kind, AnomalyKind::DeletedBinary);
+    }
+
+    #[test]
+    fn test_check_anomalies_suspicious_path() {
+        let processes = vec![(5678, "/tmp/backdoor".to_string())];
+        let suspicious = vec![PathBuf::from("/tmp")];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].pid, 5678);
+        assert_eq!(anomalies[0].kind, AnomalyKind::SuspiciousPath);
+    }
+
+    #[test]
+    fn test_check_anomalies_hidden_directory() {
+        let processes = vec![(9012, "/home/user/.hidden/malware".to_string())];
+        let suspicious: Vec<PathBuf> = vec![];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].pid, 9012);
+        assert_eq!(anomalies[0].kind, AnomalyKind::HiddenDirectory);
+    }
+
+    #[test]
+    fn test_check_anomalies_no_anomaly() {
+        let processes = vec![
+            (1, "/usr/bin/bash".to_string()),
+            (2, "/usr/sbin/sshd".to_string()),
+        ];
+        let suspicious = vec![PathBuf::from("/tmp")];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert!(anomalies.is_empty());
+    }
+
+    #[test]
+    fn test_check_anomalies_priority_deleted_over_suspicious() {
+        // 削除済みかつ不審パスの場合、削除済みが優先される（continue で次へ）
+        let processes = vec![(1234, "/tmp/malware (deleted)".to_string())];
+        let suspicious = vec![PathBuf::from("/tmp")];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].kind, AnomalyKind::DeletedBinary);
+    }
+
+    #[test]
+    fn test_check_anomalies_multiple() {
+        let processes = vec![
+            (1, "/usr/bin/bash".to_string()),
+            (2, "/tmp/miner".to_string()),
+            (3, "/usr/bin/old (deleted)".to_string()),
+            (4, "/home/user/.hidden/shell".to_string()),
+        ];
+        let suspicious = vec![PathBuf::from("/tmp"), PathBuf::from("/dev/shm")];
+
+        let anomalies = ProcessMonitorModule::check_anomalies(&processes, &suspicious);
+        assert_eq!(anomalies.len(), 3);
+    }
+
+    #[test]
+    fn test_scan_processes_returns_results() {
+        // 実環境でのテスト: /proc が存在する Linux 上で実行
+        let processes = ProcessMonitorModule::scan_processes();
+        // 少なくとも自プロセスは見えるはず
+        assert!(!processes.is_empty());
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = ProcessMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 0,
+            suspicious_paths: vec![],
+        };
+        let mut module = ProcessMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_valid_config() {
+        let config = ProcessMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            suspicious_paths: vec![PathBuf::from("/tmp")],
+        };
+        let mut module = ProcessMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let config = ProcessMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 3600,
+            suspicious_paths: vec![PathBuf::from("/tmp")],
+        };
+        let mut module = ProcessMonitorModule::new(config);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+
+    #[test]
+    fn test_anomaly_kind_display() {
+        assert_eq!(AnomalyKind::DeletedBinary.to_string(), "deleted_binary");
+        assert_eq!(AnomalyKind::SuspiciousPath.to_string(), "suspicious_path");
+        assert_eq!(AnomalyKind::HiddenDirectory.to_string(), "hidden_directory");
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -75,6 +75,34 @@ watch_paths = ["/tmp"]
 }
 
 #[test]
+fn test_config_with_process_monitor_section() {
+    use std::io::Write;
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        tmpfile,
+        r#"
+[modules.process_monitor]
+enabled = true
+scan_interval_secs = 30
+suspicious_paths = ["/tmp", "/dev/shm"]
+"#
+    )
+    .unwrap();
+    let config = AppConfig::load(tmpfile.path()).unwrap();
+    assert!(config.modules.process_monitor.enabled);
+    assert_eq!(config.modules.process_monitor.scan_interval_secs, 30);
+    assert_eq!(config.modules.process_monitor.suspicious_paths.len(), 2);
+}
+
+#[test]
+fn test_config_process_monitor_disabled_by_default() {
+    let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
+    assert!(!config.modules.process_monitor.enabled);
+    assert_eq!(config.modules.process_monitor.scan_interval_secs, 60);
+    assert_eq!(config.modules.process_monitor.suspicious_paths.len(), 3);
+}
+
+#[test]
 fn test_config_file_integrity_disabled_by_default() {
     let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
     assert!(!config.modules.file_integrity.enabled);


### PR DESCRIPTION
## Summary

- `/proc` ファイルシステムを定期スキャンし、不審なプロセスを検知する `ProcessMonitorModule` を追加
- 検知対象: 削除済みバイナリ、不審パスからの実行、隠しディレクトリからの実行
- 設定ファイルでスキャン間隔・不審パスリストを制御可能

Closes #7

## 変更内容

| ファイル | 変更 |
|---------|------|
| `src/modules/process_monitor.rs` | 新規: ProcessMonitorModule 実装 |
| `src/modules/mod.rs` | process_monitor モジュール追加 |
| `src/config.rs` | ProcessMonitorConfig 追加 |
| `src/core/daemon.rs` | モジュール統合 |
| `config.example.toml` | 設定サンプル追加 |
| `Cargo.toml` | v0.4.0 にバージョンアップ |
| `CLAUDE.md` | ディレクトリ構成更新 |
| `tests/integration_test.rs` | 統合テスト追加 |

## Test plan

- [x] `cargo test` — 全 53 テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット済み
- [x] `cargo build --release` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)