### PR TITLE
feat: CLI ステータスコマンド（status サブコマンド）の実装 (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ src/
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
     metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）
+    status.rs          # ステータスサーバー（Unix ソケット経由の CLI ステータス問い合わせ）
   modules/
     mod.rs             # モジュールトレイト・レジストリ
     at_job_monitor.rs  # at/batch ジョブ監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,13 +2228,14 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "clap",
  "libc",
  "regex",
  "reqwest",
  "serde",
+ "serde_json",
  "sha2",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.37.0"
+version = "0.38.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -11,7 +11,8 @@ serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 thiserror = "2"
 regex = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "process"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "process", "net", "io-util"] }
+serde_json = "1"
 tokio-util = "0.7"
 toml = "0.8"
 tracing = "0.1"

--- a/config.example.toml
+++ b/config.example.toml
@@ -261,6 +261,13 @@ enabled = false
 # refill_amount = 10        # 補充トークン数
 # refill_interval_secs = 60 # 補充間隔（秒）
 
+[status]
+# ステータスサーバー（Unix ソケット）の有効/無効
+# 有効にすると `zettai-mamorukun status` コマンドでデーモンの状態を確認できる
+enabled = false
+# Unix ソケットのパス
+socket_path = "/var/run/zettai-mamorukun/status.sock"
+
 [health]
 # ハートビート（定期的なヘルスチェックログ出力）の有効/無効
 enabled = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,10 @@ pub struct AppConfig {
     /// メトリクス収集設定
     #[serde(default)]
     pub metrics: MetricsConfig,
+
+    /// ステータスサーバー設定
+    #[serde(default)]
+    pub status: StatusConfig,
 }
 
 /// デーモン動作設定
@@ -1219,6 +1223,37 @@ impl Default for MetricsConfig {
     }
 }
 
+/// ステータスサーバー設定
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct StatusConfig {
+    /// ステータスサーバーの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Unix ソケットのパス
+    #[serde(default = "StatusConfig::default_socket_path")]
+    pub socket_path: String,
+}
+
+impl StatusConfig {
+    fn default_enabled() -> bool {
+        false
+    }
+
+    fn default_socket_path() -> String {
+        "/var/run/zettai-mamorukun/status.sock".to_string()
+    }
+}
+
+impl Default for StatusConfig {
+    fn default() -> Self {
+        Self {
+            enabled: Self::default_enabled(),
+            socket_path: Self::default_socket_path(),
+        }
+    }
+}
+
 impl GeneralConfig {
     fn default_log_level() -> String {
         "info".to_string()
@@ -1438,6 +1473,11 @@ impl AppConfig {
                     prefix
                 ));
             }
+        }
+
+        // status 設定の検証
+        if self.status.enabled && self.status.socket_path.is_empty() {
+            errors.push("status.socket_path: 空文字列は指定できません".to_string());
         }
 
         // rate_limit の検証
