### PR TITLE
feat: SSH ブルートフォース検知モジュールの実装 (#42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +976,7 @@ version = "0.20.0"
 dependencies = [
  "clap",
  "libc",
+ "regex",
  "serde",
  "sha2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "2"
+regex = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "process"] }
 tokio-util = "0.7"
 toml = "0.8"

--- a/config.example.toml
+++ b/config.example.toml
@@ -125,6 +125,18 @@ passwd_path = "/etc/passwd"
 # group ファイルのパス
 group_path = "/etc/group"
 
+[modules.ssh_brute_force]
+# SSH ブルートフォース検知モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+interval_secs = 30
+# 認証ログファイルのパス
+auth_log_path = "/var/log/auth.log"
+# 認証失敗の閾値（この回数を超えるとアラート）
+max_failures = 5
+# 時間窓（秒）- この期間内の失敗回数をカウント
+time_window_secs = 300
+
 [event_bus]
 # イベントバスの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,6 +96,10 @@ pub struct ModulesConfig {
     /// SUID/SGID ファイル監視モジュールの設定
     #[serde(default)]
     pub suid_sgid_monitor: SuidSgidMonitorConfig,
+
+    /// SSH ブルートフォース検知モジュールの設定
+    #[serde(default)]
+    pub ssh_brute_force: SshBruteForceConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -679,6 +683,60 @@ impl Default for SuidSgidMonitorConfig {
             enabled: false,
             scan_interval_secs: Self::default_scan_interval_secs(),
             watch_dirs: Self::default_watch_dirs(),
+        }
+    }
+}
+
+/// SSH ブルートフォース検知モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct SshBruteForceConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "SshBruteForceConfig::default_interval_secs")]
+    pub interval_secs: u64,
+
+    /// 認証ログファイルのパス
+    #[serde(default = "SshBruteForceConfig::default_auth_log_path")]
+    pub auth_log_path: PathBuf,
+
+    /// 認証失敗の閾値
+    #[serde(default = "SshBruteForceConfig::default_max_failures")]
+    pub max_failures: u32,
+
+    /// 時間窓（秒）
+    #[serde(default = "SshBruteForceConfig::default_time_window_secs")]
+    pub time_window_secs: u64,
+}
+
+impl SshBruteForceConfig {
+    fn default_interval_secs() -> u64 {
+        30
+    }
+
+    fn default_auth_log_path() -> PathBuf {
+        PathBuf::from("/var/log/auth.log")
+    }
+
+    fn default_max_failures() -> u32 {
+        5
+    }
+
+    fn default_time_window_secs() -> u64 {
+        300
+    }
+}
+
+impl Default for SshBruteForceConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: Self::default_interval_secs(),
+            auth_log_path: Self::default_auth_log_path(),
+            max_failures: Self::default_max_failures(),
+            time_window_secs: Self::default_time_window_secs(),
         }
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -13,6 +13,7 @@ use crate::modules::log_tamper::LogTamperModule;
 use crate::modules::mount_monitor::MountMonitorModule;
 use crate::modules::process_monitor::ProcessMonitorModule;
 use crate::modules::shell_config_monitor::ShellConfigMonitorModule;
+use crate::modules::ssh_brute_force::SshBruteForceModule;
 use crate::modules::ssh_key_monitor::SshKeyMonitorModule;
 use crate::modules::sudoers_monitor::SudoersMonitorModule;
 use crate::modules::suid_sgid_monitor::SuidSgidMonitorModule;
@@ -279,6 +280,21 @@ impl Daemon {
             None
         };
 
