### PR TITLE
feat: 残り17モジュールへの起動時スキャン（initial_scan）実装 (#85)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.40.0"
+version = "0.41.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/src/modules/at_job_monitor.rs
+++ b/src/modules/at_job_monitor.rs
@@ -11,7 +11,7 @@
 use crate::config::AtJobMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -293,6 +293,23 @@ impl Module for AtJobMonitorModule {
         });
 
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let files = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!(
+                "at/batch ジョブファイル {}件をスキャンしました",
+                items_scanned
+            ),
+        })
     }
 
     async fn stop(&mut self) -> Result<(), AppError> {
@@ -683,5 +700,41 @@ mod tests {
         let current = HashMap::new();
         let report = AtJobMonitorModule::detect_changes(&baseline, &current);
         assert!(!report.has_changes());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file1 = dir.path().join("job1");
+        let file2 = dir.path().join("job2");
+        std::fs::write(&file1, "echo hello").unwrap();
+        std::fs::write(&file2, "echo world").unwrap();
+
+        let config = AtJobMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![dir.path().to_path_buf()],
+        };
+        let mut module = AtJobMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = AtJobMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![],
+        };
+        let module = AtJobMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/firewall_monitor.rs
+++ b/src/modules/firewall_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::FirewallMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -234,6 +234,23 @@ impl Module for FirewallMonitorModule {
         });
 
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let files = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!(
+                "ファイアウォール関連ファイル {}件をスキャンしました",
+                items_scanned
+            ),
+        })
     }
 
     async fn stop(&mut self) -> Result<(), AppError> {
@@ -468,5 +485,40 @@ mod tests {
             removed: vec![],
         };
         assert!(!report.has_changes());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let mut tmpfile1 = tempfile::NamedTempFile::new().unwrap();
+        let mut tmpfile2 = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile1, "content1").unwrap();
+        write!(tmpfile2, "content2").unwrap();
+
+        let config = FirewallMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![tmpfile1.path().to_path_buf(), tmpfile2.path().to_path_buf()],
+        };
+        let mut module = FirewallMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = FirewallMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![],
+        };
+        let module = FirewallMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/kernel_module.rs
+++ b/src/modules/kernel_module.rs
@@ -9,7 +9,7 @@
 use crate::config::KernelModuleConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashSet;
 use tokio_util::sync::CancellationToken;
 
@@ -239,6 +239,21 @@ impl Module for KernelModuleMonitor {
         Ok(())
     }
 
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let content = Self::read_proc_modules()?;
+        let entries = Self::parse_proc_modules(&content);
+        let items_scanned = entries.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("カーネルモジュール {}件を検出しました", items_scanned),
+        })
+    }
+
     async fn stop(&mut self) -> Result<(), AppError> {
         self.cancel_token.cancel();
         Ok(())
@@ -440,5 +455,20 @@ ip_tables 32768 0 - Live 0xffffffffc0800000";
         };
         let entry2 = entry1.clone();
         assert_eq!(entry1, entry2);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_modules() {
+        let config = KernelModuleConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+        };
+        let module = KernelModuleMonitor::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        // Linux 環境では必ず何かしらのモジュールがロードされている
+        assert!(result.items_scanned > 0);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("件を検出しました"));
     }
 }

--- a/src/modules/ld_preload_monitor.rs
+++ b/src/modules/ld_preload_monitor.rs
@@ -11,7 +11,7 @@
 use crate::config::LdPreloadMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -357,6 +357,59 @@ impl Module for LdPreloadMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+        let mut issues_found = 0;
