### PR TITLE
feat: パッケージリポジトリ改ざん検知モジュールの実装 (#44)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ src/
     kernel_module.rs   # カーネルモジュール監視モジュール
     log_tamper.rs      # ログファイル改ざん検知モジュール
     mount_monitor.rs   # マウントポイント監視モジュール
+    pkg_repo_monitor.rs # パッケージリポジトリ改ざん検知モジュール
     process_monitor.rs # プロセス異常検知モジュール
     shell_config_monitor.rs # シェル設定ファイル監視モジュール
     ssh_brute_force.rs # SSH ブルートフォース検知モジュール

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -125,6 +125,14 @@ passwd_path = "/etc/passwd"
 # group ファイルのパス
 group_path = "/etc/group"
 
+[modules.pkg_repo_monitor]
+# パッケージリポジトリ改ざん検知モジュールの有効/無効
+enabled = false
+# スキャン間隔（秒）
+scan_interval_secs = 120
+# 監視対象パスのリスト（ファイルまたはディレクトリ）
+watch_paths = ["/etc/apt/sources.list", "/etc/apt/sources.list.d", "/etc/yum.repos.d"]
+
 [modules.ssh_brute_force]
 # SSH ブルートフォース検知モジュールの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,10 @@ pub struct ModulesConfig {
     /// SSH ブルートフォース検知モジュールの設定
     #[serde(default)]
     pub ssh_brute_force: SshBruteForceConfig,
+
+    /// パッケージリポジトリ改ざん検知モジュールの設定
+    #[serde(default)]
+    pub pkg_repo_monitor: PkgRepoMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -737,6 +741,46 @@ impl Default for SshBruteForceConfig {
             auth_log_path: Self::default_auth_log_path(),
             max_failures: Self::default_max_failures(),
             time_window_secs: Self::default_time_window_secs(),
+        }
+    }
+}
+
+/// パッケージリポジトリ改ざん検知モジュールの設定
+#[derive(Debug, Deserialize, Clone)]
+pub struct PkgRepoMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スキャン間隔（秒）
+    #[serde(default = "PkgRepoMonitorConfig::default_scan_interval_secs")]
+    pub scan_interval_secs: u64,
+
+    /// 監視対象パスのリスト（ファイルまたはディレクトリ）
+    #[serde(default = "PkgRepoMonitorConfig::default_watch_paths")]
+    pub watch_paths: Vec<PathBuf>,
+}
+
+impl PkgRepoMonitorConfig {
+    fn default_scan_interval_secs() -> u64 {
+        120
+    }
+
+    fn default_watch_paths() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/etc/apt/sources.list"),
+            PathBuf::from("/etc/apt/sources.list.d"),
+            PathBuf::from("/etc/yum.repos.d"),
+        ]
+    }
+}
+
+impl Default for PkgRepoMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            scan_interval_secs: Self::default_scan_interval_secs(),
+            watch_paths: Self::default_watch_paths(),
         }
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -11,6 +11,7 @@ use crate::modules::firewall_monitor::FirewallMonitorModule;
 use crate::modules::kernel_module::KernelModuleMonitor;
 use crate::modules::log_tamper::LogTamperModule;
 use crate::modules::mount_monitor::MountMonitorModule;
+use crate::modules::pkg_repo_monitor::PkgRepoMonitorModule;
 use crate::modules::process_monitor::ProcessMonitorModule;
 use crate::modules::shell_config_monitor::ShellConfigMonitorModule;
 use crate::modules::ssh_brute_force::SshBruteForceModule;
@@ -295,6 +296,21 @@ impl Daemon {
             None
         };
 
