### PR TITLE
feat: 一時ディレクトリ実行ファイル検知モジュールを追加 (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ src/
     shell_config_monitor.rs # シェル設定ファイル監視モジュール
     ssh_key_monitor.rs # SSH公開鍵ファイル監視モジュール
     systemd_service.rs # systemd サービス監視モジュール
+    tmp_exec_monitor.rs # 一時ディレクトリ実行ファイル検知モジュール
     user_account.rs    # ユーザーアカウント監視モジュール
 tests/
   integration_test.rs  # 統合テスト

--- a/config.example.toml
+++ b/config.example.toml
@@ -91,6 +91,14 @@ scan_interval_secs = 30
 # マウント情報ファイルのパス
 mounts_path = "/proc/mounts"
 
+[modules.tmp_exec_monitor]
+# 一時ディレクトリ実行ファイル検知モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+scan_interval_secs = 60
+# 監視対象ディレクトリのリスト
+watch_dirs = ["/tmp", "/dev/shm", "/var/tmp"]
+
 [modules.user_account]
 # ユーザーアカウント監視モジュールの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,10 @@ pub struct ModulesConfig {
     /// シェル設定ファイル監視モジュールの設定
     #[serde(default)]
     pub shell_config_monitor: ShellConfigMonitorConfig,
+
+    /// 一時ディレクトリ実行ファイル検知モジュールの設定
+    #[serde(default)]
+    pub tmp_exec_monitor: TmpExecMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -543,6 +547,46 @@ impl Default for ShellConfigMonitorConfig {
     }
 }
 
+/// 一時ディレクトリ実行ファイル検知モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct TmpExecMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "TmpExecMonitorConfig::default_scan_interval_secs")]
+    pub scan_interval_secs: u64,
+
+    /// 監視対象ディレクトリのリスト
+    #[serde(default = "TmpExecMonitorConfig::default_watch_dirs")]
+    pub watch_dirs: Vec<PathBuf>,
+}
+
+impl TmpExecMonitorConfig {
+    fn default_scan_interval_secs() -> u64 {
+        60
+    }
+
+    fn default_watch_dirs() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/tmp"),
+            PathBuf::from("/dev/shm"),
+            PathBuf::from("/var/tmp"),
+        ]
+    }
+}
+
+impl Default for TmpExecMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_interval_secs: Self::default_scan_interval_secs(),
+            watch_dirs: Self::default_watch_dirs(),
+        }
+    }
+}
+
 /// ヘルスチェック設定
 #[derive(Debug, Deserialize)]
 pub struct HealthConfig {
@@ -818,6 +862,28 @@ mounts_path = "/proc/self/mounts"
             config.modules.mount_monitor.mounts_path,
             PathBuf::from("/proc/self/mounts")
         );
+    }
+
+    #[test]
+    fn test_tmp_exec_monitor_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(!config.modules.tmp_exec_monitor.enabled);
+        assert_eq!(config.modules.tmp_exec_monitor.scan_interval_secs, 60);
+        assert_eq!(config.modules.tmp_exec_monitor.watch_dirs.len(), 3);
+    }
+
+    #[test]
+    fn test_tmp_exec_monitor_config_custom() {
+        let toml_str = r#"
+[modules.tmp_exec_monitor]
+enabled = true
+scan_interval_secs = 30
+watch_dirs = ["/tmp", "/dev/shm"]
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.modules.tmp_exec_monitor.enabled);
+        assert_eq!(config.modules.tmp_exec_monitor.scan_interval_secs, 30);
+        assert_eq!(config.modules.tmp_exec_monitor.watch_dirs.len(), 2);
     }
 
     #[test]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -13,6 +13,7 @@ use crate::modules::process_monitor::ProcessMonitorModule;
 use crate::modules::shell_config_monitor::ShellConfigMonitorModule;
 use crate::modules::ssh_key_monitor::SshKeyMonitorModule;
 use crate::modules::systemd_service::SystemdServiceModule;
+use crate::modules::tmp_exec_monitor::TmpExecMonitorModule;
 use crate::modules::user_account::UserAccountModule;
 use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
@@ -161,6 +162,18 @@ impl Daemon {
             None
         };
 
