### PR TITLE
feat: マウントポイント監視モジュールを追加 (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ src/
     firewall_monitor.rs # ファイアウォールルール監視モジュール
     kernel_module.rs   # カーネルモジュール監視モジュール
     log_tamper.rs      # ログファイル改ざん検知モジュール
+    mount_monitor.rs   # マウントポイント監視モジュール
     process_monitor.rs # プロセス異常検知モジュール
     ssh_key_monitor.rs # SSH公開鍵ファイル監視モジュール
     systemd_service.rs # systemd サービス監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.11.0"
+version = "0.13.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -75,6 +75,14 @@ scan_interval_secs = 120
 # 監視対象の authorized_keys ファイルパスのリスト
 watch_paths = ["/root/.ssh/authorized_keys"]
 
+[modules.mount_monitor]
+# マウントポイント監視モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+scan_interval_secs = 30
+# マウント情報ファイルのパス
+mounts_path = "/proc/mounts"
+
 [modules.user_account]
 # ユーザーアカウント監視モジュールの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,10 @@ pub struct ModulesConfig {
     /// SSH公開鍵ファイル監視モジュールの設定
     #[serde(default)]
     pub ssh_key_monitor: SshKeyMonitorConfig,
+
+    /// マウントポイント監視モジュールの設定
+    #[serde(default)]
+    pub mount_monitor: MountMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -457,6 +461,42 @@ impl Default for SshKeyMonitorConfig {
     }
 }
 
+/// マウントポイント監視モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct MountMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "MountMonitorConfig::default_scan_interval_secs")]
+    pub scan_interval_secs: u64,
+
+    /// マウント情報ファイルのパス
+    #[serde(default = "MountMonitorConfig::default_mounts_path")]
+    pub mounts_path: PathBuf,
+}
+
+impl MountMonitorConfig {
+    fn default_scan_interval_secs() -> u64 {
+        30
+    }
+
+    fn default_mounts_path() -> PathBuf {
+        PathBuf::from("/proc/mounts")
+    }
+}
+
+impl Default for MountMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_interval_secs: Self::default_scan_interval_secs(),
+            mounts_path: Self::default_mounts_path(),
+        }
+    }
+}
+
 /// ヘルスチェック設定
 #[derive(Debug, Deserialize)]
 pub struct HealthConfig {
@@ -704,5 +744,33 @@ watch_paths = ["/root/.ssh/authorized_keys", "/home/admin/.ssh/authorized_keys"]
         assert!(config.modules.ssh_key_monitor.enabled);
         assert_eq!(config.modules.ssh_key_monitor.scan_interval_secs, 60);
         assert_eq!(config.modules.ssh_key_monitor.watch_paths.len(), 2);
+    }
+
+    #[test]
+    fn test_mount_monitor_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(!config.modules.mount_monitor.enabled);
+        assert_eq!(config.modules.mount_monitor.scan_interval_secs, 30);
+        assert_eq!(
+            config.modules.mount_monitor.mounts_path,
+            PathBuf::from("/proc/mounts")
+        );
+    }
+
+    #[test]
+    fn test_mount_monitor_config_custom() {
+        let toml_str = r#"
+[modules.mount_monitor]
+enabled = true
+scan_interval_secs = 15
+mounts_path = "/proc/self/mounts"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.modules.mount_monitor.enabled);
+        assert_eq!(config.modules.mount_monitor.scan_interval_secs, 15);
+        assert_eq!(
+            config.modules.mount_monitor.mounts_path,
+            PathBuf::from("/proc/self/mounts")
+        );
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -8,6 +8,7 @@ use crate::modules::file_integrity::FileIntegrityModule;
 use crate::modules::firewall_monitor::FirewallMonitorModule;
 use crate::modules::kernel_module::KernelModuleMonitor;
 use crate::modules::log_tamper::LogTamperModule;
+use crate::modules::mount_monitor::MountMonitorModule;
 use crate::modules::process_monitor::ProcessMonitorModule;
 use crate::modules::ssh_key_monitor::SshKeyMonitorModule;
 use crate::modules::systemd_service::SystemdServiceModule;
@@ -146,6 +147,18 @@ impl Daemon {
             None
         };
 