+
+        // /etc/ld.so.preload の存在チェック
+        for path in &self.config.watch_paths {
+            if path.ends_with("ld.so.preload") && path.is_file() {
+                issues_found += 1;
+            }
+        }
+
+        // /etc/environment 内の危険な環境変数チェック
+        for path in &self.config.watch_paths {
+            let filename = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if filename != "environment" || !path.is_file() {
+                continue;
+            }
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            for line in content.lines() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
+                }
+                for var in DANGEROUS_ENV_VARS {
+                    if trimmed.starts_with(var) && trimmed[var.len()..].starts_with('=') {
+                        issues_found += 1;
+                    }
+                }
+            }
+        }
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "動的リンカ設定ファイル {}件をスキャンしました（問題: {}件）",
+                items_scanned, issues_found
+            ),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -618,5 +671,78 @@ mod tests {
         // LD_PRELOAD_EXTRA は LD_PRELOAD= で始まらないため検知しない
         std::fs::write(&env_path, "LD_PRELOAD_EXTRA=foo\n").unwrap();
         LdPreloadMonitorModule::check_dangerous_env_vars(&[env_path], &None);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_no_issues() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let conf_path = tmpdir.path().join("ld.so.conf");
+        std::fs::write(&conf_path, "/usr/lib\n").unwrap();
+
+        let config = LdPreloadMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![conf_path],
+        };
+        let module = LdPreloadMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("1件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_detects_ld_so_preload() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let preload_path = tmpdir.path().join("ld.so.preload");
+        std::fs::write(&preload_path, "/tmp/evil.so\n").unwrap();
+
+        let config = LdPreloadMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![preload_path],
+        };
+        let module = LdPreloadMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 1);
+        assert!(result.summary.contains("問題: 1件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_detects_dangerous_env() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let env_path = tmpdir.path().join("environment");
+        std::fs::write(
+            &env_path,
+            "PATH=/usr/bin\nLD_PRELOAD=/tmp/evil.so\nLD_LIBRARY_PATH=/tmp\n",
+        )
+        .unwrap();
+
+        let config = LdPreloadMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![env_path],
+        };
+        let module = LdPreloadMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.issues_found, 2);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_paths() {
+        let config = LdPreloadMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![],
+        };
+        let module = LdPreloadMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/log_tamper.rs
+++ b/src/modules/log_tamper.rs
@@ -22,7 +22,7 @@
 use crate::config::LogTamperConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashMap;
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
@@ -348,6 +348,20 @@ impl Module for LogTamperModule {
         Ok(())
     }
 
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let files = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("ログファイル {}件をスキャンしました", items_scanned),
+        })
+    }
+
     async fn stop(&mut self) -> Result<(), AppError> {
         self.cancel_token.cancel();
         Ok(())
@@ -649,5 +663,41 @@ mod tests {
         // Check that permissions include the mode bits we set
         assert_eq!(state.permissions & 0o777, 0o640);
         assert!(state.inode > 0);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file1 = dir.path().join("test1.log");
+        let file2 = dir.path().join("test2.log");
+        std::fs::write(&file1, "log content 1").unwrap();
+        std::fs::write(&file2, "log content 2").unwrap();
+
+        let config = LogTamperConfig {
+            enabled: true,
+            scan_interval_secs: 30,
+            watch_paths: vec![file1, file2],
+        };
+        let mut module = LogTamperModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = LogTamperConfig {
+            enabled: true,
+            scan_interval_secs: 30,
+            watch_paths: vec![],
+        };
+        let module = LogTamperModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/mount_monitor.rs
+++ b/src/modules/mount_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::MountMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -279,6 +279,20 @@ impl Module for MountMonitorModule {
         });
 
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let entries = Self::read_mounts(&self.config.mounts_path)?;
+        let items_scanned = entries.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("マウントポイント {}件を検出しました", items_scanned),
+        })
     }
 
     async fn stop(&mut self) -> Result<(), AppError> {
@@ -602,6 +616,46 @@ mod tests {
 
         module.stop().await.unwrap();
         assert!(cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_mounts() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmpfile.path(),
+            "sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0\nproc /proc proc rw,nosuid,nodev,noexec,relatime 0 0\n",
+        )
+        .unwrap();
+
+        let config = MountMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 30,
+            mounts_path: tmpfile.path().to_path_buf(),
+        };
+        let mut module = MountMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmpfile.path(), "").unwrap();
+
+        let config = MountMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 30,
+            mounts_path: tmpfile.path().to_path_buf(),
+        };
+        let module = MountMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 
     #[test]

--- a/src/modules/network_monitor.rs
+++ b/src/modules/network_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::NetworkMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashSet;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio_util::sync::CancellationToken;
@@ -488,6 +488,29 @@ impl Module for NetworkMonitorModule {
     async fn stop(&mut self) -> Result<(), AppError> {
         self.cancel_token.cancel();
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let entries = Self::read_connections(self.config.enable_ipv6);
+        let items_scanned = entries.len();
+
+        let suspicious_ports: HashSet<u16> = self.config.suspicious_ports.iter().copied().collect();
+        let suspicious = detect_suspicious_port_connections(&entries, &suspicious_ports);
+        let issues_found = suspicious.len();
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "ネットワーク接続 {}件をスキャンしました（不審な接続: {}件）",
+                items_scanned, issues_found
+            ),
+        })
     }
 }
 
