### PR TITLE
feat: シェル設定ファイル監視モジュールを追加 (#27)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ src/
     log_tamper.rs      # ログファイル改ざん検知モジュール
     mount_monitor.rs   # マウントポイント監視モジュール
     process_monitor.rs # プロセス異常検知モジュール
+    shell_config_monitor.rs # シェル設定ファイル監視モジュール
     ssh_key_monitor.rs # SSH公開鍵ファイル監視モジュール
     systemd_service.rs # systemd サービス監視モジュール
     user_account.rs    # ユーザーアカウント監視モジュール

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -75,6 +75,14 @@ scan_interval_secs = 120
 # 監視対象の authorized_keys ファイルパスのリスト
 watch_paths = ["/root/.ssh/authorized_keys"]
 
+[modules.shell_config_monitor]
+# シェル設定ファイル監視モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+scan_interval_secs = 120
+# 監視対象のシェル設定ファイルパスのリスト
+watch_paths = ["/etc/profile", "/etc/bash.bashrc", "/etc/environment", "/root/.bashrc", "/root/.profile"]
+
 [modules.mount_monitor]
 # マウントポイント監視モジュールの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,10 @@ pub struct ModulesConfig {
     /// マウントポイント監視モジュールの設定
     #[serde(default)]
     pub mount_monitor: MountMonitorConfig,
+
+    /// シェル設定ファイル監視モジュールの設定
+    #[serde(default)]
+    pub shell_config_monitor: ShellConfigMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -497,6 +501,48 @@ impl Default for MountMonitorConfig {
     }
 }
 
+/// シェル設定ファイル監視モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct ShellConfigMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "ShellConfigMonitorConfig::default_scan_interval_secs")]
+    pub scan_interval_secs: u64,
+
+    /// 監視対象のシェル設定ファイルパスのリスト
+    #[serde(default = "ShellConfigMonitorConfig::default_watch_paths")]
+    pub watch_paths: Vec<PathBuf>,
+}
+
+impl ShellConfigMonitorConfig {
+    fn default_scan_interval_secs() -> u64 {
+        120
+    }
+
+    fn default_watch_paths() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/etc/profile"),
+            PathBuf::from("/etc/bash.bashrc"),
+            PathBuf::from("/etc/environment"),
+            PathBuf::from("/root/.bashrc"),
+            PathBuf::from("/root/.profile"),
+        ]
+    }
+}
+
+impl Default for ShellConfigMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_interval_secs: Self::default_scan_interval_secs(),
+            watch_paths: Self::default_watch_paths(),
+        }
+    }
+}
+
 /// ヘルスチェック設定
 #[derive(Debug, Deserialize)]
 pub struct HealthConfig {
@@ -772,5 +818,27 @@ mounts_path = "/proc/self/mounts"
             config.modules.mount_monitor.mounts_path,
             PathBuf::from("/proc/self/mounts")
         );
+    }
+
+    #[test]
+    fn test_shell_config_monitor_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(!config.modules.shell_config_monitor.enabled);
+        assert_eq!(config.modules.shell_config_monitor.scan_interval_secs, 120);
+        assert_eq!(config.modules.shell_config_monitor.watch_paths.len(), 5);
+    }
+
+    #[test]
+    fn test_shell_config_monitor_config_custom() {
+        let toml_str = r#"
+[modules.shell_config_monitor]
+enabled = true
+scan_interval_secs = 60
+watch_paths = ["/etc/profile", "/etc/bash.bashrc"]
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.modules.shell_config_monitor.enabled);
+        assert_eq!(config.modules.shell_config_monitor.scan_interval_secs, 60);
+        assert_eq!(config.modules.shell_config_monitor.watch_paths.len(), 2);
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -10,6 +10,7 @@ use crate::modules::kernel_module::KernelModuleMonitor;
 use crate::modules::log_tamper::LogTamperModule;
 use crate::modules::mount_monitor::MountMonitorModule;
 use crate::modules::process_monitor::ProcessMonitorModule;
+use crate::modules::shell_config_monitor::ShellConfigMonitorModule;
 use crate::modules::ssh_key_monitor::SshKeyMonitorModule;
 use crate::modules::systemd_service::SystemdServiceModule;
 use crate::modules::user_account::UserAccountModule;
