### PR TITLE
feat: MetricsCollector ホットリロード対応 (#64)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Module System**: 各防御機能をモジュールとして実装するプラグイン的な仕組み
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
-- **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作
+- **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 
 ## ディレクトリ構成

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.29.0"
+version = "0.31.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -39,6 +39,7 @@ impl Daemon {
 
         // イベントバスの初期化
         let mut action_config_sender: Option<watch::Sender<Vec<ActionRule>>> = None;
+        let mut metrics_config_sender: Option<watch::Sender<u64>> = None;
         let event_bus = if self.config.event_bus.enabled {
             let bus = EventBus::with_debounce(
                 self.config.event_bus.channel_capacity,
@@ -62,7 +63,8 @@ impl Daemon {
 
             // メトリクスコレクターの起動
             if self.config.metrics.enabled {
-                let collector = MetricsCollector::new(&self.config.metrics, &bus);
+                let (collector, sender) = MetricsCollector::new(&self.config.metrics, &bus);
+                metrics_config_sender = Some(sender);
                 collector.spawn();
                 tracing::info!(
                     interval_secs = self.config.metrics.interval_secs,
@@ -165,13 +167,21 @@ impl Daemon {
                                 }
                             }
 
-                            // メトリクスのインターバル変更警告
-                            if self.config.metrics.interval_secs != new_config.metrics.interval_secs {
-                                tracing::warn!(
-                                    old = self.config.metrics.interval_secs,
-                                    new = new_config.metrics.interval_secs,
-                                    "メトリクスのインターバル変更はデーモン再起動後に反映されます"
-                                );
+                            // メトリクスのインターバルリロード
+                            if self.config.metrics.interval_secs != new_config.metrics.interval_secs
+                                && let Some(ref sender) = metrics_config_sender
+                            {
+                                if sender.send(new_config.metrics.interval_secs).is_ok() {
+                                    tracing::info!(
+                                        old = self.config.metrics.interval_secs,
+                                        new = new_config.metrics.interval_secs,
+                                        "メトリクスのインターバルをリロードしました"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        "メトリクスのインターバルリロードに失敗しました（受信側が閉じています）"
+                                    );
+                                }
                             }
 
                             self.config = new_config;

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -4,31 +4,42 @@ use crate::config::MetricsConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch};
 
 /// イベント統計・メトリクス収集
 pub struct MetricsCollector {
     receiver: broadcast::Receiver<SecurityEvent>,
     interval: Duration,
+    config_receiver: watch::Receiver<u64>,
 }
 
 impl MetricsCollector {
     /// 設定とイベントバスから MetricsCollector を構築する
-    pub fn new(config: &MetricsConfig, event_bus: &EventBus) -> Self {
-        Self {
-            receiver: event_bus.subscribe(),
-            interval: Duration::from_secs(config.interval_secs),
-        }
+    pub fn new(config: &MetricsConfig, event_bus: &EventBus) -> (Self, watch::Sender<u64>) {
+        let interval_secs = config.interval_secs;
+        let (config_sender, config_receiver) = watch::channel(interval_secs);
+        (
+            Self {
+                receiver: event_bus.subscribe(),
+                interval: Duration::from_secs(interval_secs),
+                config_receiver,
+            },
+            config_sender,
+        )
     }
 
     /// 非同期タスクとしてメトリクスコレクターを起動する
     pub fn spawn(self) {
         tokio::spawn(async move {
-            Self::run_loop(self.receiver, self.interval).await;
+            Self::run_loop(self.receiver, self.interval, self.config_receiver).await;
         });
     }
 
-    async fn run_loop(mut receiver: broadcast::Receiver<SecurityEvent>, interval: Duration) {
+    async fn run_loop(
+        mut receiver: broadcast::Receiver<SecurityEvent>,
+        interval: Duration,
+        mut config_receiver: watch::Receiver<u64>,
+    ) {
         let started_at = Instant::now();
         let mut total_events: u64 = 0;
         let mut info_count: u64 = 0;
@@ -90,6 +101,25 @@ impl MetricsCollector {
                     );
                     interval_events = 0;
                 }
+                result = config_receiver.changed() => {
+                    match result {
+                        Ok(()) => {
+                            let new_interval_secs = *config_receiver.borrow_and_update();
+                            let new_interval = Duration::from_secs(new_interval_secs);
+                            tracing::info!(
+                                old_interval_secs = interval.as_secs(),
+                                new_interval_secs = new_interval_secs,
+                                "メトリクスコレクター: インターバルをリロードしました"
+                            );
+                            ticker = tokio::time::interval(new_interval);
+                            ticker.tick().await;
+                        }
+                        Err(_) => {
+                            tracing::info!("設定チャネルが閉じられました。メトリクスコレクターを終了します");
+                            break;
+                        }
+                    }
+                }
             }
         }
     }
@@ -143,7 +173,7 @@ mod tests {
             interval_secs: 120,
         };
         let bus = EventBus::new(16);
-        let collector = MetricsCollector::new(&config, &bus);
+        let (collector, _sender) = MetricsCollector::new(&config, &bus);
         assert_eq!(collector.interval, Duration::from_secs(120));
     }
 
@@ -172,7 +202,7 @@ mod tests {
             enabled: true,
             interval_secs: 1,
         };
-        let collector = MetricsCollector::new(&config, &bus);
+        let (collector, _sender) = MetricsCollector::new(&config, &bus);
         collector.spawn();
 
         // イベントを発行
@@ -202,5 +232,45 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
         // パニックせずに動作することを確認（ログ出力は tracing で検証）
+    }
+
+    #[tokio::test]
+    async fn test_metrics_collector_interval_reload() {
+        let config = MetricsConfig {
+            enabled: true,
+            interval_secs: 60,
+        };
+        let bus = EventBus::new(16);
+        let (collector, sender) = MetricsCollector::new(&config, &bus);
+
+        // 初期値の確認
+        assert_eq!(collector.interval, Duration::from_secs(60));
+
+        collector.spawn();
+
+        // インターバル変更を送信
+        sender.send(30).unwrap();
+
+        // 変更が処理される時間を与える
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // パニックせずに動作することを確認
+    }
+
+    #[tokio::test]
+    async fn test_metrics_collector_config_channel_closed() {
+        let config = MetricsConfig {
+            enabled: true,
+            interval_secs: 60,
+        };
+        let bus = EventBus::new(16);
+        let (collector, sender) = MetricsCollector::new(&config, &bus);
+        collector.spawn();
+
+        // sender をドロップしてチャネルを閉じる
+        drop(sender);
+
+        // メトリクスコレクターが正常に終了することを確認
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }


### PR DESCRIPTION
## Summary

- MetricsCollector に `tokio::sync::watch` チャネルを導入し、インターバル設定のホットリロードに対応
- SIGHUP 受信時に `metrics.interval_secs` の変更を検出し、`watch::Sender` 経由で動的に更新
- ActionEngine ホットリロード（#61）と同じパターンを適用し、一貫性を維持

Closes #64

## Test plan

- [x] `test_metrics_collector_interval_reload` — watch チャネル経由のインターバル変更テスト
- [x] `test_metrics_collector_config_channel_closed` — チャネル閉鎖時の正常終了テスト
- [x] 全 506 テスト通過（`cargo test`）
- [x] `cargo clippy -- -D warnings` 通過
- [x] `cargo fmt --check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)