### PR TITLE
feat: イベント重複排除（デバウンス）機能の実装 (#59)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -182,6 +182,9 @@ interval_secs = 60
 enabled = false
 # ブロードキャストチャネルの容量
 channel_capacity = 1024
+# イベントデバウンス間隔（秒）— 同一イベントをこの期間内は抑制する
+# 0 でデバウンスを無効化。Critical イベントは常に即時配信
+debounce_secs = 30
 
 [actions]
 # アクションエンジンの有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -1012,11 +1012,19 @@ pub struct EventBusConfig {
     /// ブロードキャストチャネルの容量
     #[serde(default = "EventBusConfig::default_channel_capacity")]
     pub channel_capacity: usize,
+
+    /// イベントデバウンス間隔（秒）— 0 でデバウンス無効
+    #[serde(default = "EventBusConfig::default_debounce_secs")]
+    pub debounce_secs: u64,
 }
 
 impl EventBusConfig {
     fn default_channel_capacity() -> usize {
         1024
+    }
+
+    fn default_debounce_secs() -> u64 {
+        30
     }
 }
 
@@ -1025,6 +1033,7 @@ impl Default for EventBusConfig {
         Self {
             enabled: false,
             channel_capacity: Self::default_channel_capacity(),
+            debounce_secs: Self::default_debounce_secs(),
         }
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -38,8 +38,12 @@ impl Daemon {
 
         // イベントバスの初期化
         let event_bus = if self.config.event_bus.enabled {
-            let bus = EventBus::new(self.config.event_bus.channel_capacity);
+            let bus = EventBus::with_debounce(
+                self.config.event_bus.channel_capacity,
+                self.config.event_bus.debounce_secs,
+            );
             event::spawn_log_subscriber(&bus);
+            event::spawn_debounce_cleanup(&bus);
             // アクションエンジンの起動
             if self.config.actions.enabled {
                 match ActionEngine::new(&self.config.actions, &bus) {
@@ -126,6 +130,11 @@ impl Daemon {
                                     format!("設定ファイルをリロードしました ({})", summary),
                                 );
                                 bus.publish(event);
+                            }
+
+                            // デバウンス間隔の更新
+                            if let Some(ref bus) = event_bus {
+                                bus.update_debounce_secs(new_config.event_bus.debounce_secs);
                             }
 
                             // メトリクスのインターバル変更警告

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,7 +1,9 @@
 //! イベントバス — モジュール間イベント伝達
 
+use std::collections::HashMap;
 use std::fmt;
-use std::time::SystemTime;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime};
 use tokio::sync::broadcast;
 use tracing::{error, info, warn};
 
@@ -90,17 +92,151 @@ impl fmt::Display for SecurityEvent {
     }
 }
 
+/// デバウンスエントリ
+#[derive(Debug)]
+struct DebounceEntry {
+    last_published: Instant,
+    suppressed_count: u64,
+}
+
+/// デバウンスフィルター
+#[derive(Debug)]
+pub(crate) struct DebounceFilter {
+    entries: HashMap<String, DebounceEntry>,
+    debounce_duration: Duration,
+    max_entries: usize,
+}
+
+impl DebounceFilter {
+    /// 新しいデバウンスフィルターを作成する
+    fn new(debounce_secs: u64) -> Self {
+        Self {
+            entries: HashMap::new(),
+            debounce_duration: Duration::from_secs(debounce_secs),
+            max_entries: 10_000,
+        }
+    }
+
+    /// イベントからデバウンスキーを生成する
+    fn make_key(event: &SecurityEvent) -> String {
+        let detail_part = match &event.details {
+            Some(d) => {
+                if d.len() > 128 {
+                    &d[..d.floor_char_boundary(128)]
+                } else {
+                    d.as_str()
+                }
+            }
+            None => &event.message,
+        };
+        format!(
+            "{}:{}:{}",
+            event.source_module, event.event_type, detail_part
+        )
+    }
+
+    /// イベントを発行すべきか判定する
+    fn should_publish(&mut self, key: &str) -> bool {
+        let now = Instant::now();
+        match self.entries.get_mut(key) {
+            Some(entry) => {
+                if now.duration_since(entry.last_published) >= self.debounce_duration {
+                    entry.last_published = now;
+                    entry.suppressed_count = 0;
+                    true
+                } else {
+                    entry.suppressed_count += 1;
+                    false
+                }
+            }
+            None => {
+                self.entries.insert(
+                    key.to_string(),
+                    DebounceEntry {
+                        last_published: now,
+                        suppressed_count: 0,
+                    },
+                );
+                true
+            }
+        }
+    }
+
+    /// デバウンス間隔を更新する
+    fn update_duration(&mut self, debounce_secs: u64) {
+        self.debounce_duration = Duration::from_secs(debounce_secs);
+    }
+
+    /// 期限切れのエントリをクリーンアップする
+    fn cleanup(&mut self) -> usize {
+        let now = Instant::now();
+        let expiry = self.debounce_duration * 2;
+        let mut removed = 0;
+
+        self.entries.retain(|key, entry| {
+            if now.duration_since(entry.last_published) > expiry {
+                if entry.suppressed_count > 0 {
+                    info!(
+                        key = %key,
+                        suppressed_count = entry.suppressed_count,
+                        "デバウンス: 抑制されたイベントのクリーンアップ"
+                    );
+                }
+                removed += 1;
+                false
+            } else {
+                true
+            }
+        });
+
+        // max_entries 超過時は最も古いエントリから削除
+        if self.entries.len() > self.max_entries {
+            let mut entries_vec: Vec<(String, Instant)> = self
+                .entries
+                .iter()
+                .map(|(k, v)| (k.clone(), v.last_published))
+                .collect();
+            entries_vec.sort_by_key(|(_, t)| *t);
+
+            let to_remove = self.entries.len() - self.max_entries;
+            for (key, _) in entries_vec.into_iter().take(to_remove) {
+                self.entries.remove(&key);
+                removed += 1;
+            }
+        }
+
+        removed
+    }
+}
+
 /// モジュール間イベント伝達バス
 #[derive(Debug, Clone)]
 pub struct EventBus {
     sender: broadcast::Sender<SecurityEvent>,
+    debounce: Option<Arc<Mutex<DebounceFilter>>>,
 }
 
 impl EventBus {
-    /// 指定された容量でイベントバスを作成する
+    /// 指定された容量でイベントバスを作成する（デバウンスなし）
     pub fn new(capacity: usize) -> Self {
         let (sender, _) = broadcast::channel(capacity);
-        Self { sender }
+        Self {
+            sender,
+            debounce: None,
+        }
+    }
+
+    /// デバウンス付きでイベントバスを作成する
+    ///
+    /// `debounce_secs` が 0 の場合はデバウンスを無効にする
+    pub fn with_debounce(capacity: usize, debounce_secs: u64) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        let debounce = if debounce_secs > 0 {
+            Some(Arc::new(Mutex::new(DebounceFilter::new(debounce_secs))))
+        } else {
+            None
+        };
+        Self { sender, debounce }
     }
 
     /// イベントを発行する
@@ -114,6 +250,25 @@ impl EventBus {
             );
             return;
         }
+
+        // デバウンスフィルター適用
+        if let Some(ref debounce) = self.debounce {
+            // Critical イベントは常に即時配信
+            if event.severity != Severity::Critical {
+                let key = DebounceFilter::make_key(&event);
+                // unwrap safety: Mutex が poisoned になるのはパニック時のみで、正常動作時は安全
+                let should_publish = debounce.lock().unwrap().should_publish(&key);
+                if !should_publish {
+                    tracing::trace!(
+                        event_type = %event.event_type,
+                        source = %event.source_module,
+                        "デバウンス: イベントを抑制"
+                    );
+                    return;
+                }
+            }
+        }
+
         match self.sender.send(event) {
             Ok(n) => {
                 tracing::trace!("イベントを {} 件のサブスクライバーに配信", n);
@@ -121,6 +276,18 @@ impl EventBus {
             Err(_) => {
                 tracing::debug!("イベント発行: サブスクライバーなし（イベントは破棄）");
             }
+        }
+    }
+
+    /// デバウンス間隔を更新する
+    pub fn update_debounce_secs(&self, debounce_secs: u64) {
+        if let Some(ref debounce) = self.debounce {
+            // unwrap safety: Mutex が poisoned になるのはパニック時のみで、正常動作時は安全
+            debounce.lock().unwrap().update_duration(debounce_secs);
+            tracing::info!(
+                debounce_secs = debounce_secs,
+                "デバウンス間隔を更新しました"
+            );
         }
     }
 
@@ -180,6 +347,38 @@ pub fn spawn_log_subscriber(event_bus: &EventBus) {
             }
         }
     });