+        // 一時ディレクトリ実行ファイル検知モジュールの初期化と起動
+        let te_cancel_token = if self.config.modules.tmp_exec_monitor.enabled {
+            let mut te = TmpExecMonitorModule::new(self.config.modules.tmp_exec_monitor.clone());
+            te.init()?;
+            let cancel_token = te.cancel_token();
+            te.start().await?;
+            tracing::info!("一時ディレクトリ実行ファイル検知モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
         // マウントポイント監視モジュールの初期化と起動
         let mnt_cancel_token = if self.config.modules.mount_monitor.enabled {
             let mut mnt = MountMonitorModule::new(self.config.modules.mount_monitor.clone());
@@ -269,6 +282,10 @@ impl Daemon {
         if let Some(cancel_token) = sc_cancel_token {
             cancel_token.cancel();
             tracing::info!("シェル設定ファイル監視モジュールを停止しました");
+        }
+        if let Some(cancel_token) = te_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("一時ディレクトリ実行ファイル検知モジュールを停止しました");
         }
         if let Some(cancel_token) = mnt_cancel_token {
             cancel_token.cancel();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,6 +9,7 @@ pub mod process_monitor;
 pub mod shell_config_monitor;
 pub mod ssh_key_monitor;
 pub mod systemd_service;
+pub mod tmp_exec_monitor;
 pub mod user_account;
 
 use crate::error::AppError;

--- a/src/modules/tmp_exec_monitor.rs
+++ b/src/modules/tmp_exec_monitor.rs
@@ -1,0 +1,453 @@
+//! 一時ディレクトリ実行ファイル検知モジュール
+//!
+//! /tmp, /dev/shm, /var/tmp 等の一時ディレクトリを定期スキャンし、
+//! 実行権限が付与されたファイルを検知する。
+//!
+//! 検知対象:
+//! - 実行可能ファイルの新規出現
+//! - 実行可能ファイルの消失（証拠隠滅の可能性）
+//! - ファイルサイズ・パーミッションの変更
+
+use crate::config::TmpExecMonitorConfig;
+use crate::error::AppError;
+use crate::modules::Module;
+use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
+use walkdir::WalkDir;
+
+/// 実行可能ファイルの情報
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ExecutableFileInfo {
+    /// ファイルサイズ（バイト）
+    size: u64,
+    /// ファイルのパーミッション（mode ビット）
+    mode: u32,
+}
+
+/// 一時ディレクトリ内の実行可能ファイルのスナップショット
+struct TmpExecSnapshot {
+    /// ファイルパスごとの実行可能ファイル情報
+    files: HashMap<PathBuf, ExecutableFileInfo>,
+}
+
+/// 一時ディレクトリ実行ファイル検知モジュール
+///
+/// 一時ディレクトリを定期スキャンし、実行可能ファイルの出現・消失・変更を検知する。
+pub struct TmpExecMonitorModule {
+    config: TmpExecMonitorConfig,
+    cancel_token: CancellationToken,
+}
+
+impl TmpExecMonitorModule {
+    /// 新しい一時ディレクトリ実行ファイル検知モジュールを作成する
+    pub fn new(config: TmpExecMonitorConfig) -> Self {
+        Self {
+            config,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// 監視対象ディレクトリを再帰走査し、実行可能ファイルのスナップショットを返す
+    fn scan_dirs(watch_dirs: &[PathBuf]) -> TmpExecSnapshot {
+        let mut files = HashMap::new();
+        for dir in watch_dirs {
+            if !dir.exists() {
+                tracing::debug!(dir = %dir.display(), "監視対象ディレクトリが存在しません。スキップします");
+                continue;
+            }
+            for entry in WalkDir::new(dir).into_iter().filter_map(|e| match e {
+                Ok(entry) => Some(entry),
+                Err(err) => {
+                    tracing::debug!(error = %err, "ディレクトリエントリの読み取りに失敗しました。スキップします");
+                    None
+                }
+            }) {
+                if !entry.file_type().is_file() {
+                    continue;
+                }
+                match entry.metadata() {
+                    Ok(metadata) => {
+                        let mode = metadata.permissions().mode();
+                        if mode & 0o111 != 0 {
+                            files.insert(
+                                entry.path().to_path_buf(),
+                                ExecutableFileInfo {
+                                    size: metadata.len(),
+                                    mode,
+                                },
+                            );
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            path = %entry.path().display(),
+                            error = %err,
+                            "ファイルメタデータの取得に失敗しました。スキップします"
+                        );
+                    }
+                }
+            }
+        }
+        TmpExecSnapshot { files }
+    }
+
+    /// ベースラインと現在のスナップショットを比較し、変更を検知してログ出力する。
+    /// 変更があった場合は `true` を返す。
+    fn detect_and_report(baseline: &TmpExecSnapshot, current: &TmpExecSnapshot) -> bool {
+        let mut has_changes = false;
+
+        // 新規出現の検知
+        for (path, info) in &current.files {
+            if !baseline.files.contains_key(path) {
+                tracing::warn!(
+                    path = %path.display(),
+                    size = info.size,
+                    mode = format!("{:o}", info.mode),
+                    "一時ディレクトリに実行可能ファイルが出現しました"
+                );
+                has_changes = true;
+            }
+        }
+
+        // 消失の検知
+        for path in baseline.files.keys() {
+            if !current.files.contains_key(path) {
+                tracing::warn!(
+                    path = %path.display(),
+                    "一時ディレクトリから実行可能ファイルが消失しました（証拠隠滅の可能性）"
+                );
+                has_changes = true;
+            }
+        }
+
+        // サイズ・パーミッション変更の検知
+        for (path, current_info) in &current.files {
+            if let Some(baseline_info) = baseline.files.get(path) {
+                if baseline_info.size != current_info.size {
+                    tracing::warn!(
+                        path = %path.display(),
+                        before = baseline_info.size,
+                        after = current_info.size,
+                        "一時ディレクトリの実行可能ファイルのサイズが変更されました"
+                    );
+                    has_changes = true;
+                }
+                if baseline_info.mode != current_info.mode {
+                    tracing::warn!(
+                        path = %path.display(),
+                        before = format!("{:o}", baseline_info.mode),
+                        after = format!("{:o}", current_info.mode),
+                        "一時ディレクトリの実行可能ファイルのパーミッションが変更されました"
+                    );
+                    has_changes = true;
+                }
+            }
+        }
+
+        has_changes
+    }
+}
+
+impl Module for TmpExecMonitorModule {
+    fn name(&self) -> &str {
+        "tmp_exec_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.scan_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "scan_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        for dir in &self.config.watch_dirs {
+            if !dir.exists() {
+                tracing::warn!(
+                    dir = %dir.display(),
+                    "監視対象の一時ディレクトリが存在しません"
+                );
+            }
+        }
+
+        tracing::info!(
+            watch_dirs = ?self.config.watch_dirs,
+            scan_interval_secs = self.config.scan_interval_secs,
+            "一時ディレクトリ実行ファイル検知モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        let baseline = Self::scan_dirs(&self.config.watch_dirs);
+        tracing::info!(
+            executable_count = baseline.files.len(),
+            "ベースラインスキャンが完了しました"
+        );
+
+        let watch_dirs = self.config.watch_dirs.clone();
+        let scan_interval_secs = self.config.scan_interval_secs;
+        let cancel_token = self.cancel_token.clone();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
+            interval.tick().await;
+
+            let mut baseline = baseline;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("一時ディレクトリ実行ファイル検知モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let current = TmpExecMonitorModule::scan_dirs(&watch_dirs);
+                        let changed = TmpExecMonitorModule::detect_and_report(&baseline, &current);
+
+                        if changed {
+                            baseline = current;
+                        } else {
+                            tracing::debug!("一時ディレクトリの実行可能ファイルに変更はありません");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_scan_dirs_with_executable() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test_exec");
+        fs::write(&file_path, "#!/bin/sh\necho hello").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let snapshot = TmpExecMonitorModule::scan_dirs(&[dir.path().to_path_buf()]);
+        assert_eq!(snapshot.files.len(), 1);
+        assert!(snapshot.files.contains_key(&file_path));
+    }
+
+    #[test]
+    fn test_scan_dirs_without_executable() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test_noexec");
+        fs::write(&file_path, "just data").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let snapshot = TmpExecMonitorModule::scan_dirs(&[dir.path().to_path_buf()]);
+        assert!(snapshot.files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_dirs_empty() {
+        let dir = TempDir::new().unwrap();
+        let snapshot = TmpExecMonitorModule::scan_dirs(&[dir.path().to_path_buf()]);
+        assert!(snapshot.files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_dirs_nonexistent_skipped() {
+        let snapshot =
+            TmpExecMonitorModule::scan_dirs(&[PathBuf::from("/tmp/nonexistent_zettai_te_test")]);
+        assert!(snapshot.files.is_empty());
+    }
+
+    #[test]
+    fn test_scan_dirs_recursive() {
+        let dir = TempDir::new().unwrap();
+        let sub_dir = dir.path().join("subdir");
+        fs::create_dir(&sub_dir).unwrap();
+        let file_path = sub_dir.join("nested_exec");
+        fs::write(&file_path, "#!/bin/sh").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let snapshot = TmpExecMonitorModule::scan_dirs(&[dir.path().to_path_buf()]);
+        assert_eq!(snapshot.files.len(), 1);
+        assert!(snapshot.files.contains_key(&file_path));
+    }
+
+    #[test]
+    fn test_detect_new_file() {
+        let baseline = TmpExecSnapshot {
+            files: HashMap::new(),
+        };
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            PathBuf::from("/tmp/new_exec"),
+            ExecutableFileInfo {
+                size: 100,
+                mode: 0o100755,
+            },
+        );
+        let current = TmpExecSnapshot {
+            files: current_files,
+        };
+        assert!(TmpExecMonitorModule::detect_and_report(&baseline, &current));
+    }
+
+    #[test]
+    fn test_detect_removed_file() {
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            PathBuf::from("/tmp/removed_exec"),
+            ExecutableFileInfo {
+                size: 100,
+                mode: 0o100755,
+            },
+        );
+        let baseline = TmpExecSnapshot {
+            files: baseline_files,
+        };
+        let current = TmpExecSnapshot {
+            files: HashMap::new(),
+        };
+        assert!(TmpExecMonitorModule::detect_and_report(&baseline, &current));
+    }
+
+    #[test]
+    fn test_detect_size_change() {
+        let path = PathBuf::from("/tmp/size_change");
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            path.clone(),
+            ExecutableFileInfo {
+                size: 100,
+                mode: 0o100755,
+            },
+        );
+        let baseline = TmpExecSnapshot {
+            files: baseline_files,
+        };
+
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            path,
+            ExecutableFileInfo {
+                size: 200,
+                mode: 0o100755,
+            },
+        );
+        let current = TmpExecSnapshot {
+            files: current_files,
+        };
+        assert!(TmpExecMonitorModule::detect_and_report(&baseline, &current));
+    }
+
+    #[test]
+    fn test_detect_permission_change() {
+        let path = PathBuf::from("/tmp/perm_change");
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(
+            path.clone(),
+            ExecutableFileInfo {
+                size: 100,
+                mode: 0o100755,
+            },
+        );
+        let baseline = TmpExecSnapshot {
+            files: baseline_files,
+        };
+
+        let mut current_files = HashMap::new();
+        current_files.insert(
+            path,
+            ExecutableFileInfo {
+                size: 100,
+                mode: 0o100777,
+            },
+        );
+        let current = TmpExecSnapshot {
+            files: current_files,
+        };
+        assert!(TmpExecMonitorModule::detect_and_report(&baseline, &current));
+    }
+
+    #[test]
+    fn test_detect_no_changes() {
+        let path = PathBuf::from("/tmp/no_change");
+        let info = ExecutableFileInfo {
+            size: 100,
+            mode: 0o100755,
+        };
+
+        let mut baseline_files = HashMap::new();
+        baseline_files.insert(path.clone(), info.clone());
+        let baseline = TmpExecSnapshot {
+            files: baseline_files,
+        };
+
+        let mut current_files = HashMap::new();
+        current_files.insert(path, info);
+        let current = TmpExecSnapshot {
+            files: current_files,
+        };
+        assert!(!TmpExecMonitorModule::detect_and_report(
+            &baseline, &current
+        ));
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 0,
+            watch_dirs: vec![],
+        };
+        let mut module = TmpExecMonitorModule::new(config);
+        assert!(module.init().is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let dir = TempDir::new().unwrap();
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_dirs: vec![dir.path().to_path_buf()],
+        };
+        let mut module = TmpExecMonitorModule::new(config);
+        assert!(module.init().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let dir = TempDir::new().unwrap();
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 3600,
+            watch_dirs: vec![dir.path().to_path_buf()],
+        };
+        let mut module = TmpExecMonitorModule::new(config);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+}


### PR DESCRIPTION
## 概要

一時ディレクトリ（`/tmp`, `/dev/shm`, `/var/tmp`）を定期スキャンし、実行権限が付与されたファイルを検知する `tmp_exec_monitor` モジュールを追加。

Closes #29

## 変更内容

- `src/modules/tmp_exec_monitor.rs`: 一時ディレクトリ実行ファイル検知モジュール（453行、15テスト含む）
- `src/config.rs`: `TmpExecMonitorConfig` 設定構造体を追加
- `src/core/daemon.rs`: モジュール起動・停止ロジックを追加
- `src/modules/mod.rs`: モジュール登録
- `config.example.toml`: 設定例を追加
- `CLAUDE.md`: ディレクトリ構成を更新

## 検知対象

- 実行可能ファイルの新規出現（マルウェア配置の検知）
- 実行可能ファイルの消失（証拠隠滅の可能性）
- ファイルサイズ・パーミッションの変更

## テスト計画

- [x] `cargo test` — 全25テストパス
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマットOK
- [x] 単体テスト: スキャン（実行可能ファイルあり/なし/再帰/空/存在しないディレクトリ）
- [x] 単体テスト: 検知（新規出現/消失/サイズ変更/パーミッション変更/変更なし）
- [x] 単体テスト: init バリデーション、start/stop ライフサイクル

🤖 Generated with [Claude Code](https://claude.com/claude-code)