+        // SSH ブルートフォース検知モジュールの初期化と起動
+        let sbf_cancel_token = if self.config.modules.ssh_brute_force.enabled {
+            let mut sbf = SshBruteForceModule::new(
+                self.config.modules.ssh_brute_force.clone(),
+                event_bus.clone(),
+            );
+            sbf.init()?;
+            let cancel_token = sbf.cancel_token();
+            sbf.start().await?;
+            tracing::info!("SSH ブルートフォース検知モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
         // ユーザーアカウント監視モジュールの初期化と起動
         let ua_cancel_token = if self.config.modules.user_account.enabled {
             let mut ua =
@@ -396,6 +412,10 @@ impl Daemon {
         if let Some(cancel_token) = ssg_cancel_token {
             cancel_token.cancel();
             tracing::info!("SUID/SGID ファイル監視モジュールを停止しました");
+        }
+        if let Some(cancel_token) = sbf_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("SSH ブルートフォース検知モジュールを停止しました");
         }
 
         tracing::info!("シャットダウン完了");

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -7,6 +7,7 @@ pub mod log_tamper;
 pub mod mount_monitor;
 pub mod process_monitor;
 pub mod shell_config_monitor;
+pub mod ssh_brute_force;
 pub mod ssh_key_monitor;
 pub mod sudoers_monitor;
 pub mod suid_sgid_monitor;

--- a/src/modules/ssh_brute_force.rs
+++ b/src/modules/ssh_brute_force.rs
@@ -1,0 +1,381 @@
+//! SSH ブルートフォース検知モジュール
+//!
+//! `/var/log/auth.log` を監視し、SSH 認証失敗の連続パターンを検知する。
+//! IP アドレスごとに認証失敗回数を追跡し、設定された閾値を超えた場合に
+//! SecurityEvent を発行する。
+
+use crate::config::SshBruteForceConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use crate::error::AppError;
+use crate::modules::Module;
+use regex::Regex;
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+/// SSH ブルートフォース検知モジュール
+pub struct SshBruteForceModule {
+    config: SshBruteForceConfig,
+    event_bus: Option<EventBus>,
+    cancel_token: CancellationToken,
+}
+
+impl SshBruteForceModule {
+    /// 新しい SSH ブルートフォース検知モジュールを作成する
+    pub fn new(config: SshBruteForceConfig, event_bus: Option<EventBus>) -> Self {
+        Self {
+            config,
+            event_bus,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// ログ行から認証失敗の IP アドレスを抽出する
+    fn extract_failed_ip(line: &str, pattern: &Regex) -> Option<String> {
+        pattern.captures(line).map(|caps| caps[2].to_string())
+    }
+
+    /// 時間窓外の古いエントリを除去する
+    fn cleanup_old_entries(
+        failure_map: &mut HashMap<String, Vec<Instant>>,
+        time_window: std::time::Duration,
+    ) {
+        let now = Instant::now();
+        failure_map.retain(|_, timestamps| {
+            timestamps.retain(|t| now.duration_since(*t) <= time_window);
+            !timestamps.is_empty()
+        });
+    }
+}
+
+impl Module for SshBruteForceModule {
+    fn name(&self) -> &str {
+        "ssh_brute_force"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+        if self.config.max_failures == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "max_failures は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+        if self.config.time_window_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "time_window_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        if !self.config.auth_log_path.exists() {
+            tracing::warn!(
+                path = %self.config.auth_log_path.display(),
+                "認証ログファイルが存在しません。ファイルが作成されるまで監視をスキップします"
+            );
+        }
+
+        tracing::info!(
+            auth_log_path = %self.config.auth_log_path.display(),
+            interval_secs = self.config.interval_secs,
+            max_failures = self.config.max_failures,
+            time_window_secs = self.config.time_window_secs,
+            "SSH ブルートフォース検知モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        let auth_log_path = self.config.auth_log_path.clone();
+        let interval_secs = self.config.interval_secs;
+        let max_failures = self.config.max_failures;
+        let time_window_secs = self.config.time_window_secs;
+        let cancel_token = self.cancel_token.clone();
+        let event_bus = self.event_bus.clone();
+
+        tokio::spawn(async move {
+            // unwrap safety: このパターンは固定文字列リテラルであり、常に有効な正規表現
+            let pattern = Regex::new(
+                r"Failed password for (?:invalid user )?(\S+) from (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
+            ).unwrap();
+
+            let time_window = std::time::Duration::from_secs(time_window_secs);
+            let mut failure_map: HashMap<String, Vec<Instant>> = HashMap::new();
+            let mut last_position: u64 = 0;
+            let mut last_file_size: u64 = 0;
+
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("SSH ブルートフォース検知モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        // 古いエントリのクリーンアップ
+                        SshBruteForceModule::cleanup_old_entries(&mut failure_map, time_window);
+
+                        // ファイルを開く
+                        let file = match std::fs::File::open(&auth_log_path) {
+                            Ok(f) => f,
+                            Err(e) => {
+                                tracing::debug!(
+                                    path = %auth_log_path.display(),
+                                    error = %e,
+                                    "認証ログファイルを開けません"
+                                );
+                                continue;
+                            }
+                        };
+
+                        // ファイルサイズを確認（truncate/rotate 検知）
+                        let metadata = match file.metadata() {
+                            Ok(m) => m,
+                            Err(e) => {
+                                tracing::debug!(error = %e, "メタデータ取得に失敗");
+                                continue;
+                            }
+                        };
+                        let current_size = metadata.len();
+
+                        if current_size < last_file_size {
+                            // ファイルが truncate/rotate されたので先頭から読み直す
+                            tracing::info!("認証ログファイルのローテーションを検知しました。先頭から読み直します");
+                            last_position = 0;
+                        }
+                        last_file_size = current_size;
+
+                        if last_position >= current_size {
+                            continue;
+                        }
+
+                        // 前回の位置から読み取り
+                        let mut reader = BufReader::new(&file);
+                        if let Err(e) = reader.seek(SeekFrom::Start(last_position)) {
+                            tracing::debug!(error = %e, "seek に失敗");
+                            continue;
+                        }
+
+                        let mut new_position = last_position;
+                        let mut line = String::new();
+
+                        loop {
+                            line.clear();
+                            match reader.read_line(&mut line) {
+                                Ok(0) => break, // EOF
+                                Ok(n) => {
+                                    new_position += n as u64;
+                                    if let Some(ip) = SshBruteForceModule::extract_failed_ip(&line, &pattern) {
+                                        let now = Instant::now();
+                                        let timestamps = failure_map.entry(ip.clone()).or_default();
+                                        timestamps.push(now);
+
+                                        // 時間窓内の失敗回数をチェック
+                                        let recent_count = timestamps
+                                            .iter()
+                                            .filter(|t| now.duration_since(**t) <= time_window)
+                                            .count();
+
+                                        if recent_count >= max_failures as usize {
+                                            tracing::warn!(
+                                                ip = %ip,
+                                                failure_count = recent_count,
+                                                time_window_secs = time_window_secs,
+                                                "SSH ブルートフォース攻撃の可能性を検知しました"
+                                            );
+                                            if let Some(ref bus) = event_bus {
+                                                bus.publish(
+                                                    SecurityEvent::new(
+                                                        "ssh_brute_force",
+                                                        Severity::Critical,
+                                                        "ssh_brute_force",
+                                                        format!(
+                                                            "SSH ブルートフォース攻撃の可能性: IP {} から {}秒以内に {}回の認証失敗",
+                                                            ip, time_window_secs, recent_count
+                                                        ),
+                                                    )
+                                                    .with_details(format!("ip={}, failures={}", ip, recent_count)),
+                                                );
+                                            }
+                                            // 重複イベント抑制: 該当 IP のエントリをクリア
+                                            failure_map.remove(&ip);
+                                        }
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::debug!(error = %e, "行の読み取りに失敗");
+                                    break;
+                                }
+                            }
+                        }
+
+                        last_position = new_position;
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    fn test_config() -> SshBruteForceConfig {
+        SshBruteForceConfig {
+            enabled: true,
+            interval_secs: 30,
+            auth_log_path: PathBuf::from("/var/log/auth.log"),
+            max_failures: 5,
+            time_window_secs: 300,
+        }
+    }
+
+    fn test_pattern() -> Regex {
+        Regex::new(
+            r"Failed password for (?:invalid user )?(\S+) from (\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"
+        ).unwrap()
+    }
+
+    #[test]
+    fn test_extract_failed_ip_valid() {
+        let pattern = test_pattern();
+        let line = "Mar 31 10:00:00 server sshd[1234]: Failed password for root from 192.168.1.100 port 22 ssh2";
+        let result = SshBruteForceModule::extract_failed_ip(line, &pattern);
+        assert_eq!(result, Some("192.168.1.100".to_string()));
+    }
+
+    #[test]
+    fn test_extract_failed_ip_invalid_user() {
+        let pattern = test_pattern();
+        let line = "Mar 31 10:00:00 server sshd[1234]: Failed password for invalid user admin from 10.0.0.1 port 22 ssh2";
+        let result = SshBruteForceModule::extract_failed_ip(line, &pattern);
+        assert_eq!(result, Some("10.0.0.1".to_string()));
+    }
+
+    #[test]
+    fn test_extract_failed_ip_no_match() {
+        let pattern = test_pattern();
+        let line = "Mar 31 10:00:00 server sshd[1234]: Accepted password for root from 192.168.1.100 port 22 ssh2";
+        let result = SshBruteForceModule::extract_failed_ip(line, &pattern);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_cleanup_old_entries() {
+        let mut failure_map: HashMap<String, Vec<Instant>> = HashMap::new();
+        let now = Instant::now();
+        // 古いエントリ（時間窓外）をシミュレート
+        failure_map.insert(
+            "192.168.1.1".to_string(),
+            vec![now - Duration::from_secs(600)],
+        );
+        // 新しいエントリ（時間窓内）
+        failure_map.insert("192.168.1.2".to_string(), vec![now]);
+
+        let time_window = Duration::from_secs(300);
+        SshBruteForceModule::cleanup_old_entries(&mut failure_map, time_window);
+
+        assert!(!failure_map.contains_key("192.168.1.1"));
+        assert!(failure_map.contains_key("192.168.1.2"));
+    }
+
+    #[test]
+    fn test_cleanup_old_entries_empty() {
+        let mut failure_map: HashMap<String, Vec<Instant>> = HashMap::new();
+        let time_window = Duration::from_secs(300);
+        SshBruteForceModule::cleanup_old_entries(&mut failure_map, time_window);
+        assert!(failure_map.is_empty());
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = SshBruteForceConfig {
+            interval_secs: 0,
+            ..test_config()
+        };
+        let mut module = SshBruteForceModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_zero_max_failures() {
+        let config = SshBruteForceConfig {
+            max_failures: 0,
+            ..test_config()
+        };
+        let mut module = SshBruteForceModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_zero_time_window() {
+        let config = SshBruteForceConfig {
+            time_window_secs: 0,
+            ..test_config()
+        };
+        let mut module = SshBruteForceModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let mut module = SshBruteForceModule::new(test_config(), None);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_init_nonexistent_path() {
+        let config = SshBruteForceConfig {
+            auth_log_path: PathBuf::from("/tmp/nonexistent-auth-log-test"),
+            ..test_config()
+        };
+        let mut module = SshBruteForceModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let config = SshBruteForceConfig {
+            auth_log_path: PathBuf::from("/tmp/nonexistent-auth-log-test"),
+            ..test_config()
+        };
+        let mut module = SshBruteForceModule::new(config, None);
+        module.init().unwrap();
+        module.start().await.unwrap();
+        // モジュールが起動していることを確認
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        module.stop().await.unwrap();
+    }
+
+    #[test]
+    fn test_module_name() {
+        let module = SshBruteForceModule::new(test_config(), None);
+        assert_eq!(module.name(), "ssh_brute_force");
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -411,6 +411,46 @@ watch_paths = ["/etc/sudoers"]
 }
 
 #[test]
+fn test_config_ssh_brute_force_disabled_by_default() {
+    let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
+    assert!(!config.modules.ssh_brute_force.enabled);
+    assert_eq!(config.modules.ssh_brute_force.interval_secs, 30);
+    assert_eq!(
+        config.modules.ssh_brute_force.auth_log_path,
+        std::path::PathBuf::from("/var/log/auth.log")
+    );
+    assert_eq!(config.modules.ssh_brute_force.max_failures, 5);
+    assert_eq!(config.modules.ssh_brute_force.time_window_secs, 300);
+}
+
+#[test]
+fn test_config_with_ssh_brute_force_section() {
+    use std::io::Write;
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(
+        tmpfile,
+        r#"
+[modules.ssh_brute_force]
+enabled = true
+interval_secs = 15
+auth_log_path = "/var/log/auth.log"
+max_failures = 10
+time_window_secs = 600
+"#
+    )
+    .unwrap();
+    let config = AppConfig::load(tmpfile.path()).unwrap();
+    assert!(config.modules.ssh_brute_force.enabled);
+    assert_eq!(config.modules.ssh_brute_force.interval_secs, 15);
+    assert_eq!(
+        config.modules.ssh_brute_force.auth_log_path,
+        std::path::PathBuf::from("/var/log/auth.log")
+    );
+    assert_eq!(config.modules.ssh_brute_force.max_failures, 10);
+    assert_eq!(config.modules.ssh_brute_force.time_window_secs, 600);
+}
+
+#[test]
 fn test_config_event_bus_defaults() {
     let config = AppConfig::load(Path::new("/tmp/nonexistent-zettai-config.toml")).unwrap();
     assert!(!config.event_bus.enabled);


### PR DESCRIPTION
## 概要

Closes #42

`/var/log/auth.log` を監視し、SSH 認証失敗の連続パターンを検知する新しいモジュールを実装。IP アドレスごとに認証失敗回数を追跡し、設定された閾値を超えた場合に Critical レベルの SecurityEvent を発行する。

## 変更内容

- `SshBruteForceModule` を新規実装（`src/modules/ssh_brute_force.rs`）
- `SshBruteForceConfig` を追加（`src/config.rs`）
- `regex` クレートを依存に追加（MIT/Apache-2.0）
- daemon.rs にモジュールの初期化・起動・停止を統合
- config.example.toml に設定セクションを追加
- 単体テスト 12 件、統合テスト 2 件を追加

## 主な機能

- `Failed password for ... from <IP>` パターンの正規表現マッチング
- IP ごとの認証失敗タイムスタンプを HashMap で管理
- 設定可能な時間窓（デフォルト 300 秒）と閾値（デフォルト 5 回）
- seek ベースの差分読み取り（前回位置から差分のみ）
- ログローテーション検知（ファイルサイズ減少で先頭リセット）
- 重複イベント抑制（検知後に該当 IP のエントリをクリア）
- ファイル不存在時は warn ログのみ（デーモン停止しない）

## テスト計画

- [x] `cargo fmt --check` — パス
- [x] `cargo clippy -- -D warnings` — パス
- [x] `cargo test` — 全 326 単体テスト + 31 統合テスト パス
- [x] IP 抽出の正規表現テスト（正常パターン、invalid user、マッチなし）
- [x] 時間窓外エントリの除去テスト
- [x] 設定バリデーションテスト（interval_secs=0, max_failures=0, time_window_secs=0）
- [x] 起動・停止テスト
- [x] 統合テスト（デフォルト無効、カスタム設定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)