+        // マウントポイント監視モジュールの初期化と起動
+        let mnt_cancel_token = if self.config.modules.mount_monitor.enabled {
+            let mut mnt = MountMonitorModule::new(self.config.modules.mount_monitor.clone());
+            mnt.init()?;
+            let cancel_token = mnt.cancel_token();
+            mnt.start().await?;
+            tracing::info!("マウントポイント監視モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
         // ユーザーアカウント監視モジュールの初期化と起動
         let ua_cancel_token = if self.config.modules.user_account.enabled {
             let mut ua = UserAccountModule::new(self.config.modules.user_account.clone());
@@ -238,6 +251,10 @@ impl Daemon {
         if let Some(cancel_token) = ssh_cancel_token {
             cancel_token.cancel();
             tracing::info!("SSH公開鍵ファイル監視モジュールを停止しました");
+        }
+        if let Some(cancel_token) = mnt_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("マウントポイント監視モジュールを停止しました");
         }
         if let Some(cancel_token) = ua_cancel_token {
             cancel_token.cancel();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -4,6 +4,7 @@ pub mod file_integrity;
 pub mod firewall_monitor;
 pub mod kernel_module;
 pub mod log_tamper;
+pub mod mount_monitor;
 pub mod process_monitor;
 pub mod ssh_key_monitor;
 pub mod systemd_service;

--- a/src/modules/mount_monitor.rs
+++ b/src/modules/mount_monitor.rs
@@ -1,0 +1,585 @@
+//! マウントポイント監視モジュール
+//!
+//! `/proc/mounts` を定期的にスキャンし、マウントポイントの変更を検知する。
+//!
+//! 検知対象:
+//! - 新規マウントポイントの追加
+//! - 既存マウントポイントの削除
+//! - マウントオプションやファイルシステムタイプの変更
+
+use crate::config::MountMonitorConfig;
+use crate::error::AppError;
+use crate::modules::Module;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
+
+/// マウントエントリ（`/proc/mounts` の 1 行分）
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MountEntry {
+    device: String,
+    mount_point: String,
+    fs_type: String,
+    options: String,
+}
+
+/// マウントポイント変更レポート
+struct ChangeReport {
+    added: Vec<MountEntry>,
+    removed: Vec<MountEntry>,
+    modified: Vec<(MountEntry, MountEntry)>,
+}
+
+impl ChangeReport {
+    /// 変更があったかどうかを返す
+    fn has_changes(&self) -> bool {
+        !self.added.is_empty() || !self.removed.is_empty() || !self.modified.is_empty()
+    }
+}
+
+/// マウントポイント監視モジュール
+///
+/// `/proc/mounts` を定期スキャンし、ベースラインとの差分を検知する。
+pub struct MountMonitorModule {
+    config: MountMonitorConfig,
+    cancel_token: CancellationToken,
+}
+
+impl MountMonitorModule {
+    /// 新しいマウントポイント監視モジュールを作成する
+    pub fn new(config: MountMonitorConfig) -> Self {
+        Self {
+            config,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// `/proc/mounts` の内容をパースしてマウントエントリのリストを返す
+    fn parse_mounts(content: &str) -> Vec<MountEntry> {
+        content
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() {
+                    return None;
+                }
+                let fields: Vec<&str> = line.split_whitespace().collect();
+                if fields.len() < 4 {
+                    tracing::debug!(
+                        line = line,
+                        "マウントエントリのパースに失敗しました。フィールド数不足"
+                    );
+                    return None;
+                }
+                Some(MountEntry {
+                    device: fields[0].to_string(),
+                    mount_point: fields[1].to_string(),
+                    fs_type: fields[2].to_string(),
+                    options: fields[3].to_string(),
+                })
+            })
+            .collect()
+    }
+
+    /// マウントエントリのリストを mount_point をキーとする HashMap に変換する
+    fn entries_to_map(entries: &[MountEntry]) -> HashMap<String, MountEntry> {
+        let mut map = HashMap::new();
+        for entry in entries {
+            map.insert(entry.mount_point.clone(), entry.clone());
+        }
+        map
+    }
+
+    /// `/proc/mounts` ファイルを読み込みパースする
+    fn read_mounts(mounts_path: &PathBuf) -> Result<Vec<MountEntry>, AppError> {
+        let content = std::fs::read_to_string(mounts_path).map_err(|e| AppError::FileIo {
+            path: mounts_path.clone(),
+            source: e,
+        })?;
+        Ok(Self::parse_mounts(&content))
+    }
+
+    /// ベースラインと現在のマウント状態を比較し、変更レポートを返す
+    fn detect_changes(
+        baseline: &HashMap<String, MountEntry>,
+        current: &HashMap<String, MountEntry>,
+    ) -> ChangeReport {
+        let mut added = Vec::new();
+        let mut removed = Vec::new();
+        let mut modified = Vec::new();
+
+        for (mount_point, current_entry) in current {
+            match baseline.get(mount_point) {
+                Some(baseline_entry) if baseline_entry != current_entry => {
+                    modified.push((baseline_entry.clone(), current_entry.clone()));
+                }
+                None => {
+                    added.push(current_entry.clone());
+                }
+                _ => {}
+            }
+        }
+
+        for (mount_point, baseline_entry) in baseline {
+            if !current.contains_key(mount_point) {
+                removed.push(baseline_entry.clone());
+            }
+        }
+
+        ChangeReport {
+            added,
+            removed,
+            modified,
+        }
+    }
+}
+
+impl Module for MountMonitorModule {
+    fn name(&self) -> &str {
+        "mount_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.scan_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "scan_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        tracing::info!(
+            mounts_path = %self.config.mounts_path.display(),
+            scan_interval_secs = self.config.scan_interval_secs,
+            "マウントポイント監視モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        // 初回スキャンでベースライン作成
+        let entries = Self::read_mounts(&self.config.mounts_path)?;
+        let baseline = Self::entries_to_map(&entries);
+        tracing::info!(
+            mount_count = baseline.len(),
+            "ベースラインスキャンが完了しました"
+        );
+
+        let mounts_path = self.config.mounts_path.clone();
+        let scan_interval_secs = self.config.scan_interval_secs;
+        let cancel_token = self.cancel_token.clone();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
+            // 最初の tick は即座に発火するのでスキップ
+            interval.tick().await;
+
+            let mut baseline = baseline;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("マウントポイント監視モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let current_entries = match MountMonitorModule::read_mounts(&mounts_path) {
+                            Ok(entries) => entries,
+                            Err(e) => {
+                                tracing::error!(error = %e, "マウント情報の読み取りに失敗しました");
+                                continue;
+                            }
+                        };
+                        let current = MountMonitorModule::entries_to_map(&current_entries);
+                        let report = MountMonitorModule::detect_changes(&baseline, &current);
+
+                        if report.has_changes() {
+                            for entry in &report.added {
+                                tracing::warn!(
+                                    mount_point = %entry.mount_point,
+                                    device = %entry.device,
+                                    fs_type = %entry.fs_type,
+                                    options = %entry.options,
+                                    change = "added",
+                                    "新規マウントポイントを検知しました"
+                                );
+                            }
+                            for entry in &report.removed {
+                                tracing::warn!(
+                                    mount_point = %entry.mount_point,
+                                    device = %entry.device,
+                                    fs_type = %entry.fs_type,
+                                    change = "removed",
+                                    "マウントポイントの削除を検知しました"
+                                );
+                            }
+                            for (old, new) in &report.modified {
+                                tracing::warn!(
+                                    mount_point = %new.mount_point,
+                                    old_device = %old.device,
+                                    new_device = %new.device,
+                                    old_fs_type = %old.fs_type,
+                                    new_fs_type = %new.fs_type,
+                                    old_options = %old.options,
+                                    new_options = %new.options,
+                                    change = "modified",
+                                    "マウントポイントの変更を検知しました"
+                                );
+                            }
+                            // ベースラインを更新
+                            baseline = current;
+                        } else {
+                            tracing::debug!("マウントポイントの変更はありません");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_mounts_basic() {
+        let content = "sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n";
+        let entries = MountMonitorModule::parse_mounts(content);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].device, "sysfs");
+        assert_eq!(entries[0].mount_point, "/sys");
+        assert_eq!(entries[0].fs_type, "sysfs");
+        assert_eq!(entries[0].options, "rw,nosuid,nodev,noexec,relatime");
+        assert_eq!(entries[1].device, "proc");
+        assert_eq!(entries[1].mount_point, "/proc");
+    }
+
+    #[test]
+    fn test_parse_mounts_empty() {
+        let entries = MountMonitorModule::parse_mounts("");
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_parse_mounts_blank_lines() {
+        let content = "\n  \nsysfs /sys sysfs rw 0 0\n\n";
+        let entries = MountMonitorModule::parse_mounts(content);
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_mounts_insufficient_fields() {
+        let content = "device /mnt\nsysfs /sys sysfs rw 0 0\n";
+        let entries = MountMonitorModule::parse_mounts(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].device, "sysfs");
+    }
+
+    #[test]
+    fn test_entries_to_map() {
+        let entries = vec![
+            MountEntry {
+                device: "sysfs".to_string(),
+                mount_point: "/sys".to_string(),
+                fs_type: "sysfs".to_string(),
+                options: "rw".to_string(),
+            },
+            MountEntry {
+                device: "/dev/sda1".to_string(),
+                mount_point: "/".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw,relatime".to_string(),
+            },
+        ];
+        let map = MountMonitorModule::entries_to_map(&entries);
+        assert_eq!(map.len(), 2);
+        assert!(map.contains_key("/sys"));
+        assert!(map.contains_key("/"));
+    }
+
+    #[test]
+    fn test_detect_changes_no_changes() {
+        let entry = MountEntry {
+            device: "/dev/sda1".to_string(),
+            mount_point: "/".to_string(),
+            fs_type: "ext4".to_string(),
+            options: "rw".to_string(),
+        };
+        let mut baseline = HashMap::new();
+        baseline.insert("/".to_string(), entry.clone());
+        let current = baseline.clone();
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert!(!report.has_changes());
+    }
+
+    #[test]
+    fn test_detect_changes_added() {
+        let baseline = HashMap::new();
+        let mut current = HashMap::new();
+        current.insert(
+            "/mnt/evil".to_string(),
+            MountEntry {
+                device: "tmpfs".to_string(),
+                mount_point: "/mnt/evil".to_string(),
+                fs_type: "tmpfs".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert_eq!(report.added.len(), 1);
+        assert!(report.removed.is_empty());
+        assert!(report.modified.is_empty());
+        assert_eq!(report.added[0].mount_point, "/mnt/evil");
+    }
+
+    #[test]
+    fn test_detect_changes_removed() {
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            "/mnt/data".to_string(),
+            MountEntry {
+                device: "/dev/sdb1".to_string(),
+                mount_point: "/mnt/data".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        let current = HashMap::new();
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert!(report.added.is_empty());
+        assert_eq!(report.removed.len(), 1);
+        assert!(report.modified.is_empty());
+    }
+
+    #[test]
+    fn test_detect_changes_modified_options() {
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            "/".to_string(),
+            MountEntry {
+                device: "/dev/sda1".to_string(),
+                mount_point: "/".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw,relatime".to_string(),
+            },
+        );
+        let mut current = HashMap::new();
+        current.insert(
+            "/".to_string(),
+            MountEntry {
+                device: "/dev/sda1".to_string(),
+                mount_point: "/".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw,noatime".to_string(),
+            },
+        );
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert!(report.added.is_empty());
+        assert!(report.removed.is_empty());
+        assert_eq!(report.modified.len(), 1);
+    }
+
+    #[test]
+    fn test_detect_changes_modified_device() {
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            "/mnt/data".to_string(),
+            MountEntry {
+                device: "/dev/sdb1".to_string(),
+                mount_point: "/mnt/data".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        let mut current = HashMap::new();
+        current.insert(
+            "/mnt/data".to_string(),
+            MountEntry {
+                device: "/dev/sdc1".to_string(),
+                mount_point: "/mnt/data".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert_eq!(report.modified.len(), 1);
+        assert_eq!(report.modified[0].0.device, "/dev/sdb1");
+        assert_eq!(report.modified[0].1.device, "/dev/sdc1");
+    }
+
+    #[test]
+    fn test_detect_changes_combined() {
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            "/".to_string(),
+            MountEntry {
+                device: "/dev/sda1".to_string(),
+                mount_point: "/".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        baseline.insert(
+            "/mnt/old".to_string(),
+            MountEntry {
+                device: "/dev/sdb1".to_string(),
+                mount_point: "/mnt/old".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        baseline.insert(
+            "/mnt/changed".to_string(),
+            MountEntry {
+                device: "/dev/sdc1".to_string(),
+                mount_point: "/mnt/changed".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+
+        let mut current = HashMap::new();
+        current.insert(
+            "/".to_string(),
+            MountEntry {
+                device: "/dev/sda1".to_string(),
+                mount_point: "/".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        current.insert(
+            "/mnt/new".to_string(),
+            MountEntry {
+                device: "tmpfs".to_string(),
+                mount_point: "/mnt/new".to_string(),
+                fs_type: "tmpfs".to_string(),
+                options: "rw".to_string(),
+            },
+        );
+        current.insert(
+            "/mnt/changed".to_string(),
+            MountEntry {
+                device: "/dev/sdc1".to_string(),
+                mount_point: "/mnt/changed".to_string(),
+                fs_type: "ext4".to_string(),
+                options: "ro".to_string(),
+            },
+        );
+
+        let report = MountMonitorModule::detect_changes(&baseline, &current);
+        assert_eq!(report.added.len(), 1);
+        assert_eq!(report.removed.len(), 1);
+        assert_eq!(report.modified.len(), 1);
+    }
+
+    #[test]
+    fn test_change_report_has_changes_empty() {
+        let report = ChangeReport {
+            added: vec![],
+            removed: vec![],
+            modified: vec![],
+        };
+        assert!(!report.has_changes());
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = MountMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 0,
+            mounts_path: PathBuf::from("/proc/mounts"),
+        };
+        let mut module = MountMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let config = MountMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 30,
+            mounts_path: PathBuf::from("/proc/mounts"),
+        };
+        let mut module = MountMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_read_mounts_from_proc() {
+        // /proc/mounts が存在する環境でのみテスト
+        let path = PathBuf::from("/proc/mounts");
+        if path.exists() {
+            let entries = MountMonitorModule::read_mounts(&path).unwrap();
+            assert!(!entries.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_read_mounts_nonexistent() {
+        let path = PathBuf::from("/tmp/nonexistent-zettai-mounts-test");
+        let result = MountMonitorModule::read_mounts(&path);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        // テスト用の仮マウントファイルを作成
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmpfile.path(),
+            "sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0\n",
+        )
+        .unwrap();
+
+        let config = MountMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 3600,
+            mounts_path: tmpfile.path().to_path_buf(),
+        };
+        let mut module = MountMonitorModule::new(config);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+
+    #[test]
+    fn test_parse_mounts_real_format() {
+        let content = r#"/dev/sda1 / ext4 rw,relatime,errors=remount-ro 0 0
+tmpfs /run tmpfs rw,nosuid,nodev,mode=755 0 0
+/dev/sda2 /home ext4 rw,relatime 0 0
+overlay /var/lib/docker/overlay2/abc/merged overlay rw,lowerdir=/var/lib/docker/overlay2/abc/diff,upperdir=/var/lib/docker/overlay2/abc/upper,workdir=/var/lib/docker/overlay2/abc/work 0 0
+"#;
+        let entries = MountMonitorModule::parse_mounts(content);
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[3].fs_type, "overlay");
+        assert_eq!(
+            entries[3].mount_point,
+            "/var/lib/docker/overlay2/abc/merged"
+        );
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -283,6 +283,40 @@ fn test_config_firewall_monitor_disabled_by_default() {
 }
 
 #[test]
+fn test_config_with_mount_monitor_section() {
+    use std::io::Write;
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        tmpfile,
+        r#"
+[modules.mount_monitor]
+enabled = true
+scan_interval_secs = 15
+mounts_path = "/proc/mounts"
+"#
+    )
+    .unwrap();
+    let config = AppConfig::load(tmpfile.path()).unwrap();
+    assert!(config.modules.mount_monitor.enabled);
+    assert_eq!(config.modules.mount_monitor.scan_interval_secs, 15);
+    assert_eq!(
+        config.modules.mount_monitor.mounts_path,
+        std::path::PathBuf::from("/proc/mounts")
+    );
+}
+
+#[test]
+fn test_config_mount_monitor_disabled_by_default() {
+    let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
+    assert!(!config.modules.mount_monitor.enabled);
+    assert_eq!(config.modules.mount_monitor.scan_interval_secs, 30);
+    assert_eq!(
+        config.modules.mount_monitor.mounts_path,
+        std::path::PathBuf::from("/proc/mounts")
+    );
+}
+
+#[test]
 fn test_config_file_integrity_disabled_by_default() {
     let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
     assert!(!config.modules.file_integrity.enabled);


### PR DESCRIPTION
## Summary

- `/proc/mounts` を定期的に監視し、マウントポイントの追加・削除・変更を検知する `MountMonitorModule` を追加
- bind mount や overlayfs によるファイルシステム改ざん攻撃の検知に有用
- 既存モジュールパターン（ベースライン方式・CancellationToken）に準拠

## 変更内容

- `src/modules/mount_monitor.rs` — 新規モジュール本体（パース・差分検知・監視ループ）+ 単体テスト18件
- `src/config.rs` — `MountMonitorConfig` 追加 + 単体テスト2件
- `src/modules/mod.rs` — `pub mod mount_monitor` 追加
- `src/core/daemon.rs` — モジュールの初期化・起動・停止を追加
- `config.example.toml` — 設定例追加
- `CLAUDE.md` — ディレクトリ構成に `mount_monitor.rs` 追加
- `tests/integration_test.rs` — 統合テスト2件追加
- `Cargo.toml` — バージョンを 0.13.0 に更新

## Test plan

- [x] `cargo test` — 全212ユニットテスト + 23統合テスト パス
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット済み
- [x] `cargo build --release` — ビルド成功

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)