### PR TITLE
feat: イベント統計・メトリクス収集の実装 (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Module System**: 各防御機能をモジュールとして実装するプラグイン的な仕組み
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
+- **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 
 ## ディレクトリ構成
@@ -79,6 +80,7 @@ src/
     action.rs          # アクションエンジン（ルールベースのアクション実行）
     event.rs           # イベントバス（SecurityEvent / EventBus / ログサブスクライバー）
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
+    metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）
   modules/
     mod.rs             # モジュールトレイト・レジストリ

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -171,6 +171,12 @@ max_failures = 5
 # 時間窓（秒）- この期間内の失敗回数をカウント
 time_window_secs = 300
 
+[metrics]
+# イベント統計・メトリクス収集の有効/無効
+enabled = false
+# サマリーログ出力インターバル（秒）
+interval_secs = 60
+
 [event_bus]
 # イベントバスの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,10 @@ pub struct AppConfig {
     /// アクションエンジン設定
     #[serde(default)]
     pub actions: ActionConfig,
+
+    /// メトリクス収集設定
+    #[serde(default)]
+    pub metrics: MetricsConfig,
 }
 
 /// 一般設定
@@ -1025,6 +1029,33 @@ impl Default for EventBusConfig {
     }
 }
 
+/// メトリクス収集の設定
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+pub struct MetricsConfig {
+    /// メトリクス収集の有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// サマリーログ出力インターバル（秒）
+    #[serde(default = "MetricsConfig::default_interval_secs")]
+    pub interval_secs: u64,
+}
+
+impl MetricsConfig {
+    fn default_interval_secs() -> u64 {
+        60
+    }
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: Self::default_interval_secs(),
+        }
+    }
+}
+
 impl GeneralConfig {
     fn default_log_level() -> String {
         "info".to_string()
@@ -1418,6 +1449,25 @@ channel_capacity = 512
         let config: AppConfig = toml::from_str(toml_str).unwrap();
         assert!(config.event_bus.enabled);
         assert_eq!(config.event_bus.channel_capacity, 512);
+    }
+
+    #[test]
+    fn test_metrics_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(!config.metrics.enabled);
+        assert_eq!(config.metrics.interval_secs, 60);
+    }
+
+    #[test]
+    fn test_metrics_config_custom() {
+        let toml_str = r#"
+[metrics]
+enabled = true
+interval_secs = 300
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.metrics.enabled);
+        assert_eq!(config.metrics.interval_secs, 300);
     }
 
     #[test]

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::core::action::ActionEngine;
 use crate::core::event::{self, EventBus, SecurityEvent, Severity};
 use crate::core::health::HealthChecker;
+use crate::core::metrics::MetricsCollector;
 use crate::core::module_manager::ModuleManager;
 use crate::error::AppError;
 use std::path::PathBuf;
@@ -50,6 +51,16 @@ impl Daemon {
                         tracing::error!(error = %e, "アクションエンジンの初期化に失敗しました");
                     }
                 }