+        // パッケージリポジトリ改ざん検知モジュールの初期化と起動
+        let pkg_cancel_token = if self.config.modules.pkg_repo_monitor.enabled {
+            let mut pkg = PkgRepoMonitorModule::new(
+                self.config.modules.pkg_repo_monitor.clone(),
+                event_bus.clone(),
+            );
+            pkg.init()?;
+            let cancel_token = pkg.cancel_token();
+            pkg.start().await?;
+            tracing::info!("パッケージリポジトリ改ざん検知モジュールを起動しました");
+            Some(cancel_token)
+        } else {
+            None
+        };
+
         // ユーザーアカウント監視モジュールの初期化と起動
         let ua_cancel_token = if self.config.modules.user_account.enabled {
             let mut ua =
@@ -416,6 +432,10 @@ impl Daemon {
         if let Some(cancel_token) = sbf_cancel_token {
             cancel_token.cancel();
             tracing::info!("SSH ブルートフォース検知モジュールを停止しました");
+        }
+        if let Some(cancel_token) = pkg_cancel_token {
+            cancel_token.cancel();
+            tracing::info!("パッケージリポジトリ改ざん検知モジュールを停止しました");
         }
 
         tracing::info!("シャットダウン完了");

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -5,6 +5,7 @@ pub mod firewall_monitor;
 pub mod kernel_module;
 pub mod log_tamper;
 pub mod mount_monitor;
+pub mod pkg_repo_monitor;
 pub mod process_monitor;
 pub mod shell_config_monitor;
 pub mod ssh_brute_force;

--- a/src/modules/pkg_repo_monitor.rs
+++ b/src/modules/pkg_repo_monitor.rs
@@ -1,0 +1,536 @@
+//! パッケージリポジトリ改ざん検知モジュール
+//!
+//! APT/YUM 等のパッケージリポジトリ設定ファイルを定期的にスキャンし、
+//! SHA-256 ハッシュベースで変更を検知する。
+//!
+//! 検知対象:
+//! - `/etc/apt/sources.list` の変更（APT リポジトリ設定の改ざん）
+//! - `/etc/apt/sources.list.d/` 配下のファイルの変更・追加・削除
+//! - `/etc/yum.repos.d/` 配下のファイルの変更・追加・削除
+//! - 監視対象ファイルの追加・削除
+
+use crate::config::PkgRepoMonitorConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use crate::error::AppError;
+use crate::modules::Module;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tokio_util::sync::CancellationToken;
+use walkdir::WalkDir;
+
+/// パッケージリポジトリ設定変更レポート
+struct ChangeReport {
+    modified: Vec<PathBuf>,
+    added: Vec<PathBuf>,
+    removed: Vec<PathBuf>,
+}
+
+impl ChangeReport {
+    /// 変更があったかどうかを返す
+    fn has_changes(&self) -> bool {
+        !self.modified.is_empty() || !self.added.is_empty() || !self.removed.is_empty()
+    }
+}
+
+/// パッケージリポジトリ改ざん検知モジュール
+///
+/// パッケージリポジトリ設定ファイルを定期スキャンし、ベースラインとの差分を検知する。
+pub struct PkgRepoMonitorModule {
+    config: PkgRepoMonitorConfig,
+    event_bus: Option<EventBus>,
+    baseline: Option<HashMap<PathBuf, String>>,
+    cancel_token: CancellationToken,
+}
+
+impl PkgRepoMonitorModule {
+    /// 新しいパッケージリポジトリ改ざん検知モジュールを作成する
+    pub fn new(config: PkgRepoMonitorConfig, event_bus: Option<EventBus>) -> Self {
+        Self {
+            config,
+            event_bus,
+            baseline: None,
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// 監視対象パスをスキャンし、各ファイルの SHA-256 ハッシュを返す
+    ///
+    /// `watch_paths` にファイルが指定された場合は直接スキャンし、
+    /// ディレクトリが指定された場合は配下を再帰的にスキャンする。
+    fn scan_files(watch_paths: &[PathBuf]) -> HashMap<PathBuf, String> {
+        let mut result = HashMap::new();
+        for path in watch_paths {
+            if path.is_file() {
+                match compute_hash(path) {
+                    Ok(hash) => {
+                        result.insert(path.clone(), hash);
+                    }
+                    Err(e) => {
+                        tracing::debug!(path = %path.display(), error = %e, "リポジトリ設定ファイルの読み取りに失敗しました。スキャンを継続します");
+                    }
+                }
+            } else if path.is_dir() {
+                for entry in WalkDir::new(path)
+                    .min_depth(1)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                {
+                    let entry_path = entry.path().to_path_buf();
+                    if entry_path.is_file() {
+                        match compute_hash(&entry_path) {
+                            Ok(hash) => {
+                                result.insert(entry_path, hash);
+                            }
+                            Err(e) => {
+                                tracing::debug!(path = %entry.path().display(), error = %e, "リポジトリ設定ファイルの読み取りに失敗しました。スキャンを継続します");
+                            }
+                        }
+                    }
+                }
+            } else {
+                tracing::debug!(path = %path.display(), "リポジトリ設定パスが存在しません。スキップします");
+            }
+        }
+        result
+    }
+
+    /// ベースラインと現在のスキャン結果を比較し、変更レポートを返す
+    fn detect_changes(
+        baseline: &HashMap<PathBuf, String>,
+        current: &HashMap<PathBuf, String>,
+    ) -> ChangeReport {
+        let mut modified = Vec::new();
+        let mut added = Vec::new();
+        let mut removed = Vec::new();
+
+        for (path, current_hash) in current {
+            match baseline.get(path) {
+                Some(baseline_hash) if baseline_hash != current_hash => {
+                    modified.push(path.clone());
+                }
+                None => {
+                    added.push(path.clone());
+                }
+                _ => {}
+            }
+        }
+
+        for path in baseline.keys() {
+            if !current.contains_key(path) {
+                removed.push(path.clone());
+            }
+        }
+
+        ChangeReport {
+            modified,
+            added,
+            removed,
+        }
+    }
+}
+
+/// ファイルの SHA-256 ハッシュを計算する
+fn compute_hash(path: &PathBuf) -> Result<String, AppError> {
+    let data = std::fs::read(path).map_err(|e| AppError::FileIo {
+        path: path.clone(),
+        source: e,
+    })?;
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let hash = hasher.finalize();
+    Ok(format!("{:x}", hash))
+}
+
+impl Module for PkgRepoMonitorModule {
+    fn name(&self) -> &str {
+        "pkg_repo_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.scan_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "scan_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        tracing::info!(
+            watch_paths = ?self.config.watch_paths,
+            scan_interval_secs = self.config.scan_interval_secs,
+            "パッケージリポジトリ改ざん検知モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        // 初回スキャンでベースライン作成
+        let baseline = Self::scan_files(&self.config.watch_paths);
+        tracing::info!(
+            file_count = baseline.len(),
+            "ベースラインスキャンが完了しました"
+        );
+
+        self.baseline = Some(baseline);
+
+        // baseline の所有権をタスクに移動
+        let mut baseline = self.baseline.take().ok_or_else(|| AppError::ModuleConfig {
+            message: "ベースラインが未初期化です".to_string(),
+        })?;
+
+        let watch_paths = self.config.watch_paths.clone();
+        let scan_interval_secs = self.config.scan_interval_secs;
+        let cancel_token = self.cancel_token.clone();
+        let event_bus = self.event_bus.clone();
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
+            // 最初の tick は即座に発火するのでスキップ
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("パッケージリポジトリ改ざん検知モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let current = PkgRepoMonitorModule::scan_files(&watch_paths);
+                        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+
+                        if report.has_changes() {
+                            for path in &report.modified {
+                                tracing::warn!(path = %path.display(), change = "modified", "リポジトリ設定ファイルの変更を検知しました");
+                                if let Some(ref bus) = event_bus {
+                                    bus.publish(
+                                        SecurityEvent::new(
+                                            "pkg_repo_modified",
+                                            Severity::Warning,
+                                            "pkg_repo_monitor",
+                                            format!("リポジトリ設定ファイルの変更を検知しました: {}", path.display()),
+                                        )
+                                        .with_details(path.display().to_string()),
+                                    );
+                                }
+                            }
+                            for path in &report.added {
+                                tracing::warn!(path = %path.display(), change = "added", "リポジトリ設定ファイルの追加を検知しました");
+                                if let Some(ref bus) = event_bus {
+                                    bus.publish(
+                                        SecurityEvent::new(
+                                            "pkg_repo_added",
+                                            Severity::Warning,
+                                            "pkg_repo_monitor",
+                                            format!("リポジトリ設定ファイルの追加を検知しました: {}", path.display()),
+                                        )
+                                        .with_details(path.display().to_string()),
+                                    );
+                                }
+                            }
+                            for path in &report.removed {
+                                tracing::warn!(path = %path.display(), change = "removed", "リポジトリ設定ファイルの削除を検知しました");
+                                if let Some(ref bus) = event_bus {
+                                    bus.publish(
+                                        SecurityEvent::new(
+                                            "pkg_repo_removed",
+                                            Severity::Warning,
+                                            "pkg_repo_monitor",
+                                            format!("リポジトリ設定ファイルの削除を検知しました: {}", path.display()),
+                                        )
+                                        .with_details(path.display().to_string()),
+                                    );
+                                }
+                            }
+                            // ベースラインを更新
+                            baseline = current;
+                        } else {
+                            tracing::debug!("リポジトリ設定ファイルの変更はありません");
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_compute_hash() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "deb http://archive.ubuntu.com/ubuntu jammy main").unwrap();
+        let hash = compute_hash(&tmpfile.path().to_path_buf()).unwrap();
+        assert!(!hash.is_empty());
+        assert_eq!(hash.len(), 64); // SHA-256 は 64 文字の hex
+    }
+
+    #[test]
+    fn test_compute_hash_deterministic() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "hello world").unwrap();
+        let hash = compute_hash(&tmpfile.path().to_path_buf()).unwrap();
+        assert_eq!(
+            hash,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+    }
+
+    #[test]
+    fn test_compute_hash_nonexistent() {
+        let result = compute_hash(&PathBuf::from("/tmp/nonexistent-file-zettai-pkg-test"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_scan_files_with_single_file() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "deb http://archive.ubuntu.com/ubuntu jammy main").unwrap();
+        let path = tmpfile.path().to_path_buf();
+
+        let watch_paths = vec![path.clone()];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert_eq!(result.len(), 1);
+        assert!(result.contains_key(&path));
+    }
+
+    #[test]
+    fn test_scan_files_empty() {
+        let watch_paths: Vec<PathBuf> = vec![];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_files_nonexistent_skipped() {
+        let watch_paths = vec![PathBuf::from("/tmp/nonexistent_zettai_pkg_test")];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_scan_files_directory() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file1 = dir.path().join("repo1.list");
+        let file2 = dir.path().join("repo2.list");
+        std::fs::write(&file1, "deb http://example.com/repo1 stable main").unwrap();
+        std::fs::write(&file2, "deb http://example.com/repo2 stable main").unwrap();
+
+        let watch_paths = vec![dir.path().to_path_buf()];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&file1));
+        assert!(result.contains_key(&file2));
+    }
+
+    #[test]
+    fn test_scan_files_directory_nested() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let subdir = dir.path().join("subdir");
+        std::fs::create_dir(&subdir).unwrap();
+        let file1 = dir.path().join("repo1.list");
+        let file2 = subdir.join("repo2.list");
+        std::fs::write(&file1, "content1").unwrap();
+        std::fs::write(&file2, "content2").unwrap();
+
+        let watch_paths = vec![dir.path().to_path_buf()];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&file1));
+        assert!(result.contains_key(&file2));
+    }
+
+    #[test]
+    fn test_scan_files_mixed_file_and_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let dir_file = dir.path().join("repo.list");
+        std::fs::write(&dir_file, "dir content").unwrap();
+
+        let mut standalone = tempfile::NamedTempFile::new().unwrap();
+        write!(standalone, "standalone content").unwrap();
+
+        let watch_paths = vec![standalone.path().to_path_buf(), dir.path().to_path_buf()];
+        let result = PkgRepoMonitorModule::scan_files(&watch_paths);
+        assert_eq!(result.len(), 2);
+        assert!(result.contains_key(&standalone.path().to_path_buf()));
+        assert!(result.contains_key(&dir_file));
+    }
+
+    #[test]
+    fn test_detect_changes_no_changes() {
+        let mut baseline = HashMap::new();
+        baseline.insert(PathBuf::from("/etc/apt/sources.list"), "hash1".to_string());
+
+        let current = baseline.clone();
+        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+        assert!(!report.has_changes());
+    }
+
+    #[test]
+    fn test_detect_changes_modified() {
+        let mut baseline = HashMap::new();
+        baseline.insert(PathBuf::from("/etc/apt/sources.list"), "hash1".to_string());
+
+        let mut current = HashMap::new();
+        current.insert(PathBuf::from("/etc/apt/sources.list"), "hash2".to_string());
+
+        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+        assert_eq!(report.modified.len(), 1);
+        assert!(report.added.is_empty());
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn test_detect_changes_added() {
+        let baseline = HashMap::new();
+        let mut current = HashMap::new();
+        current.insert(
+            PathBuf::from("/etc/apt/sources.list.d/malicious.list"),
+            "hash1".to_string(),
+        );
+
+        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+        assert!(report.modified.is_empty());
+        assert_eq!(report.added.len(), 1);
+        assert!(report.removed.is_empty());
+    }
+
+    #[test]
+    fn test_detect_changes_removed() {
+        let mut baseline = HashMap::new();
+        baseline.insert(
+            PathBuf::from("/etc/apt/sources.list.d/official.list"),
+            "hash1".to_string(),
+        );
+
+        let current = HashMap::new();
+        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+        assert!(report.modified.is_empty());
+        assert!(report.added.is_empty());
+        assert_eq!(report.removed.len(), 1);
+    }
+
+    #[test]
+    fn test_detect_changes_combined() {
+        let mut baseline = HashMap::new();
+        baseline.insert(PathBuf::from("/etc/apt/sources.list"), "hash1".to_string());
+        baseline.insert(
+            PathBuf::from("/etc/apt/sources.list.d/official.list"),
+            "hash2".to_string(),
+        );
+        baseline.insert(
+            PathBuf::from("/etc/apt/sources.list.d/removed.list"),
+            "hash3".to_string(),
+        );
+
+        let mut current = HashMap::new();
+        current.insert(PathBuf::from("/etc/apt/sources.list"), "hash1".to_string());
+        current.insert(
+            PathBuf::from("/etc/apt/sources.list.d/official.list"),
+            "hash_changed".to_string(),
+        );
+        current.insert(
+            PathBuf::from("/etc/apt/sources.list.d/new.list"),
+            "hash4".to_string(),
+        );
+
+        let report = PkgRepoMonitorModule::detect_changes(&baseline, &current);
+        assert_eq!(report.modified.len(), 1);
+        assert_eq!(report.added.len(), 1);
+        assert_eq!(report.removed.len(), 1);
+        assert!(
+            report
+                .modified
+                .contains(&PathBuf::from("/etc/apt/sources.list.d/official.list"))
+        );
+        assert!(
+            report
+                .added
+                .contains(&PathBuf::from("/etc/apt/sources.list.d/new.list"))
+        );
+        assert!(
+            report
+                .removed
+                .contains(&PathBuf::from("/etc/apt/sources.list.d/removed.list"))
+        );
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = PkgRepoMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 0,
+            watch_paths: vec![],
+        };
+        let mut module = PkgRepoMonitorModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let config = PkgRepoMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![PathBuf::from("/etc/apt/sources.list")],
+        };
+        let mut module = PkgRepoMonitorModule::new(config, None);
+        let result = module.init();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile, "deb http://archive.ubuntu.com/ubuntu jammy main").unwrap();
+
+        let config = PkgRepoMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 3600,
+            watch_paths: vec![tmpfile.path().to_path_buf()],
+        };
+        let mut module = PkgRepoMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+
+    #[test]
+    fn test_change_report_has_changes_empty() {
+        let report = ChangeReport {
+            modified: vec![],
+            added: vec![],
+            removed: vec![],
+        };
+        assert!(!report.has_changes());
+    }
+
+    #[test]
+    fn test_change_report_has_changes_modified() {
+        let report = ChangeReport {
+            modified: vec![PathBuf::from("/test")],
+            added: vec![],
+            removed: vec![],
+        };
+        assert!(report.has_changes());
+    }
+}


### PR DESCRIPTION
## Summary

- APT/YUM のリポジトリ設定ファイルを SHA-256 ハッシュベースで定期監視し、改ざん（変更・追加・削除）を検知する `pkg_repo_monitor` モジュールを追加
- ディレクトリ配下のファイルも `walkdir` で再帰的にスキャンし、`/etc/apt/sources.list.d/` や `/etc/yum.repos.d/` に対応
- イベントバス連携で `SecurityEvent`（pkg_repo_modified, pkg_repo_added, pkg_repo_removed）を発行

Closes #44

## 変更ファイル

- `src/modules/pkg_repo_monitor.rs` — 新規モジュール本体（テスト含む）
- `src/modules/mod.rs` — モジュール登録
- `src/config.rs` — `PkgRepoMonitorConfig` 追加
- `src/core/daemon.rs` — モジュール初期化・起動・停止
- `config.example.toml` — サンプル設定追加
- `CLAUDE.md` — ディレクトリ構成更新
- `Cargo.toml` — バージョン v0.22.0

## Test plan

- [x] `cargo test` — 全 345+31 テスト通過（新規 20 テスト追加）
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)