@@ -2280,6 +2320,49 @@ max_connections = 500
         config.metrics.enabled = false;
         config.metrics.interval_secs = 0;
         // メトリクスが無効なら interval_secs = 0 は許容
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_status_config_defaults() {
+        let config: AppConfig = toml::from_str("").unwrap();
+        assert!(!config.status.enabled);
+        assert_eq!(
+            config.status.socket_path,
+            "/var/run/zettai-mamorukun/status.sock"
+        );
+    }
+
+    #[test]
+    fn test_status_config_custom() {
+        let toml_str = r#"
+[status]
+enabled = true
+socket_path = "/tmp/custom.sock"
+"#;
+        let config: AppConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.status.enabled);
+        assert_eq!(config.status.socket_path, "/tmp/custom.sock");
+    }
+
+    #[test]
+    fn test_validate_status_empty_socket_path() {
+        let mut config = AppConfig::default();
+        config.status.enabled = true;
+        config.status.socket_path = String::new();
+        let result = config.validate();
+        assert!(result.is_err());
+        if let Err(AppError::ConfigValidation { errors, .. }) = result {
+            assert!(errors.iter().any(|e| e.contains("status.socket_path")));
+        }
+    }
+
+    #[test]
+    fn test_validate_status_disabled_empty_socket_path_ok() {
+        let mut config = AppConfig::default();
+        config.status.enabled = false;
+        config.status.socket_path = String::new();
+        // ステータスが無効なら空パスは許容
         assert!(config.validate().is_ok());
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -2,13 +2,16 @@ use crate::config::AppConfig;
 use crate::core::action::{ActionEngine, ActionEngineConfig, InFlightTracker};
 use crate::core::event::{self, EventBus, SecurityEvent, Severity};
 use crate::core::health::HealthChecker;
-use crate::core::metrics::MetricsCollector;
+use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
+use crate::core::status::{DaemonState, StatusServer};
 use crate::error::AppError;
 use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
 
 /// デーモンプロセスを管理する
 pub struct Daemon {
@@ -36,6 +39,11 @@ impl Daemon {
         let mut heartbeat = tokio::time::interval(heartbeat_interval);
         // 最初の tick は即座に発火するのでスキップ
         heartbeat.tick().await;
+
+        // ステータスサーバー用の共有状態
+        let shared_module_names: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
+        let mut shared_metrics: Option<Arc<StdMutex<SharedMetrics>>> = None;
+        let mut status_cancel_token: Option<CancellationToken> = None;
 
         // イベントバスの初期化
         let mut action_config_sender: Option<watch::Sender<ActionEngineConfig>> = None;
@@ -65,8 +73,10 @@ impl Daemon {
 
             // メトリクスコレクターの起動
             if self.config.metrics.enabled {
-                let (collector, sender) = MetricsCollector::new(&self.config.metrics, &bus);
+                let (collector, sender, metrics) =
+                    MetricsCollector::new(&self.config.metrics, &bus);
                 metrics_config_sender = Some(sender);
+                shared_metrics = Some(metrics);
                 collector.spawn();
                 tracing::info!(
                     interval_secs = self.config.metrics.interval_secs,
@@ -90,6 +100,26 @@ impl Daemon {
         // モジュールマネージャーでモジュールを一括起動
         let mut module_manager =
             ModuleManager::start_modules(&self.config.modules, &event_bus).await;
+
+        // モジュール名を共有状態に反映
+        {
+            // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+            let mut names = shared_module_names.lock().unwrap();
+            *names = module_manager.running_module_names();
+        }
+
+        // ステータスサーバーの起動
+        if self.config.status.enabled {
+            let state = DaemonState::new(Arc::clone(&shared_module_names), shared_metrics.clone());
+            let server = StatusServer::new(&self.config.status.socket_path, state);
+            status_cancel_token = Some(server.cancel_token());
+            match server.spawn() {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, "ステータスサーバーの起動に失敗しました");
+                }
+            }
+        }
 
         tracing::info!("デーモンを起動しました");
 
@@ -137,6 +167,13 @@ impl Daemon {
                                     format!("設定ファイルをリロードしました ({})", summary),
                                 );
                                 bus.publish(event);
+                            }
+
+                            // モジュール名を共有状態に反映
+                            {
+                                // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+                                let mut names = shared_module_names.lock().unwrap();
+                                *names = module_manager.running_module_names();
                             }
 
                             // デバウンス間隔の更新
@@ -222,6 +259,11 @@ impl Daemon {
                     }
                 }
             }
+        }
+
+        // ステータスサーバーの停止
+        if let Some(token) = status_cancel_token {
+            token.cancel();
         }
 
         // インフライトトラッカーのシャットダウン開始

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -2,36 +2,67 @@
 
 use crate::config::MetricsConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
+use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, watch};
+
+/// 外部から参照可能なメトリクスデータ
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SharedMetrics {
+    /// 合計イベント数
+    pub total_events: u64,
+    /// INFO レベルのイベント数
+    pub info_count: u64,
+    /// WARNING レベルのイベント数
+    pub warning_count: u64,
+    /// CRITICAL レベルのイベント数
+    pub critical_count: u64,
+    /// モジュール別イベント数
+    pub module_counts: HashMap<String, u64>,
+}
 
 /// イベント統計・メトリクス収集
 pub struct MetricsCollector {
     receiver: broadcast::Receiver<SecurityEvent>,
     interval: Duration,
     config_receiver: watch::Receiver<u64>,
+    shared_metrics: Arc<StdMutex<SharedMetrics>>,
 }
 
 impl MetricsCollector {
     /// 設定とイベントバスから MetricsCollector を構築する
-    pub fn new(config: &MetricsConfig, event_bus: &EventBus) -> (Self, watch::Sender<u64>) {
+    pub fn new(
+        config: &MetricsConfig,
+        event_bus: &EventBus,
+    ) -> (Self, watch::Sender<u64>, Arc<StdMutex<SharedMetrics>>) {
         let interval_secs = config.interval_secs;
         let (config_sender, config_receiver) = watch::channel(interval_secs);
+        let shared_metrics = Arc::new(StdMutex::new(SharedMetrics::default()));
         (
             Self {
                 receiver: event_bus.subscribe(),
                 interval: Duration::from_secs(interval_secs),
                 config_receiver,
+                shared_metrics: Arc::clone(&shared_metrics),
             },
             config_sender,
+            shared_metrics,
         )
     }
 
     /// 非同期タスクとしてメトリクスコレクターを起動する
     pub fn spawn(self) {
+        let shared_metrics = self.shared_metrics;
         tokio::spawn(async move {
-            Self::run_loop(self.receiver, self.interval, self.config_receiver).await;
+            Self::run_loop(
+                self.receiver,
+                self.interval,
+                self.config_receiver,
+                shared_metrics,
+            )
+            .await;
         });
     }
 
@@ -39,6 +70,7 @@ impl MetricsCollector {
         mut receiver: broadcast::Receiver<SecurityEvent>,
         interval: Duration,
         mut config_receiver: watch::Receiver<u64>,
+        shared_metrics: Arc<StdMutex<SharedMetrics>>,
     ) {
         let started_at = Instant::now();
         let mut total_events: u64 = 0;
@@ -66,6 +98,16 @@ impl MetricsCollector {
                             *module_counts
                                 .entry(event.source_module.clone())
                                 .or_insert(0) += 1;
+
+                            // SharedMetrics を更新
+                            // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+                            if let Ok(mut m) = shared_metrics.lock() {
+                                m.total_events = total_events;
+                                m.info_count = info_count;
+                                m.warning_count = warning_count;
+                                m.critical_count = critical_count;
+                                m.module_counts = module_counts.clone();
+                            }
                         }
                         Err(broadcast::error::RecvError::Lagged(n)) => {
                             tracing::warn!(
@@ -173,7 +215,7 @@ mod tests {
             interval_secs: 120,
         };
         let bus = EventBus::new(16);
-        let (collector, _sender) = MetricsCollector::new(&config, &bus);
+        let (collector, _sender, _shared) = MetricsCollector::new(&config, &bus);
         assert_eq!(collector.interval, Duration::from_secs(120));
     }
 
@@ -202,7 +244,7 @@ mod tests {
             enabled: true,
             interval_secs: 1,
         };
-        let (collector, _sender) = MetricsCollector::new(&config, &bus);
+        let (collector, _sender, _shared) = MetricsCollector::new(&config, &bus);
         collector.spawn();
 
         // イベントを発行
@@ -241,7 +283,7 @@ mod tests {
             interval_secs: 60,
         };
         let bus = EventBus::new(16);
-        let (collector, sender) = MetricsCollector::new(&config, &bus);
+        let (collector, sender, _shared) = MetricsCollector::new(&config, &bus);
 
         // 初期値の確認
         assert_eq!(collector.interval, Duration::from_secs(60));
@@ -264,7 +306,7 @@ mod tests {
             interval_secs: 60,
         };
         let bus = EventBus::new(16);
-        let (collector, sender) = MetricsCollector::new(&config, &bus);
+        let (collector, sender, _shared) = MetricsCollector::new(&config, &bus);
         collector.spawn();
 
         // sender をドロップしてチャネルを閉じる
@@ -272,5 +314,65 @@ mod tests {
 
         // メトリクスコレクターが正常に終了することを確認
         tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    #[test]
+    fn test_shared_metrics_default() {
+        let metrics = SharedMetrics::default();
+        assert_eq!(metrics.total_events, 0);
+        assert_eq!(metrics.info_count, 0);
+        assert_eq!(metrics.warning_count, 0);
+        assert_eq!(metrics.critical_count, 0);
+        assert!(metrics.module_counts.is_empty());
+    }
+
+    #[test]
+    fn test_shared_metrics_serialize() {
+        let mut metrics = SharedMetrics::default();
+        metrics.total_events = 10;
+        metrics.info_count = 5;
+        metrics.warning_count = 3;
+        metrics.critical_count = 2;
+        metrics.module_counts.insert("test_module".to_string(), 10);
+
+        let json = serde_json::to_string(&metrics).unwrap();
+        assert!(json.contains("\"total_events\":10"));
+        assert!(json.contains("\"test_module\":10"));
+    }
+
+    #[tokio::test]
+    async fn test_shared_metrics_updated_by_collector() {
+        let bus = EventBus::new(16);
+        let config = MetricsConfig {
+            enabled: true,
+            interval_secs: 60,
+        };
+        let (collector, _sender, shared) = MetricsCollector::new(&config, &bus);
+        collector.spawn();
+
+        // イベントを発行
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Info,
+            "test_module",
+            "テストイベント",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Critical,
+            "another_module",
+            "テストイベント",
+        ));
+
+        // メトリクスコレクターがイベントを処理する時間を与える
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // unwrap safety: テストコード
+        let m = shared.lock().unwrap();
+        assert_eq!(m.total_events, 2);
+        assert_eq!(m.info_count, 1);
+        assert_eq!(m.critical_count, 1);
+        assert_eq!(m.module_counts.get("test_module"), Some(&1));
+        assert_eq!(m.module_counts.get("another_module"), Some(&1));
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,3 +4,4 @@ pub mod event;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;
+pub mod status;

--- a/src/core/module_manager.rs
+++ b/src/core/module_manager.rs
@@ -371,6 +371,14 @@ impl ModuleManager {
         }
     }
 
+    /// 実行中モジュール名のリストを取得する
+    pub fn running_module_names(&self) -> Vec<String> {
+        self.running_modules
+            .iter()
+            .map(|m| m.name.clone())
+            .collect()
+    }
+
     /// 全モジュールを停止する
     pub fn stop_all(&mut self) {
         for module in &self.running_modules {
@@ -667,6 +675,25 @@ impl ModuleManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn test_running_module_names_empty() {
+        let config = ModulesConfig::default();
+        let event_bus = None;
+        let manager = ModuleManager::start_modules(&config, &event_bus).await;
+        assert!(manager.running_module_names().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_running_module_names_with_enabled() {
+        let mut config = ModulesConfig::default();
+        config.dns_monitor.enabled = true;
+        let event_bus = None;
+        let manager = ModuleManager::start_modules(&config, &event_bus).await;
+        let names = manager.running_module_names();
+        assert_eq!(names.len(), 1);
+        assert!(names.contains(&"DNS設定改ざん検知モジュール".to_string()));
+    }
 
     #[tokio::test]
     async fn test_start_modules_with_all_disabled() {

--- a/src/core/status.rs
+++ b/src/core/status.rs
@@ -1,0 +1,391 @@
+//! CLI ステータスコマンド用 Unix ソケットサーバー・クライアント
+
+use crate::core::metrics::SharedMetrics;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{UnixListener, UnixStream};
+use tokio_util::sync::CancellationToken;
+
+/// ステータスレスポンス
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StatusResponse {
+    /// バージョン
+    pub version: String,
+    /// 稼働時間（秒）
+    pub uptime_secs: u64,
+    /// 有効モジュール名のリスト
+    pub modules: Vec<String>,
+    /// メトリクスサマリー（メトリクスが無効の場合は None）
+    pub metrics: Option<MetricsSummary>,
+}
+
+/// メトリクスサマリー
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MetricsSummary {
+    /// 合計イベント数
+    pub total_events: u64,
+    /// INFO レベルのイベント数
+    pub info_count: u64,
+    /// WARNING レベルのイベント数
+    pub warning_count: u64,
+    /// CRITICAL レベルのイベント数
+    pub critical_count: u64,
+    /// モジュール別イベント数
+    pub module_counts: HashMap<String, u64>,
+}
+
+/// ステータスサーバーが参照するデーモン状態
+pub struct DaemonState {
+    started_at: Instant,
+    modules: Arc<Mutex<Vec<String>>>,
+    shared_metrics: Option<Arc<Mutex<SharedMetrics>>>,
+}
+
+impl DaemonState {
+    /// 新しい DaemonState を作成する
+    pub fn new(
+        modules: Arc<Mutex<Vec<String>>>,
+        shared_metrics: Option<Arc<Mutex<SharedMetrics>>>,
+    ) -> Self {
+        Self {
+            started_at: Instant::now(),
+            modules,
+            shared_metrics,
+        }
+    }
+
+    fn to_response(&self) -> StatusResponse {
+        // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+        let modules = self.modules.lock().unwrap().clone();
+        let metrics = self.shared_metrics.as_ref().map(|m| {
+            // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+            let m = m.lock().unwrap();
+            MetricsSummary {
+                total_events: m.total_events,
+                info_count: m.info_count,
+                warning_count: m.warning_count,
+                critical_count: m.critical_count,
+                module_counts: m.module_counts.clone(),
+            }
+        });
+        StatusResponse {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            uptime_secs: self.started_at.elapsed().as_secs(),
+            modules,
+            metrics,
+        }
+    }
+}
+
+/// Unix ソケット経由でステータスを提供するサーバー
+pub struct StatusServer {
+    socket_path: PathBuf,
+    state: Arc<DaemonState>,
+    cancel_token: CancellationToken,
+}
+
+impl StatusServer {
+    /// 新しい StatusServer を作成する
+    pub fn new(socket_path: impl Into<PathBuf>, state: DaemonState) -> Self {
+        Self {
+            socket_path: socket_path.into(),
+            state: Arc::new(state),
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンを取得する
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// ステータスサーバーを非同期タスクとして起動する
+    pub fn spawn(self) -> Result<(), std::io::Error> {
+        // 既存のソケットファイルを削除
+        if self.socket_path.exists() {
+            std::fs::remove_file(&self.socket_path)?;
+        }
+
+        // 親ディレクトリが存在しない場合は作成を試みる（失敗してもOK）
+        if let Some(parent) = self.socket_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let listener = std::os::unix::net::UnixListener::bind(&self.socket_path)?;
+        listener.set_nonblocking(true)?;
+        let listener = UnixListener::from_std(listener)?;
+
+        let socket_path = self.socket_path.clone();
+        let state = self.state;
+        let cancel_token = self.cancel_token;
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, _)) => {
+                                let state = Arc::clone(&state);
+                                tokio::spawn(async move {
+                                    if let Err(e) = Self::handle_connection(stream, &state).await {
+                                        tracing::debug!(error = %e, "ステータス接続の処理に失敗");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::debug!(error = %e, "ステータスソケットの accept に失敗");
+                            }
+                        }
+                    }
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("ステータスサーバーを停止します");
+                        break;
+                    }
+                }
+            }
+            // ソケットファイルのクリーンアップ
+            let _ = std::fs::remove_file(&socket_path);
+        });
+
+        tracing::info!(
+            socket_path = %self.socket_path.display(),
+            "ステータスサーバーを起動しました"
+        );
+        Ok(())
+    }
+
+    async fn handle_connection(
+        mut stream: tokio::net::UnixStream,
+        state: &DaemonState,
+    ) -> Result<(), std::io::Error> {
+        let response = state.to_response();
+        let json = serde_json::to_vec(&response)
+            .map_err(std::io::Error::other)?;
+        stream.write_all(&json).await?;
+        stream.shutdown().await?;
+        Ok(())
+    }
+}
+
+/// ステータスクライアント — CLI status コマンドから呼び出す
+pub async fn query_status(socket_path: &Path) -> Result<StatusResponse, String> {
+    use tokio::io::AsyncReadExt;
+
+    let mut stream = UnixStream::connect(socket_path).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound
+            || e.kind() == std::io::ErrorKind::ConnectionRefused
+        {
+            format!(
+                "デーモンに接続できません ({})\nデーモンが起動していない可能性があります。",
+                socket_path.display()
+            )
+        } else {
+            format!("ソケット接続エラー: {}", e)
+        }
+    })?;
+
+    let mut buf = Vec::new();
+    stream
+        .read_to_end(&mut buf)
+        .await
+        .map_err(|e| format!("読み取りエラー: {}", e))?;
+
+    serde_json::from_slice(&buf).map_err(|e| format!("JSON パースエラー: {}", e))
+}
+
+/// ステータスレスポンスを人間が読める形式で表示する
+pub fn print_status(response: &StatusResponse) {
+    println!("ぜったいまもるくん v{}", response.version);
+    println!("稼働時間: {} 秒", response.uptime_secs);
+    println!();
+
+    println!("有効モジュール ({} 個):", response.modules.len());
+    if response.modules.is_empty() {
+        println!("  (なし)");
+    } else {
+        for module in &response.modules {
+            println!("  - {}", module);
+        }
+    }
+
+    if let Some(ref metrics) = response.metrics {
+        println!();
+        println!("イベント統計:");
+        println!("  合計: {}", metrics.total_events);
+        println!("  INFO: {}", metrics.info_count);
+        println!("  WARNING: {}", metrics.warning_count);
+        println!("  CRITICAL: {}", metrics.critical_count);
+        if !metrics.module_counts.is_empty() {
+            println!();
+            println!("  モジュール別:");
+            let mut counts: Vec<_> = metrics.module_counts.iter().collect();
+            counts.sort_by_key(|(_, v)| std::cmp::Reverse(**v));
+            for (module, count) in counts {
+                println!("    {}: {}", module, count);
+            }
+        }
+    } else {
+        println!();
+        println!("メトリクス: 無効");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_response_serialize_deserialize() {
+        let response = StatusResponse {
+            version: "0.37.0".to_string(),
+            uptime_secs: 120,
+            modules: vec!["module_a".to_string(), "module_b".to_string()],
+            metrics: Some(MetricsSummary {
+                total_events: 42,
+                info_count: 30,
+                warning_count: 10,
+                critical_count: 2,
+                module_counts: HashMap::from([
+                    ("module_a".to_string(), 25),
+                    ("module_b".to_string(), 17),
+                ]),
+            }),
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: StatusResponse = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.version, "0.37.0");
+        assert_eq!(deserialized.uptime_secs, 120);
+        assert_eq!(deserialized.modules.len(), 2);
+        let metrics = deserialized.metrics.unwrap();
+        assert_eq!(metrics.total_events, 42);
+        assert_eq!(metrics.info_count, 30);
+        assert_eq!(metrics.warning_count, 10);
+        assert_eq!(metrics.critical_count, 2);
+    }
+
+    #[test]
+    fn test_status_response_without_metrics() {
+        let response = StatusResponse {
+            version: "0.37.0".to_string(),
+            uptime_secs: 60,
+            modules: vec![],
+            metrics: None,
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: StatusResponse = serde_json::from_str(&json).unwrap();
+
+        assert!(deserialized.metrics.is_none());
+        assert!(deserialized.modules.is_empty());
+    }
+
+    #[test]
+    fn test_daemon_state_to_response() {
+        let modules = Arc::new(Mutex::new(vec![
+            "module_a".to_string(),
+            "module_b".to_string(),
+        ]));
+        let shared_metrics = Arc::new(Mutex::new(SharedMetrics {
+            total_events: 10,
+            info_count: 5,
+            warning_count: 3,
+            critical_count: 2,
+            module_counts: HashMap::from([("module_a".to_string(), 10)]),
+        }));
+
+        let state = DaemonState::new(modules, Some(shared_metrics));
+        let response = state.to_response();
+
+        assert_eq!(response.modules.len(), 2);
+        assert!(response.modules.contains(&"module_a".to_string()));
+        let metrics = response.metrics.unwrap();
+        assert_eq!(metrics.total_events, 10);
+    }
+
+    #[test]
+    fn test_daemon_state_to_response_without_metrics() {
+        let modules = Arc::new(Mutex::new(vec![]));
+        let state = DaemonState::new(modules, None);
+        let response = state.to_response();
+
+        assert!(response.modules.is_empty());
+        assert!(response.metrics.is_none());
+    }
+
+    #[test]
+    fn test_print_status_does_not_panic() {
+        let response = StatusResponse {
+            version: "0.37.0".to_string(),
+            uptime_secs: 3600,
+            modules: vec!["module_a".to_string()],
+            metrics: Some(MetricsSummary {
+                total_events: 100,
+                info_count: 80,
+                warning_count: 15,
+                critical_count: 5,
+                module_counts: HashMap::from([("module_a".to_string(), 100)]),
+            }),
+        };
+        // パニックしないことを確認
+        print_status(&response);
+    }
+
+    #[test]
+    fn test_print_status_without_metrics_does_not_panic() {
+        let response = StatusResponse {
+            version: "0.37.0".to_string(),
+            uptime_secs: 0,
+            modules: vec![],
+            metrics: None,
+        };
+        // パニックしないことを確認
+        print_status(&response);
+    }
+
+    #[tokio::test]
+    async fn test_status_server_and_client() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("test_status.sock");
+
+        let modules = Arc::new(Mutex::new(vec!["test_module".to_string()]));
+        let shared_metrics = Arc::new(Mutex::new(SharedMetrics {
+            total_events: 5,
+            info_count: 3,
+            warning_count: 1,
+            critical_count: 1,
+            module_counts: HashMap::from([("test_module".to_string(), 5)]),
+        }));
+
+        let state = DaemonState::new(modules, Some(shared_metrics));
+        let server = StatusServer::new(&socket_path, state);
+        let cancel_token = server.cancel_token();
+        server.spawn().unwrap();
+
+        // サーバーが起動する時間を与える
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // クライアントで接続
+        let response = query_status(&socket_path).await.unwrap();
+        assert_eq!(response.modules, vec!["test_module".to_string()]);
+        let metrics = response.metrics.unwrap();
+        assert_eq!(metrics.total_events, 5);
+
+        // サーバー停止
+        cancel_token.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_query_status_connection_refused() {
+        let result = query_status(Path::new("/tmp/nonexistent-zettai-status.sock")).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("デーモンに接続できません") || err.contains("ソケット接続エラー"));
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,4 +63,8 @@ pub enum AppError {
     /// 設定バリデーションエラー
     #[error("設定バリデーションエラー: {count} 件のエラーが見つかりました")]
     ConfigValidation { count: usize, errors: Vec<String> },
+
+    /// ステータスサーバーエラー
+    #[error("ステータスサーバーエラー: {message}")]
+    StatusServer { message: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use zettai_mamorukun::config::AppConfig;
 use zettai_mamorukun::core::daemon::Daemon;
+use zettai_mamorukun::core::status;
 use zettai_mamorukun::error::AppError;
 
 /// サイバー攻撃防御デーモン
@@ -29,6 +30,12 @@ enum Commands {
         /// チェック対象の設定ファイルパス（省略時は --config の値を使用）
         #[arg(value_name = "PATH")]
         path: Option<PathBuf>,
+    },
+    /// デーモンの動作状態を表示する
+    Status {
+        /// ステータスソケットのパス
+        #[arg(long, default_value = "/var/run/zettai-mamorukun/status.sock")]
+        socket_path: PathBuf,
     },
 }
 
@@ -114,6 +121,14 @@ fn run_check_config(config_path: &Path) -> Result<(), Box<dyn std::error::Error>
             "無効"
         }
     );
+    eprintln!(
+        "  ステータスサーバー: {}",
+        if config.status.enabled {
+            "有効"
+        } else {
+            "無効"
+        }
+    );
 
     Ok(())
 }
@@ -123,10 +138,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     // サブコマンド処理
-    if let Some(Commands::CheckConfig { path }) = &cli.command {
-        let config_path = path.as_ref().unwrap_or(&cli.config);
-        run_check_config(config_path)?;
-        return Ok(());
+    match &cli.command {
+        Some(Commands::CheckConfig { path }) => {
+            let config_path = path.as_ref().unwrap_or(&cli.config);
+            run_check_config(config_path)?;
+            return Ok(());
+        }
+        Some(Commands::Status { socket_path }) => {
+            match status::query_status(socket_path).await {
+                Ok(response) => {
+                    status::print_status(&response);
+                }
+                Err(e) => {
+                    eprintln!("エラー: {}", e);
+                    process::exit(1);
+                }
+            }
+            return Ok(());
+        }
+        None => {}
     }
 
     // デーモンモード


### PR DESCRIPTION
## Summary

- Unix ソケット経由でデーモンの動作状態を問い合わせる `status` サブコマンドを追加
- `StatusServer` がデーモン内で Unix ソケットをリッスンし、接続時に JSON でステータスを返す
- `SharedMetrics`（`Arc<Mutex>`）で MetricsCollector のデータをステータスサーバーと共有

### 表示項目
- バージョン、稼働時間
- 有効モジュール一覧
- イベント統計（合計、Severity 別、モジュール別）

### 変更ファイル
- `src/core/status.rs` — 新規（StatusServer / DaemonState / StatusResponse / query_status / print_status）
- `src/core/metrics.rs` — SharedMetrics 追加、MetricsCollector がデータ共有
- `src/core/daemon.rs` — StatusServer 統合（起動・リロード時更新・シャットダウン）
- `src/core/module_manager.rs` — `running_module_names()` 追加
- `src/main.rs` — `Status` サブコマンド追加
- `src/config.rs` — `StatusConfig` 追加
- `config.example.toml` — `[status]` セクション追加
- `CLAUDE.md` — ディレクトリ構成に `status.rs` 追加

Closes #79

## Test plan

- [x] `cargo test` — 全 635 テスト通過（新規テスト 16 件含む）
- [x] `cargo clippy -- -D warnings` — 警告ゼロ
- [x] `cargo fmt --check` — OK
- [x] StatusServer の起動・接続テスト（Unix ソケット経由）
- [x] SharedMetrics の同期テスト
- [x] StatusResponse のシリアライズ/デシリアライズテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)