+            }
+
+            // メトリクスコレクターの起動
+            if self.config.metrics.enabled {
+                let collector = MetricsCollector::new(&self.config.metrics, &bus);
+                collector.spawn();
+                tracing::info!(
+                    interval_secs = self.config.metrics.interval_secs,
+                    "メトリクスコレクターを起動しました"
+                );
             }
 
             tracing::info!(
@@ -115,6 +126,15 @@ impl Daemon {
                                     format!("設定ファイルをリロードしました ({})", summary),
                                 );
                                 bus.publish(event);
+                            }
+
+                            // メトリクスのインターバル変更警告
+                            if self.config.metrics.interval_secs != new_config.metrics.interval_secs {
+                                tracing::warn!(
+                                    old = self.config.metrics.interval_secs,
+                                    new = new_config.metrics.interval_secs,
+                                    "メトリクスのインターバル変更はデーモン再起動後に反映されます"
+                                );
                             }
 
                             self.config = new_config;

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -1,0 +1,206 @@
+//! イベント統計・メトリクス収集
+
+use crate::config::MetricsConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+use tokio::sync::broadcast;
+
+/// イベント統計・メトリクス収集
+pub struct MetricsCollector {
+    receiver: broadcast::Receiver<SecurityEvent>,
+    interval: Duration,
+}
+
+impl MetricsCollector {
+    /// 設定とイベントバスから MetricsCollector を構築する
+    pub fn new(config: &MetricsConfig, event_bus: &EventBus) -> Self {
+        Self {
+            receiver: event_bus.subscribe(),
+            interval: Duration::from_secs(config.interval_secs),
+        }
+    }
+
+    /// 非同期タスクとしてメトリクスコレクターを起動する
+    pub fn spawn(self) {
+        tokio::spawn(async move {
+            Self::run_loop(self.receiver, self.interval).await;
+        });
+    }
+
+    async fn run_loop(mut receiver: broadcast::Receiver<SecurityEvent>, interval: Duration) {
+        let started_at = Instant::now();
+        let mut total_events: u64 = 0;
+        let mut info_count: u64 = 0;
+        let mut warning_count: u64 = 0;
+        let mut critical_count: u64 = 0;
+        let mut module_counts: HashMap<String, u64> = HashMap::new();
+        let mut interval_events: u64 = 0;
+
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // 最初の tick をスキップ
+
+        loop {
+            tokio::select! {
+                result = receiver.recv() => {
+                    match result {
+                        Ok(event) => {
+                            total_events += 1;
+                            interval_events += 1;
+                            match event.severity {
+                                Severity::Info => info_count += 1,
+                                Severity::Warning => warning_count += 1,
+                                Severity::Critical => critical_count += 1,
+                            }
+                            *module_counts
+                                .entry(event.source_module.clone())
+                                .or_insert(0) += 1;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                skipped = n,
+                                "メトリクス: {} 件のイベントをスキップ（遅延）",
+                                n
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            Self::emit_summary(
+                                total_events,
+                                interval_events,
+                                info_count,
+                                warning_count,
+                                critical_count,
+                                &module_counts,
+                                &started_at,
+                            );
+                            tracing::info!("イベントバスが閉じられました。メトリクスコレクターを終了します");
+                            break;
+                        }
+                    }
+                }
+                _ = ticker.tick() => {
+                    Self::emit_summary(
+                        total_events,
+                        interval_events,
+                        info_count,
+                        warning_count,
+                        critical_count,
+                        &module_counts,
+                        &started_at,
+                    );
+                    interval_events = 0;
+                }
+            }
+        }
+    }
+
+    fn emit_summary(
+        total_events: u64,
+        interval_events: u64,
+        info_count: u64,
+        warning_count: u64,
+        critical_count: u64,
+        module_counts: &HashMap<String, u64>,
+        started_at: &Instant,
+    ) {
+        let uptime_secs = started_at.elapsed().as_secs();
+        tracing::info!(
+            total_events = total_events,
+            interval_events = interval_events,
+            info_count = info_count,
+            warning_count = warning_count,
+            critical_count = critical_count,
+            uptime_secs = uptime_secs,
+            "[MetricsSummary] 合計: {}, 直近: {}, INFO: {}, WARNING: {}, CRITICAL: {}",
+            total_events,
+            interval_events,
+            info_count,
+            warning_count,
+            critical_count
+        );
+
+        if !module_counts.is_empty() {
+            let module_summary: Vec<String> = module_counts
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect();
+            tracing::info!(
+                modules = %module_summary.join(", "),
+                "[MetricsSummary] モジュール別カウント"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_collector_new() {
+        let config = MetricsConfig {
+            enabled: true,
+            interval_secs: 120,
+        };
+        let bus = EventBus::new(16);
+        let collector = MetricsCollector::new(&config, &bus);
+        assert_eq!(collector.interval, Duration::from_secs(120));
+    }
+
+    #[tokio::test]
+    async fn test_emit_summary_does_not_panic() {
+        let module_counts = HashMap::new();
+        let started_at = Instant::now();
+        // パニックしないことを確認
+        MetricsCollector::emit_summary(0, 0, 0, 0, 0, &module_counts, &started_at);
+    }
+
+    #[tokio::test]
+    async fn test_emit_summary_with_module_counts() {
+        let mut module_counts = HashMap::new();
+        module_counts.insert("file_integrity".to_string(), 5);
+        module_counts.insert("process_monitor".to_string(), 3);
+        let started_at = Instant::now();
+        // パニックしないことを確認
+        MetricsCollector::emit_summary(8, 2, 4, 3, 1, &module_counts, &started_at);
+    }
+
+    #[tokio::test]
+    async fn test_metrics_collector_receives_events() {
+        let bus = EventBus::new(16);
+        let config = MetricsConfig {
+            enabled: true,
+            interval_secs: 1,
+        };
+        let collector = MetricsCollector::new(&config, &bus);
+        collector.spawn();
+
+        // イベントを発行
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Info,
+            "test_module",
+            "テストイベント",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Warning,
+            "test_module",
+            "テストイベント",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Critical,
+            "another_module",
+            "テストイベント",
+        ));
+
+        // メトリクスコレクターがイベントを処理する時間を与える
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // サマリー出力まで待つ（1秒インターバル）
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // パニックせずに動作することを確認（ログ出力は tracing で検証）
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,4 +2,5 @@ pub mod action;
 pub mod daemon;
 pub mod event;
 pub mod health;
+pub mod metrics;
 pub mod module_manager;


### PR DESCRIPTION
## 概要

Closes #57

EventBus のサブスクライバーとして `MetricsCollector` を実装し、SecurityEvent の統計を収集・ログ出力する機能を追加。

## 変更内容

- `src/core/metrics.rs` — MetricsCollector の実装（イベント受信・集計・定期サマリー出力）
- `src/config.rs` — MetricsConfig 設定構造体の追加
- `src/core/daemon.rs` — MetricsCollector の初期化・ホットリロード警告
- `config.example.toml` — `[metrics]` セクション追加
- `CLAUDE.md` — ドキュメント更新

## メトリクス項目

- イベント総数
- Severity 別カウント（Info / Warning / Critical）
- モジュール別カウント
- 直近インターバルのイベント数
- 経過時間

## 設定

```toml
[metrics]
enabled = false
interval_secs = 60
```

## テスト

- MetricsCollector の構築テスト
- サマリー出力テスト（空・データあり）
- イベント受信テスト
- MetricsConfig デフォルト値・カスタム値テスト
- 全 452 単体テスト + 34 統合テスト通過
- cargo clippy / cargo fmt 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)