@@ -1218,5 +1241,21 @@ mod tests {
             entries[0].remote_addr,
             IpAddr::V6(Ipv6Addr::new(0x2001, 0x0db8, 0, 0, 0, 0, 0, 2))
         );
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_returns_connections() {
+        let config = NetworkMonitorConfig {
+            enabled: true,
+            interval_secs: 60,
+            suspicious_ports: vec![4444, 5555],
+            max_connections: 1000,
+            enable_ipv6: false,
+        };
+        let module = NetworkMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert!(result.summary.contains("ネットワーク接続"));
+        assert!(result.summary.contains("不審な接続"));
     }
 }

--- a/src/modules/pam_monitor.rs
+++ b/src/modules/pam_monitor.rs
@@ -11,7 +11,7 @@
 use crate::config::PamMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -522,6 +522,78 @@ impl Module for PamMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+        let mut issues_found = 0;
+
+        for path in &self.config.watch_paths {
+            let files_to_check = if path.is_file() {
+                vec![path.clone()]
+            } else if path.is_dir() {
+                WalkDir::new(path)
+                    .min_depth(1)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_file())
+                    .map(|e| e.path().to_path_buf())
+                    .collect()
+            } else {
+                continue;
+            };
+
+            for file_path in &files_to_check {
+                let content = match std::fs::read_to_string(file_path) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+
+                for line in content.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with('#') {
+                        continue;
+                    }
+
+                    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                    if parts.len() < 3 {
+                        continue;
+                    }
+
+                    let module_path = parts[2];
+
+                    if module_path.contains("pam_permit.so") {
+                        issues_found += 1;
+                    }
+                    if module_path.contains("pam_exec.so") {
+                        issues_found += 1;
+                    }
+                    if module_path.contains('/') {
+                        let is_standard = STANDARD_PAM_MODULE_PATHS
+                            .iter()
+                            .any(|std_path| module_path.starts_with(std_path));
+                        if !is_standard {
+                            issues_found += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "PAM 設定ファイル {}件をスキャンしました（危険パターン: {}件）",
+                items_scanned, issues_found
+            ),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -987,5 +1059,61 @@ mod tests {
             &None,
         );
         assert!(reported.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_no_issues() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let pam_file = tmpdir.path().join("common-auth");
+        std::fs::write(&pam_file, "# PAM config\nauth required pam_unix.so\n").unwrap();
+
+        let config = PamMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![tmpdir.path().to_path_buf()],
+        };
+        let module = PamMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("PAM 設定ファイル"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_detects_dangerous_patterns() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let pam_file = tmpdir.path().join("backdoor");
+        std::fs::write(
+            &pam_file,
+            "auth sufficient pam_permit.so\nsession required pam_exec.so /tmp/evil.sh\n",
+        )
+        .unwrap();
+
+        let config = PamMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![tmpdir.path().to_path_buf()],
+        };
+        let module = PamMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert!(result.issues_found >= 2);
+        assert!(result.summary.contains("危険パターン"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_paths() {
+        let config = PamMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![],
+        };
+        let module = PamMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/pkg_repo_monitor.rs
+++ b/src/modules/pkg_repo_monitor.rs
@@ -12,7 +12,7 @@
 use crate::config::PkgRepoMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -258,6 +258,23 @@ impl Module for PkgRepoMonitorModule {
         });
 
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let files = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!(
+                "パッケージリポジトリ設定ファイル {}件をスキャンしました",
+                items_scanned
+            ),
+        })
     }
 
     async fn stop(&mut self) -> Result<(), AppError> {
@@ -532,5 +549,41 @@ mod tests {
             removed: vec![],
         };
         assert!(report.has_changes());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file1 = dir.path().join("repo1.list");
+        let file2 = dir.path().join("repo2.list");
+        std::fs::write(&file1, "deb http://example.com/repo1 stable main").unwrap();
+        std::fs::write(&file2, "deb http://example.com/repo2 stable main").unwrap();
+
+        let config = PkgRepoMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![dir.path().to_path_buf()],
+        };
+        let mut module = PkgRepoMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = PkgRepoMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![],
+        };
+        let module = PkgRepoMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/process_monitor.rs
+++ b/src/modules/process_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::ProcessMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
@@ -273,6 +273,28 @@ impl Module for ProcessMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let processes = Self::scan_processes();
+        let items_scanned = processes.len();
+
+        let anomalies = Self::check_anomalies(&processes, &self.config.suspicious_paths);
+        let issues_found = anomalies.len();
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "プロセス {}件をスキャンしました（不審なプロセス: {}件）",
+                items_scanned, issues_found
+            ),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -484,5 +506,20 @@ mod tests {
         let bus = EventBus::new(16);
         let mut module = ProcessMonitorModule::new(config, Some(bus));
         assert!(module.init().is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_returns_processes() {
+        let config = ProcessMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            suspicious_paths: vec![PathBuf::from("/tmp"), PathBuf::from("/dev/shm")],
+        };
+        let module = ProcessMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert!(result.items_scanned > 0);
+        assert!(result.summary.contains("プロセス"));
+        assert!(result.summary.contains("不審なプロセス"));
     }
 }