+}
+
+/// デバウンスフィルターの定期クリーンアップを起動する
+///
+/// デバウンスが有効な場合のみクリーンアップタスクを起動する
+pub fn spawn_debounce_cleanup(event_bus: &EventBus) {
+    if let Some(ref debounce) = event_bus.debounce {
+        let debounce = Arc::clone(debounce);
+        // unwrap safety: Mutex が poisoned になるのはパニック時のみで、正常動作時は安全
+        let debounce_duration = debounce.lock().unwrap().debounce_duration;
+        let interval_duration = std::cmp::max(debounce_duration * 2, Duration::from_secs(10));
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(interval_duration);
+            // 最初の tick は即座に発火するのでスキップ
+            interval.tick().await;
+
+            loop {
+                interval.tick().await;
+                // unwrap safety: Mutex が poisoned になるのはパニック時のみで、正常動作時は安全
+                let removed = debounce.lock().unwrap().cleanup();
+                if removed > 0 {
+                    tracing::debug!(
+                        removed = removed,
+                        "デバウンスクリーンアップ: {} 件のエントリを削除",
+                        removed
+                    );
+                }
+            }
+        });
+        tracing::info!("デバウンスクリーンアップタスクを起動しました");
+    }
 }
 
 #[cfg(test)]
@@ -359,5 +558,130 @@ mod tests {
         let received = receiver.recv().await.unwrap();
         assert_eq!(received.event_type, "from_clone");
         assert_eq!(received.message, "クローンからの送信");
+    }
+
+    #[test]
+    fn test_debounce_filter_new() {
+        let filter = DebounceFilter::new(30);
+        assert_eq!(filter.debounce_duration, Duration::from_secs(30));
+        assert_eq!(filter.max_entries, 10_000);
+        assert!(filter.entries.is_empty());
+    }
+
+    #[test]
+    fn test_debounce_key_with_details() {
+        let event = SecurityEvent::new(
+            "file_modified",
+            Severity::Warning,
+            "file_integrity",
+            "ファイルが変更されました",
+        )
+        .with_details("/etc/passwd");
+        let key = DebounceFilter::make_key(&event);
+        assert_eq!(key, "file_integrity:file_modified:/etc/passwd");
+    }
+
+    #[test]
+    fn test_debounce_key_without_details() {
+        let event = SecurityEvent::new(
+            "file_modified",
+            Severity::Warning,
+            "file_integrity",
+            "ファイルが変更されました",
+        );
+        let key = DebounceFilter::make_key(&event);
+        assert_eq!(key, "file_integrity:file_modified:ファイルが変更されました");
+    }
+
+    #[test]
+    fn test_debounce_key_long_details_truncated() {
+        let long_details = "a".repeat(200);
+        let event = SecurityEvent::new("file_modified", Severity::Warning, "file_integrity", "msg")
+            .with_details(long_details);
+        let key = DebounceFilter::make_key(&event);
+        // "file_integrity:file_modified:" = 29 chars + 128 chars = 157 chars
+        let prefix = "file_integrity:file_modified:";
+        assert!(key.starts_with(prefix));
+        assert_eq!(key.len(), prefix.len() + 128);
+    }
+
+    #[test]
+    fn test_debounce_first_event_passes() {
+        let mut filter = DebounceFilter::new(30);
+        assert!(filter.should_publish("test_key"));
+    }
+
+    #[test]
+    fn test_debounce_duplicate_suppressed() {
+        let mut filter = DebounceFilter::new(30);
+        assert!(filter.should_publish("test_key"));
+        assert!(!filter.should_publish("test_key"));
+        assert!(!filter.should_publish("test_key"));
+    }
+
+    #[test]
+    fn test_debounce_different_keys_pass() {
+        let mut filter = DebounceFilter::new(30);
+        assert!(filter.should_publish("key_a"));
+        assert!(filter.should_publish("key_b"));
+        assert!(!filter.should_publish("key_a"));
+        assert!(!filter.should_publish("key_b"));
+    }
+
+    #[tokio::test]
+    async fn test_debounce_critical_bypasses() {
+        let bus = EventBus::with_debounce(16, 60);
+        let mut receiver = bus.subscribe();
+
+        // 同じ Critical イベントを 2 回送信 — 両方とも配信される
+        for _ in 0..2 {
+            let event = SecurityEvent::new("intrusion", Severity::Critical, "ids", "侵入検知");
+            bus.publish(event);
+        }
+
+        let r1 = receiver.recv().await.unwrap();
+        assert_eq!(r1.event_type, "intrusion");
+        let r2 = receiver.recv().await.unwrap();
+        assert_eq!(r2.event_type, "intrusion");
+    }
+
+    #[test]
+    fn test_debounce_cleanup_removes_expired() {
+        let mut filter = DebounceFilter::new(0); // 0 秒 = 即座に期限切れ
+        filter.should_publish("key_a");
+        filter.should_publish("key_b");
+        assert_eq!(filter.entries.len(), 2);
+
+        // debounce_duration が 0 なので expiry (0*2=0) も即座に期限切れ
+        std::thread::sleep(Duration::from_millis(10));
+        let removed = filter.cleanup();
+        assert_eq!(removed, 2);
+        assert!(filter.entries.is_empty());
+    }
+
+    #[test]
+    fn test_debounce_update_duration() {
+        let mut filter = DebounceFilter::new(30);
+        assert_eq!(filter.debounce_duration, Duration::from_secs(30));
+        filter.update_duration(60);
+        assert_eq!(filter.debounce_duration, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_debounce_zero_disables() {
+        let bus = EventBus::with_debounce(16, 0);
+        assert!(bus.debounce.is_none());
+    }
+
+    #[test]
+    fn test_event_bus_with_debounce() {
+        let bus = EventBus::with_debounce(16, 30);
+        assert!(bus.debounce.is_some());
+    }
+
+    #[test]
+    fn test_event_bus_new_no_debounce() {
+        let bus = EventBus::new(16);
+        assert!(bus.debounce.is_none());
     }
 }


### PR DESCRIPTION
## 概要

Closes #59

EventBus にイベントデバウンス（重複排除）機能を追加。同一イベントが短期間に大量発生した場合にまとめて処理し、アラート疲れを防止する。

## 変更内容

- `EventBusConfig` に `debounce_secs`（デフォルト30秒）を追加
- `DebounceFilter` 構造体を新規実装（HashMap ベースの重複排除フィルター）
- `EventBus::with_debounce()` メソッドを追加（既存の `new()` はシグネチャ変更なし）
- Critical イベントはデバウンス対象外（常に即時配信）
- デバウンスバッファの定期クリーンアップ（`spawn_debounce_cleanup`）
- SIGHUP ホットリロードでデバウンス間隔を動的更新
- HashMap エントリ数上限（10,000）によるメモリ保護
- デバウンスキーの details 部分は128文字に制限

## テスト計画

- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全34テストパス（新規13テスト追加）
- [x] デバウンスフィルターの単体テスト
- [x] Critical イベントのバイパステスト
- [x] クリーンアップ動作テスト
- [x] 統合テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)