@@ -147,6 +148,19 @@ impl Daemon {
             None
         };
 
+        // シェル設定ファイル監視モジュールの初期化と起動
+        let sc_cancel_token = if self.config.modules.shell_config_monitor.enabled {
+            let mut sc =
+                ShellConfigMonitorModule::new(self.config.modules.shell_config_monitor.clone());
+            sc.init()?;
+            let cancel_token = sc.cancel_token();
+            sc.start().await?;
+            tracing::info!("シェル設定ファイル監視モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
         // マウントポイント監視モジュールの初期化と起動
         let mnt_cancel_token = if self.config.modules.mount_monitor.enabled {
             let mut mnt = MountMonitorModule::new(self.config.modules.mount_monitor.clone());
@@ -251,6 +265,10 @@ impl Daemon {
         if let Some(cancel_token) = ssh_cancel_token {
             cancel_token.cancel();
             tracing::info!("SSH公開鍵ファイル監視モジュールを停止しました");
+        }
+        if let Some(cancel_token) = sc_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("シェル設定ファイル監視モジュールを停止しました");
         }
         if let Some(cancel_token) = mnt_cancel_token {
             cancel_token.cancel();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -6,6 +6,7 @@ pub mod kernel_module;
 pub mod log_tamper;
 pub mod mount_monitor;
 pub mod process_monitor;
+pub mod shell_config_monitor;
 pub mod ssh_key_monitor;
 pub mod systemd_service;
 pub mod user_account;

--- a/src/modules/shell_config_monitor.rs
+++ b/src/modules/shell_config_monitor.rs
@@ -1,0 +1,503 @@
+//! シェル設定ファイル監視モジュール
+//!
+//! /etc/profile, /etc/bash.bashrc 等のシェル設定ファイルを定期的にスキャンし、
+//! SHA-256 ハッシュベースで変更を検知する。
+//!
+//! 検知対象:
+//! - シェル設定ファイルの追加・削除
+//! - 設定行の追加・削除（行レベルの変更検知）
+
+use crate::config::ShellConfigMonitorConfig;
+use crate::error::AppError;
+use crate::modules::Module;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
+
+/// ファイルごとのスナップショット
+struct FileSnapshot {
+    /// ファイル全体の SHA-256 ハッシュ
+    file_hash: String,
+    /// 有効な設定行の各行の SHA-256 ハッシュ
+    line_hashes: Vec<String>,
+}
+
+impl FileSnapshot {
+    /// 有効な設定行の数を返す
+    fn line_count(&self) -> usize {
+        self.line_hashes.len()
+    }
+}
+
+/// シェル設定ファイル群のスナップショット
+struct ShellConfigSnapshot {
+    /// ファイルパスごとのスナップショット
+    files: HashMap<PathBuf, FileSnapshot>,
+}
+
+/// シェル設定ファイル監視モジュール
+///
+/// シェル設定ファイルを定期スキャンし、ベースラインとの差分を検知する。
+pub struct ShellConfigMonitorModule {
+    config: ShellConfigMonitorConfig,
+    cancel_token: CancellationToken,
+}
+
+impl ShellConfigMonitorModule {
+    /// 新しいシェル設定ファイル監視モジュールを作成する
+    pub fn new(config: ShellConfigMonitorConfig) -> Self {
+        Self {
+            config,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// 監視対象パスをスキャンし、各ファイルのスナップショットを返す
+    fn scan_files(watch_paths: &[PathBuf]) -> ShellConfigSnapshot {
+        let mut files = HashMap::new();
+        for path in watch_paths {
+            if path.is_file() {
+                match build_file_snapshot(path) {
+                    Ok(snapshot) => {
+                        files.insert(path.clone(), snapshot);
+                    }
+                    Err(e) => {
+                        tracing::debug!(path = %path.display(), error = %e, "シェル設定ファイルの読み取りに失敗しました。スキャンを継続します");
+                    }
+                }
+            } else {
+                tracing::debug!(path = %path.display(), "シェル設定ファイルが存在しません。スキップします");
+            }
+        }
+        ShellConfigSnapshot { files }
+    }
+
+    /// ベースラインと現在のスナップショットを比較し、変更を検知してログ出力する。
+    /// 変更があった場合は `true` を返す。
+    fn detect_and_report(baseline: &ShellConfigSnapshot, current: &ShellConfigSnapshot) -> bool {
+        let mut has_changes = false;
+
+        // 新しいファイルの検知
+        for path in current.files.keys() {
+            if !baseline.files.contains_key(path) {
+                let line_count = current.files[path].line_count();
+                tracing::warn!(
+                    path = %path.display(),
+                    line_count,
+                    "シェル設定ファイルが追加されました"
+                );
+                has_changes = true;
+            }
+        }
+
+        // 削除されたファイルの検知
+        for path in baseline.files.keys() {
+            if !current.files.contains_key(path) {
+                tracing::warn!(
+                    path = %path.display(),
+                    "シェル設定ファイルが削除されました"
+                );
+                has_changes = true;
+            }
+        }
+
+        // 変更されたファイルの検知（ハッシュが異なる場合のみ行レベル比較）
+        for (path, current_snapshot) in &current.files {
+            if let Some(baseline_snapshot) = baseline.files.get(path)
+                && baseline_snapshot.file_hash != current_snapshot.file_hash
+            {
+                has_changes = true;
+
+                let baseline_set: HashSet<&String> = baseline_snapshot.line_hashes.iter().collect();
+                let current_set: HashSet<&String> = current_snapshot.line_hashes.iter().collect();
+
+                let added_count = current_set.difference(&baseline_set).count();
+                let removed_count = baseline_set.difference(&current_set).count();
+
+                if added_count > 0 {
+                    tracing::warn!(
+                        path = %path.display(),
+                        added_count,
+                        "シェル設定行が追加されました"
+                    );
+                }
+                if removed_count > 0 {
+                    tracing::warn!(
+                        path = %path.display(),
+                        removed_count,
+                        "シェル設定行が削除されました"
+                    );
+                }
+
+                tracing::warn!(
+                    path = %path.display(),
+                    before = baseline_snapshot.line_count(),
+                    after = current_snapshot.line_count(),
+                    "シェル設定行数が変化しました"
+                );
+            }
+        }
+
+        has_changes
+    }
+}
+
+/// ファイルのスナップショットを作成する
+fn build_file_snapshot(path: &PathBuf) -> Result<FileSnapshot, AppError> {
+    let data = std::fs::read(path).map_err(|e| AppError::FileIo {
+        path: path.clone(),
+        source: e,
+    })?;
+
+    // ファイル全体のハッシュ
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let file_hash = format!("{:x}", hasher.finalize());
+
+    // 行ごとのハッシュ（空行・コメント行はスキップ）
+    let content = String::from_utf8_lossy(&data);
+    let line_hashes = content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        })
+        .map(|line| {
+            let mut hasher = Sha256::new();
+            hasher.update(line.as_bytes());
+            format!("{:x}", hasher.finalize())
+        })
+        .collect();
+
+    Ok(FileSnapshot {
+        file_hash,
+        line_hashes,
+    })
+}
+
+impl Module for ShellConfigMonitorModule {
+    fn name(&self) -> &str {
+        "shell_config_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.scan_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "scan_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        for path in &self.config.watch_paths {
+            if !path.exists() {
+                tracing::warn!(
+                    path = %path.display(),
+                    "監視対象のシェル設定ファイルが存在しません"
+                );
+            }
+        }
+
+        tracing::info!(
+            watch_paths = ?self.config.watch_paths,
+            scan_interval_secs = self.config.scan_interval_secs,
+            "シェル設定ファイル監視モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        let baseline = Self::scan_files(&self.config.watch_paths);
+        let total_lines: usize = baseline.files.values().map(|s| s.line_count()).sum();
+        tracing::info!(
+            file_count = baseline.files.len(),
+            total_lines,
+            "ベースラインスキャンが完了しました"
+        );
+
+        let watch_paths = self.config.watch_paths.clone();
+        let scan_interval_secs = self.config.scan_interval_secs;
+        let cancel_token = self.cancel_token.clone();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
+            interval.tick().await;
+
+            let mut baseline = baseline;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("シェル設定ファイル監視モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let current = ShellConfigMonitorModule::scan_files(&watch_paths);
+                        let changed = ShellConfigMonitorModule::detect_and_report(&baseline, &current);
+
+                        if changed {
+                            baseline = current;
+                        } else {
+                            tracing::debug!("シェル設定ファイルの変更はありません");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_build_file_snapshot_basic() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmpfile,
+            "export PATH=/usr/local/bin:$PATH\nexport EDITOR=vim\n"
+        )
+        .unwrap();
+        let snapshot = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
+        assert!(!snapshot.file_hash.is_empty());
+        assert_eq!(snapshot.file_hash.len(), 64);
+        assert_eq!(snapshot.line_count(), 2);
+        assert_eq!(snapshot.line_hashes.len(), 2);
+    }
+
+    #[test]
+    fn test_build_file_snapshot_skips_comments_and_empty() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(
+            tmpfile,
+            "# This is a comment\n\nexport PATH=/usr/local/bin:$PATH\n\n# Another comment\n"
+        )
+        .unwrap();
+        let snapshot = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
+        assert_eq!(snapshot.line_count(), 1);
+    }
+
+    #[test]
+    fn test_build_file_snapshot_empty_file() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let snapshot = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
+        assert_eq!(snapshot.line_count(), 0);
+        assert!(snapshot.line_hashes.is_empty());
+    }
+
+    #[test]
+    fn test_build_file_snapshot_nonexistent() {
+        let result = build_file_snapshot(&PathBuf::from("/tmp/nonexistent-zettai-shell-test"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_file_snapshot_deterministic() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
+        let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
+        assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
+        assert_eq!(snapshot1.line_hashes, snapshot2.line_hashes);
+    }
+
+    #[test]
+    fn test_scan_files_with_single_file() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        let path = tmpfile.path().to_path_buf();
+
+        let watch_paths = vec![path.clone()];
+        let result = ShellConfigMonitorModule::scan_files(&watch_paths);
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files.contains_key(&path));
+    }
+
+    #[test]
+    fn test_scan_files_empty() {
+        let watch_paths: Vec<PathBuf> = vec![];
+        let result = ShellConfigMonitorModule::scan_files(&watch_paths);
+        assert!(result.files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_files_nonexistent_skipped() {
+        let watch_paths = vec![PathBuf::from("/tmp/nonexistent_zettai_shell_test")];
+        let result = ShellConfigMonitorModule::scan_files(&watch_paths);
+        assert!(result.files.is_empty());
+    }
+
+    #[test]
+    fn test_detect_no_changes() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        let path = tmpfile.path().to_path_buf();
+
+        let watch_paths = vec![path];
+        let snapshot1 = ShellConfigMonitorModule::scan_files(&watch_paths);
+        let snapshot2 = ShellConfigMonitorModule::scan_files(&watch_paths);
+        let changed = ShellConfigMonitorModule::detect_and_report(&snapshot1, &snapshot2);
+        assert!(!changed);
+    }
+
+    #[test]
+    fn test_detect_file_added() {
+        let baseline = ShellConfigSnapshot {
+            files: HashMap::new(),
+        };
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            PathBuf::from("/tmp/test_added"),
+            FileSnapshot {
+                file_hash: "hash1".to_string(),
+                line_hashes: vec!["linehash1".to_string()],
+            },
+        );
+        let current = ShellConfigSnapshot {
+            files: current_files,
+        };
+        let changed = ShellConfigMonitorModule::detect_and_report(&baseline, &current);
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_detect_file_removed() {
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            PathBuf::from("/tmp/test_removed"),
+            FileSnapshot {
+                file_hash: "hash1".to_string(),
+                line_hashes: vec!["linehash1".to_string()],
+            },
+        );
+        let baseline = ShellConfigSnapshot {
+            files: baseline_files,
+        };
+        let current = ShellConfigSnapshot {
+            files: HashMap::new(),
+        };
+        let changed = ShellConfigMonitorModule::detect_and_report(&baseline, &current);
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_detect_line_added() {
+        let path = PathBuf::from("/tmp/test_line_change");
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            path.clone(),
+            FileSnapshot {
+                file_hash: "hash1".to_string(),
+                line_hashes: vec!["linehash1".to_string()],
+            },
+        );
+        let baseline = ShellConfigSnapshot {
+            files: baseline_files,
+        };
+
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            path,
+            FileSnapshot {
+                file_hash: "hash2".to_string(),
+                line_hashes: vec!["linehash1".to_string(), "linehash2".to_string()],
+            },
+        );
+        let current = ShellConfigSnapshot {
+            files: current_files,
+        };
+
+        let changed = ShellConfigMonitorModule::detect_and_report(&baseline, &current);
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_detect_line_removed() {
+        let path = PathBuf::from("/tmp/test_line_removed");
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            path.clone(),
+            FileSnapshot {
+                file_hash: "hash1".to_string(),
+                line_hashes: vec!["linehash1".to_string(), "linehash2".to_string()],
+            },
+        );
+        let baseline = ShellConfigSnapshot {
+            files: baseline_files,
+        };
+
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            path,
+            FileSnapshot {
+                file_hash: "hash2".to_string(),
+                line_hashes: vec!["linehash1".to_string()],
+            },
+        );
+        let current = ShellConfigSnapshot {
+            files: current_files,
+        };
+
+        let changed = ShellConfigMonitorModule::detect_and_report(&baseline, &current);
+        assert!(changed);
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = ShellConfigMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 0,
+            watch_paths: vec![],
+        };
+        let mut module = ShellConfigMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let config = ShellConfigMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![PathBuf::from("/etc/profile")],
+        };
+        let mut module = ShellConfigMonitorModule::new(config);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+
+        let config = ShellConfigMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 3600,
+            watch_paths: vec![tmpfile.path().to_path_buf()],
+        };
+        let mut module = ShellConfigMonitorModule::new(config);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -353,3 +353,31 @@ async fn test_daemon_sigterm_shutdown() {
     let output = result.unwrap().expect("出力の取得に失敗");
     assert!(output.status.success());
 }
+
+#[test]
+fn test_config_with_shell_config_monitor_section() {
+    use std::io::Write;
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        tmpfile,
+        r#"
+[modules.shell_config_monitor]
+enabled = true
+scan_interval_secs = 60
+watch_paths = ["/etc/profile", "/etc/bash.bashrc"]
+"#
+    )
+    .unwrap();
+    let config = AppConfig::load(tmpfile.path()).unwrap();
+    assert!(config.modules.shell_config_monitor.enabled);
+    assert_eq!(config.modules.shell_config_monitor.scan_interval_secs, 60);
+    assert_eq!(config.modules.shell_config_monitor.watch_paths.len(), 2);
+}
+
+#[test]
+fn test_config_shell_config_monitor_disabled_by_default() {
+    let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
+    assert!(!config.modules.shell_config_monitor.enabled);
+    assert_eq!(config.modules.shell_config_monitor.scan_interval_secs, 120);
+    assert_eq!(config.modules.shell_config_monitor.watch_paths.len(), 5);
+}


### PR DESCRIPTION
## 概要

シェル設定ファイル（`/etc/profile`, `/etc/bash.bashrc`, `/etc/environment`, `/root/.bashrc`, `/root/.profile`）の改ざんを検知する `shell_config_monitor` モジュールを追加する。

Closes #27

## 変更内容

- `src/modules/shell_config_monitor.rs` — 新規モジュール実装（SHA-256 ハッシュベースのベースライン + デルタ検知、行レベル変更検知）
- `src/config.rs` — `ShellConfigMonitorConfig` 追加
- `src/modules/mod.rs` — モジュール登録
- `src/core/daemon.rs` — デーモンへの組み込み（初期化・起動・停止）
- `config.example.toml` — 設定サンプル追加
- `tests/integration_test.rs` — 統合テスト 2 件追加
- `CLAUDE.md` — ディレクトリ構成更新
- `Cargo.toml` — version を 0.14.0 に更新

## 背景

攻撃者がバックドアの永続化のためにシェル設定ファイルに悪意のあるコマンドを追加する手法（MITRE ATT&CK T1546.004）を検知する。

## テスト計画

- [x] `cargo fmt --check` — OK
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo test` — 全テスト成功（単体テスト + 統合テスト）
- [x] `cargo build --release` — 成功