--- a/src/modules/security_files_monitor.rs
+++ b/src/modules/security_files_monitor.rs
@@ -11,7 +11,7 @@
 use crate::config::SecurityFilesMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -449,6 +449,72 @@ impl Module for SecurityFilesMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+        let mut issues_found = 0;
+
+        for path in &self.config.watch_paths {
+            let files_to_check = collect_files_to_check(path);
+
+            for file_path in &files_to_check {
+                let file_name = file_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                let parent_name = file_path
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+
+                let is_limits_file = file_name == "limits.conf" || parent_name == "limits.d";
+
+                if !is_limits_file {
+                    continue;
+                }
+
+                let content = match std::fs::read_to_string(file_path) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+
+                for line in content.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with('#') {
+                        continue;
+                    }
+
+                    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+                    if parts.len() < 4 {
+                        continue;
+                    }
+
+                    let domain = parts[0];
+                    let value = parts[3];
+
+                    if domain == "*" && value == "unlimited" {
+                        issues_found += 1;
+                    }
+                }
+            }
+        }
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "セキュリティ設定ファイル {}件をスキャンしました（危険パターン: {}件）",
+                items_scanned, issues_found
+            ),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -858,5 +924,61 @@ mod tests {
     fn test_collect_files_to_check_nonexistent() {
         let result = collect_files_to_check(&PathBuf::from("/tmp/nonexistent_zettai_test"));
         assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_no_issues() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let conf_path = tmpdir.path().join("access.conf");
+        std::fs::write(&conf_path, "# access configuration\n+ : root : ALL\n").unwrap();
+
+        let config = SecurityFilesMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![tmpdir.path().to_path_buf()],
+        };
+        let module = SecurityFilesMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("セキュリティ設定ファイル"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_detects_unlimited() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let limits_path = tmpdir.path().join("limits.conf");
+        std::fs::write(
+            &limits_path,
+            "* soft nofile unlimited\n* hard nproc unlimited\n",
+        )
+        .unwrap();
+
+        let config = SecurityFilesMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![tmpdir.path().to_path_buf()],
+        };
+        let module = SecurityFilesMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 2);
+        assert!(result.summary.contains("危険パターン: 2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_paths() {
+        let config = SecurityFilesMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![],
+        };
+        let module = SecurityFilesMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/shell_config_monitor.rs
+++ b/src/modules/shell_config_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::ShellConfigMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -306,6 +306,20 @@ impl Module for ShellConfigMonitorModule {
         Ok(())
     }
 
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("シェル設定ファイル {}件をスキャンしました", items_scanned),
+        })
+    }
+
     async fn stop(&mut self) -> Result<(), AppError> {
         self.cancel_token.cancel();
         Ok(())
@@ -551,5 +565,40 @@ mod tests {
 
         module.stop().await.unwrap();
         assert!(cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let mut tmpfile1 = tempfile::NamedTempFile::new().unwrap();
+        let mut tmpfile2 = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile1, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        write!(tmpfile2, "export EDITOR=vim\n").unwrap();
+
+        let config = ShellConfigMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![tmpfile1.path().to_path_buf(), tmpfile2.path().to_path_buf()],
+        };
+        let mut module = ShellConfigMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = ShellConfigMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![],
+        };
+        let module = ShellConfigMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/ssh_brute_force.rs
+++ b/src/modules/ssh_brute_force.rs
@@ -7,7 +7,7 @@
 use crate::config::SshBruteForceConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use regex::Regex;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
@@ -233,6 +233,42 @@ impl Module for SshBruteForceModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let path = &self.config.auth_log_path;
+
+        let (items_scanned, summary) = if path.is_file() {
+            match std::fs::metadata(path) {
+                Ok(metadata) => (
+                    1,
+                    format!(
+                        "認証ログファイルを確認しました（{}、サイズ: {} bytes）",
+                        path.display(),
+                        metadata.len()
+                    ),
+                ),
+                Err(_) => (
+                    0,
+                    format!("認証ログファイルが存在しません（{}）", path.display()),
+                ),
+            }
+        } else {
+            (
+                0,
+                format!("認証ログファイルが存在しません（{}）", path.display()),
+            )
+        };
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -377,5 +413,44 @@ mod tests {
     fn test_module_name() {
         let module = SshBruteForceModule::new(test_config(), None);
         assert_eq!(module.name(), "ssh_brute_force");
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_existing_file() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let log_path = tmpdir.path().join("auth.log");
+        std::fs::write(&log_path, "Mar 31 10:00:00 server sshd[1234]: log entry\n").unwrap();
+
+        let config = SshBruteForceConfig {
+            enabled: true,
+            interval_secs: 30,
+            auth_log_path: log_path,
+            max_failures: 5,
+            time_window_secs: 300,
+        };
+        let module = SshBruteForceModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("認証ログファイルを確認しました"));
+        assert!(result.summary.contains("bytes"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_nonexistent_file() {
+        let config = SshBruteForceConfig {
+            enabled: true,
+            interval_secs: 30,
+            auth_log_path: PathBuf::from("/nonexistent/auth.log"),
+            max_failures: 5,
+            time_window_secs: 300,
+        };
+        let module = SshBruteForceModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("認証ログファイルが存在しません"));
     }
 }

--- a/src/modules/ssh_key_monitor.rs
+++ b/src/modules/ssh_key_monitor.rs
@@ -9,7 +9,7 @@
 use crate::config::SshKeyMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -317,6 +317,22 @@ impl Module for SshKeyMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("SSH 公開鍵ファイル {}件をスキャンしました", items_scanned),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -558,5 +574,56 @@ mod tests {
 
         module.stop().await.unwrap();
         assert!(cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let key_file = tmpdir.path().join("authorized_keys");
+        std::fs::write(
+            &key_file,
+            "ssh-rsa AAAAB3... user@host\nssh-ed25519 AAAAC3... admin@host\n",
+        )
+        .unwrap();
+
+        let config = SshKeyMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![key_file],
+        };
+        let module = SshKeyMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("SSH 公開鍵ファイル 1件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_paths() {
+        let config = SshKeyMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![],
+        };
+        let module = SshKeyMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_nonexistent_file() {
+        let config = SshKeyMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_paths: vec![PathBuf::from("/nonexistent/authorized_keys")],
+        };
+        let module = SshKeyMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/sudoers_monitor.rs
+++ b/src/modules/sudoers_monitor.rs
@@ -10,7 +10,7 @@
 use crate::config::SudoersMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -328,6 +328,20 @@ impl Module for SudoersMonitorModule {
         Ok(())
     }
 
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let snapshot = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = snapshot.files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!("sudoers ファイル {}件をスキャンしました", items_scanned),
+        })
+    }
+
     async fn stop(&mut self) -> Result<(), AppError> {
         self.cancel_token.cancel();
         Ok(())
@@ -618,5 +632,40 @@ mod tests {
 
         let changed = SudoersMonitorModule::detect_and_report(&baseline, &current, &None);
         assert!(changed);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let mut tmpfile1 = tempfile::NamedTempFile::new().unwrap();
+        let mut tmpfile2 = tempfile::NamedTempFile::new().unwrap();
+        write!(tmpfile1, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        write!(tmpfile2, "%admin ALL=(ALL) ALL\n").unwrap();
+
+        let config = SudoersMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![tmpfile1.path().to_path_buf(), tmpfile2.path().to_path_buf()],
+        };
+        let mut module = SudoersMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = SudoersMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![],
+        };
+        let module = SudoersMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/systemd_service.rs
+++ b/src/modules/systemd_service.rs
@@ -10,7 +10,7 @@
 use crate::config::SystemdServiceConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -269,6 +269,23 @@ impl Module for SystemdServiceModule {
         });
 
         Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+        let files = Self::scan_files(&self.config.watch_paths);
+        let items_scanned = files.len();
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found: 0,
+            duration,
+            summary: format!(
+                "systemd ユニットファイル {}件をスキャンしました",
+                items_scanned
+            ),
+        })
     }
 
     async fn stop(&mut self) -> Result<(), AppError> {
@@ -557,5 +574,41 @@ mod tests {
             removed: vec![],
         };
         assert!(!report.has_changes());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file1 = dir.path().join("test.service");
+        let file2 = dir.path().join("test.timer");
+        std::fs::write(&file1, "[Unit]\nDescription=Test").unwrap();
+        std::fs::write(&file2, "[Unit]\nDescription=Timer").unwrap();
+
+        let config = SystemdServiceConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![dir.path().to_path_buf()],
+        };
+        let mut module = SystemdServiceModule::new(config, None);
+        module.init().unwrap();
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 2);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("2件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty() {
+        let config = SystemdServiceConfig {
+            enabled: true,
+            scan_interval_secs: 120,
+            watch_paths: vec![],
+        };
+        let module = SystemdServiceModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }

--- a/src/modules/tmp_exec_monitor.rs
+++ b/src/modules/tmp_exec_monitor.rs
@@ -11,7 +11,7 @@
 use crate::config::TmpExecMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use crate::modules::Module;
+use crate::modules::{InitialScanResult, Module};
 use std::collections::HashMap;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
@@ -282,6 +282,26 @@ impl Module for TmpExecMonitorModule {
         self.cancel_token.cancel();
         Ok(())
     }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let snapshot = Self::scan_dirs(&self.config.watch_dirs);
+        let items_scanned = snapshot.files.len();
+        let issues_found = items_scanned;
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned,
+            issues_found,
+            duration,
+            summary: format!(
+                "一時ディレクトリから実行可能ファイル {}件を検出しました",
+                items_scanned
+            ),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -509,5 +529,58 @@ mod tests {
 
         module.stop().await.unwrap();
         assert!(cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_executables() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("test_exec");
+        fs::write(&file_path, "#!/bin/sh\necho hello").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_dirs: vec![dir.path().to_path_buf()],
+        };
+        let module = TmpExecMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 1);
+        assert!(result.summary.contains("実行可能ファイル 1件"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_no_executables() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("not_exec");
+        fs::write(&file_path, "data").unwrap();
+        fs::set_permissions(&file_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_dirs: vec![dir.path().to_path_buf()],
+        };
+        let module = TmpExecMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_dirs() {
+        let config = TmpExecMonitorConfig {
+            enabled: true,
+            scan_interval_secs: 60,
+            watch_dirs: vec![],
+        };
+        let module = TmpExecMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
     }
 }


### PR DESCRIPTION
## Summary

- v0.40.0 で5モジュールに実装した `initial_scan` を、残り17モジュールすべてに実装
- 全22モジュールで起動時ベースライン記録が完備された
- 4パターンで実装: ハッシュベーススキャン（7）、エントリカウント（2）、問題検出あり（6）、特殊系（2）

## 対象モジュール

### ハッシュベーススキャン（issues_found: 0）
at_job_monitor, firewall_monitor, log_tamper, pkg_repo_monitor, shell_config_monitor, sudoers_monitor, systemd_service

### エントリカウント（issues_found: 0）
kernel_module, mount_monitor

### 問題検出あり
ld_preload_monitor, network_monitor, pam_monitor, process_monitor, security_files_monitor, tmp_exec_monitor

### 特殊系
ssh_brute_force, ssh_key_monitor

## Test plan

- [x] `cargo test` — 全662テスト合格
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット OK
- [x] 統合テスト — 36テスト合格

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)