### PR TITLE
feat: 起動時スキャン結果の永続化 — 前回スキャンとの差分検出 (#87)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.41.0"
+version = "0.42.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,6 +18,11 @@ shutdown_timeout_secs = 30
 enabled = true
 # スキャン全体のタイムアウト（秒）
 timeout_secs = 60
+# スキャン結果の永続化の有効/無効
+# 有効にするとスキャン結果をファイルに保存し、次回起動時に前回との差分を検出する
+persist_state = true
+# スキャン状態ファイルのパス
+state_file = "/var/lib/zettai-mamorukun/scan_state.json"
 
 [modules.file_integrity]
 # ファイル整合性監視モジュールの有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,12 @@ pub struct StartupScanConfig {
     /// スキャン全体のタイムアウト（秒、デフォルト: 60）
     #[serde(default = "StartupScanConfig::default_timeout_secs")]
     pub timeout_secs: u64,
+    /// スキャン結果の永続化の有効/無効（デフォルト: true）
+    #[serde(default = "StartupScanConfig::default_persist_state")]
+    pub persist_state: bool,
+    /// スキャン状態ファイルのパス
+    #[serde(default = "StartupScanConfig::default_state_file")]
+    pub state_file: String,
 }
 
 impl Default for StartupScanConfig {
@@ -81,6 +87,8 @@ impl Default for StartupScanConfig {
         Self {
             enabled: Self::default_enabled(),
             timeout_secs: Self::default_timeout_secs(),
+            persist_state: Self::default_persist_state(),
+            state_file: Self::default_state_file(),
         }
     }
 }
@@ -92,6 +100,14 @@ impl StartupScanConfig {
 
     fn default_timeout_secs() -> u64 {
         60
+    }
+
+    fn default_persist_state() -> bool {
+        true
+    }
+
+    fn default_state_file() -> String {
+        "/var/lib/zettai-mamorukun/scan_state.json".to_string()
     }
 }
 

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -4,9 +4,10 @@ use crate::core::event::{self, EventBus, SecurityEvent, Severity};
 use crate::core::health::HealthChecker;
 use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
+use crate::core::scan_state::{self, DiffKind};
 use crate::core::status::{DaemonState, StatusServer};
 use crate::error::AppError;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
@@ -98,6 +99,15 @@ impl Daemon {
             tracing::warn!("アクションエンジンはイベントバスが無効のため起動できません");
         }
 
+        // 前回のスキャン状態を読み込み
+        let previous_scan_state =
+            if self.config.startup_scan.enabled && self.config.startup_scan.persist_state {
+                let state_path = Path::new(&self.config.startup_scan.state_file);
+                scan_state::load_scan_state(state_path)
+            } else {
+                None
+            };
+
         // モジュールマネージャーでモジュールを一括起動（起動時スキャン付き）
         let (mut module_manager, scan_report) = ModuleManager::start_modules(
             &self.config.modules,
@@ -139,6 +149,64 @@ impl Daemon {
                 "daemon",
                 summary,
             ));
+        }
+
+        // スキャン状態の差分検出と永続化
+        if self.config.startup_scan.enabled && self.config.startup_scan.persist_state {
+            // スナップショットデータを収集
+            let snapshot_data: Vec<(String, std::collections::BTreeMap<String, String>)> =
+                scan_report
+                    .results
+                    .iter()
+                    .filter(|(_, r)| !r.snapshot.is_empty())
+                    .map(|(name, r)| (name.clone(), r.snapshot.clone()))
+                    .collect();
+
+            // 前回の状態との差分検出
+            if let Some(ref prev_state) = previous_scan_state {
+                let diffs = scan_state::detect_diffs(prev_state, &snapshot_data);
+                if !diffs.is_empty() {
+                    let total_changes: usize = diffs.iter().map(|d| d.entries.len()).sum();
+                    tracing::warn!(
+                        modules = diffs.len(),
+                        total_changes = total_changes,
+                        "前回起動時からの変更を検出しました"
+                    );
+
+                    if let Some(ref bus) = event_bus {
+                        for diff in &diffs {
+                            for entry in &diff.entries {
+                                let (event_type, message) = match entry.kind {
+                                    DiffKind::Added => (
+                                        "scan_state_added",
+                                        format!("[{}] 新規追加: {}", diff.module_name, entry.key),
+                                    ),
+                                    DiffKind::Removed => (
+                                        "scan_state_removed",
+                                        format!("[{}] 削除: {}", diff.module_name, entry.key),
+                                    ),
+                                    DiffKind::Modified => (
+                                        "scan_state_modified",
+                                        format!("[{}] 変更: {}", diff.module_name, entry.key),
+                                    ),
+                                };
+                                bus.publish(SecurityEvent::new(
+                                    event_type,
+                                    Severity::Warning,
+                                    "daemon",
+                                    message,
+                                ));
+                            }
+                        }
+                    }
+                } else {
+                    tracing::info!("前回起動時からの変更はありません");
+                }
+            }
+
+            // 現在のスナップショットを保存
+            let state_path = Path::new(&self.config.startup_scan.state_file);
+            scan_state::save_scan_state(state_path, &snapshot_data);
         }
 
         // モジュール名を共有状態に反映

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,4 +4,5 @@ pub mod event;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;
+pub mod scan_state;
 pub mod status;

--- a/src/core/scan_state.rs
+++ b/src/core/scan_state.rs
@@ -1,0 +1,523 @@
+//! スキャン状態の永続化 — 起動時スキャン結果の保存・読み込み・差分検出
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::SystemTime;
+use tracing::{info, warn};
+
+/// 永続化されるスキャン状態
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScanState {
+    /// 保存日時（RFC 3339 形式）
+    pub saved_at: String,
+    /// 各モジュールのスナップショット（モジュール名 → アイテム識別子 → ハッシュ/状態文字列）
+    pub modules: BTreeMap<String, BTreeMap<String, String>>,
+}
+
+/// スナップショットの差分種別
+#[derive(Debug, PartialEq, Eq)]
+pub enum DiffKind {
+    /// 新規追加されたアイテム
+    Added,
+    /// 削除されたアイテム
+    Removed,
+    /// 変更されたアイテム
+    Modified,
+}
+
+/// 個別の差分エントリ
+#[derive(Debug)]
+pub struct DiffEntry {
+    /// 差分種別
+    pub kind: DiffKind,
+    /// アイテム識別子（ファイルパス等）
+    pub key: String,
+    /// 前回の値（Added の場合は None）
+    pub old_value: Option<String>,
+    /// 今回の値（Removed の場合は None）
+    pub new_value: Option<String>,
+}
+
+/// モジュール単位の差分結果
+#[derive(Debug)]
+pub struct ModuleDiff {
+    /// モジュール名
+    pub module_name: String,
+    /// 差分エントリのリスト
+    pub entries: Vec<DiffEntry>,
+}
+
+impl ModuleDiff {
+    /// 差分があるかどうかを返す
+    pub fn has_changes(&self) -> bool {
+        !self.entries.is_empty()
+    }
+}
+
+/// 前回のスキャン状態をファイルから読み込む
+///
+/// ファイルが存在しない場合は `None` を返す。
+/// パースに失敗した場合はログ警告を出して `None` を返す。
+pub fn load_scan_state(path: &Path) -> Option<ScanState> {
+    if !path.exists() {
+        info!(path = %path.display(), "前回のスキャン状態ファイルが存在しません（初回起動）");
+        return None;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(content) => match serde_json::from_str::<ScanState>(&content) {
+            Ok(state) => {
+                info!(
+                    path = %path.display(),
+                    saved_at = %state.saved_at,
+                    modules = state.modules.len(),
+                    "前回のスキャン状態を読み込みました"
+                );
+                Some(state)
+            }
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "スキャン状態ファイルのパースに失敗しました。差分検出をスキップします"
+                );
+                None
+            }
+        },
+        Err(e) => {
+            warn!(
+                path = %path.display(),
+                error = %e,
+                "スキャン状態ファイルの読み込みに失敗しました。差分検出をスキップします"
+            );
+            None
+        }
+    }
+}
+
+/// スキャン状態をファイルに保存する
+///
+/// アトミック書き込み（一時ファイル→リネーム）を使用する。
+/// 書き込みに失敗してもデーモン動作には影響しない（ログ警告のみ）。
+pub fn save_scan_state(path: &Path, modules: &[(String, BTreeMap<String, String>)]) {
+    let saved_at = match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+        Ok(d) => format!("{}", d.as_secs()),
+        Err(_) => "0".to_string(),
+    };
+    let state = ScanState {
+        saved_at,
+        modules: modules.iter().cloned().collect(),
+    };
+
+    let json = match serde_json::to_string_pretty(&state) {
+        Ok(j) => j,
+        Err(e) => {
+            warn!(error = %e, "スキャン状態の JSON シリアライズに失敗しました");
+            return;
+        }
+    };
+
+    // 親ディレクトリを作成
+    if let Some(parent) = path.parent()
+        && !parent.exists()
+        && let Err(e) = std::fs::create_dir_all(parent)
+    {
+        warn!(
+            path = %parent.display(),
+            error = %e,
+            "スキャン状態保存先ディレクトリの作成に失敗しました"
+        );
+        return;
+    }
+
+    // 一時ファイルに書き込み→リネーム（アトミック書き込み）
+    let tmp_path = path.with_extension("json.tmp");
+    match std::fs::write(&tmp_path, &json) {
+        Ok(()) => match std::fs::rename(&tmp_path, path) {
+            Ok(()) => {
+                info!(
+                    path = %path.display(),
+                    modules = state.modules.len(),
+                    "スキャン状態を保存しました"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    path = %path.display(),
+                    error = %e,
+                    "スキャン状態ファイルのリネームに失敗しました"
+                );
+                // 一時ファイルのクリーンアップ
+                let _ = std::fs::remove_file(&tmp_path);
+            }
+        },
+        Err(e) => {
+            warn!(
+                path = %tmp_path.display(),
+                error = %e,
+                "スキャン状態の一時ファイル書き込みに失敗しました"
+            );
+        }
+    }
+}
+
+/// 前回と今回のスナップショットを比較し、差分を検出する
+pub fn detect_diffs(
+    previous: &ScanState,
+    current_modules: &[(String, BTreeMap<String, String>)],
+) -> Vec<ModuleDiff> {
+    let mut diffs = Vec::new();
+
+    for (module_name, current_snapshot) in current_modules {
+        let mut entries = Vec::new();
+
+        if let Some(prev_snapshot) = previous.modules.get(module_name) {
+            // 変更・削除の検出
+            for (key, old_value) in prev_snapshot {
+                match current_snapshot.get(key) {
+                    Some(new_value) if new_value != old_value => {
+                        entries.push(DiffEntry {
+                            kind: DiffKind::Modified,
+                            key: key.clone(),
+                            old_value: Some(old_value.clone()),
+                            new_value: Some(new_value.clone()),
+                        });
+                    }
+                    None => {
+                        entries.push(DiffEntry {
+                            kind: DiffKind::Removed,
+                            key: key.clone(),
+                            old_value: Some(old_value.clone()),
+                            new_value: None,
+                        });
+                    }
+                    _ => {} // 変更なし
+                }
+            }
+
+            // 追加の検出
+            for (key, new_value) in current_snapshot {
+                if !prev_snapshot.contains_key(key) {
+                    entries.push(DiffEntry {
+                        kind: DiffKind::Added,
+                        key: key.clone(),
+                        old_value: None,
+                        new_value: Some(new_value.clone()),
+                    });
+                }
+            }
+        }
+        // 前回のスナップショットにモジュールが存在しない場合は差分なし（初回とみなす）
+
+        if !entries.is_empty() {
+            diffs.push(ModuleDiff {
+                module_name: module_name.clone(),
+                entries,
+            });
+        }
+    }
+
+    diffs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_load_scan_state_nonexistent() {
+        let result = load_scan_state(Path::new("/tmp/nonexistent-scan-state-zettai-test.json"));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_scan_state_invalid_json() {
+        let mut tmpfile = NamedTempFile::new().unwrap();
+        write!(tmpfile, "not valid json").unwrap();
+        let result = load_scan_state(tmpfile.path());
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_load_scan_state_valid() {
+        let mut tmpfile = NamedTempFile::new().unwrap();
+        let state = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "module_a".to_string(),
+                BTreeMap::from([("/etc/file".to_string(), "abc123".to_string())]),
+            )]),
+        };
+        let json = serde_json::to_string(&state).unwrap();
+        write!(tmpfile, "{}", json).unwrap();
+        let result = load_scan_state(tmpfile.path());
+        assert!(result.is_some());
+        let loaded = result.unwrap();
+        assert_eq!(loaded.modules.len(), 1);
+        assert!(loaded.modules.contains_key("module_a"));
+    }
+
+    #[test]
+    fn test_save_scan_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("scan_state.json");
+        let modules = vec![(
+            "module_a".to_string(),
+            BTreeMap::from([("/etc/file".to_string(), "abc123".to_string())]),
+        )];
+        save_scan_state(&path, &modules);
+        assert!(path.exists());
+
+        let loaded = load_scan_state(&path);
+        assert!(loaded.is_some());
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.modules.len(), 1);
+    }
+
+    #[test]
+    fn test_save_scan_state_creates_parent_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("subdir").join("scan_state.json");
+        let modules = vec![];
+        save_scan_state(&path, &modules);
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn test_detect_diffs_no_changes() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "mod_a".to_string(),
+                BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+            )]),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+        )];
+        let diffs = detect_diffs(&previous, &current);
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn test_detect_diffs_added() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "mod_a".to_string(),
+                BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+            )]),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([
+                ("/a".to_string(), "hash1".to_string()),
+                ("/b".to_string(), "hash2".to_string()),
+            ]),
+        )];
+        let diffs = detect_diffs(&previous, &current);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].entries.len(), 1);
+        assert_eq!(diffs[0].entries[0].kind, DiffKind::Added);
+        assert_eq!(diffs[0].entries[0].key, "/b");
+    }
+
+    #[test]
+    fn test_detect_diffs_removed() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "mod_a".to_string(),
+                BTreeMap::from([
+                    ("/a".to_string(), "hash1".to_string()),
+                    ("/b".to_string(), "hash2".to_string()),
+                ]),
+            )]),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+        )];
+        let diffs = detect_diffs(&previous, &current);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].entries.len(), 1);
+        assert_eq!(diffs[0].entries[0].kind, DiffKind::Removed);
+        assert_eq!(diffs[0].entries[0].key, "/b");
+    }
+
+    #[test]
+    fn test_detect_diffs_modified() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "mod_a".to_string(),
+                BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+            )]),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([("/a".to_string(), "hash_changed".to_string())]),
+        )];
+        let diffs = detect_diffs(&previous, &current);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].entries.len(), 1);
+        assert_eq!(diffs[0].entries[0].kind, DiffKind::Modified);
+        assert_eq!(diffs[0].entries[0].old_value, Some("hash1".to_string()));
+        assert_eq!(
+            diffs[0].entries[0].new_value,
+            Some("hash_changed".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_diffs_new_module() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::new(),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+        )];
+        // 前回にモジュールが存在しない場合は差分なし（初回とみなす）
+        let diffs = detect_diffs(&previous, &current);
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn test_detect_diffs_combined() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([(
+                "mod_a".to_string(),
+                BTreeMap::from([
+                    ("/existing".to_string(), "hash1".to_string()),
+                    ("/to_remove".to_string(), "hash2".to_string()),
+                    ("/to_modify".to_string(), "hash3".to_string()),
+                ]),
+            )]),
+        };
+        let current = vec![(
+            "mod_a".to_string(),
+            BTreeMap::from([
+                ("/existing".to_string(), "hash1".to_string()),
+                ("/to_modify".to_string(), "hash_changed".to_string()),
+                ("/new_file".to_string(), "hash4".to_string()),
+            ]),
+        )];
+        let diffs = detect_diffs(&previous, &current);
+        assert_eq!(diffs.len(), 1);
+        let diff = &diffs[0];
+        assert_eq!(diff.entries.len(), 3); // modified + removed + added
+
+        let added: Vec<_> = diff
+            .entries
+            .iter()
+            .filter(|e| e.kind == DiffKind::Added)
+            .collect();
+        let removed: Vec<_> = diff
+            .entries
+            .iter()
+            .filter(|e| e.kind == DiffKind::Removed)
+            .collect();
+        let modified: Vec<_> = diff
+            .entries
+            .iter()
+            .filter(|e| e.kind == DiffKind::Modified)
+            .collect();
+
+        assert_eq!(added.len(), 1);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(modified.len(), 1);
+        assert_eq!(added[0].key, "/new_file");
+        assert_eq!(removed[0].key, "/to_remove");
+        assert_eq!(modified[0].key, "/to_modify");
+    }
+
+    #[test]
+    fn test_module_diff_has_changes() {
+        let diff = ModuleDiff {
+            module_name: "test".to_string(),
+            entries: vec![DiffEntry {
+                kind: DiffKind::Added,
+                key: "/new".to_string(),
+                old_value: None,
+                new_value: Some("hash".to_string()),
+            }],
+        };
+        assert!(diff.has_changes());
+
+        let empty_diff = ModuleDiff {
+            module_name: "test".to_string(),
+            entries: vec![],
+        };
+        assert!(!empty_diff.has_changes());
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+
+        let modules = vec![
+            (
+                "mod_a".to_string(),
+                BTreeMap::from([
+                    ("/etc/file1".to_string(), "hash1".to_string()),
+                    ("/etc/file2".to_string(), "hash2".to_string()),
+                ]),
+            ),
+            (
+                "mod_b".to_string(),
+                BTreeMap::from([("kernel_mod".to_string(), "loaded".to_string())]),
+            ),
+        ];
+
+        save_scan_state(&path, &modules);
+        let loaded = load_scan_state(&path).unwrap();
+        assert_eq!(loaded.modules.len(), 2);
+        assert_eq!(
+            loaded.modules["mod_a"].get("/etc/file1"),
+            Some(&"hash1".to_string())
+        );
+        assert_eq!(
+            loaded.modules["mod_b"].get("kernel_mod"),
+            Some(&"loaded".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_diffs_multiple_modules() {
+        let previous = ScanState {
+            saved_at: "2026-04-03T00:00:00Z".to_string(),
+            modules: BTreeMap::from([
+                (
+                    "mod_a".to_string(),
+                    BTreeMap::from([("/a".to_string(), "hash1".to_string())]),
+                ),
+                (
+                    "mod_b".to_string(),
+                    BTreeMap::from([("/b".to_string(), "hash2".to_string())]),
+                ),
+            ]),
+        };
+        let current = vec![
+            (
+                "mod_a".to_string(),
+                BTreeMap::from([("/a".to_string(), "hash_changed".to_string())]),
+            ),
+            (
+                "mod_b".to_string(),
+                BTreeMap::from([("/b".to_string(), "hash2".to_string())]),
+            ),
+        ];
+        let diffs = detect_diffs(&previous, &current);
+        // mod_a のみ差分あり
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].module_name, "mod_a");
+    }
+}

--- a/src/modules/at_job_monitor.rs
+++ b/src/modules/at_job_monitor.rs
@@ -13,7 +13,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -299,6 +299,10 @@ impl Module for AtJobMonitorModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -309,6 +313,7 @@ impl Module for AtJobMonitorModule {
                 "at/batch ジョブファイル {}件をスキャンしました",
                 items_scanned
             ),
+            snapshot,
         })
     }
 

--- a/src/modules/cron_monitor.rs
+++ b/src/modules/cron_monitor.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -275,6 +275,10 @@ impl Module for CronMonitorModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -282,6 +286,7 @@ impl Module for CronMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("cron ファイル {}件をスキャンしました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/dns_monitor.rs
+++ b/src/modules/dns_monitor.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -240,6 +240,10 @@ impl Module for DnsMonitorModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -247,6 +251,7 @@ impl Module for DnsMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("DNS設定ファイル {}件をスキャンしました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/file_integrity.rs
+++ b/src/modules/file_integrity.rs
@@ -8,7 +8,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -271,6 +271,10 @@ impl Module for FileIntegrityModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -278,6 +282,7 @@ impl Module for FileIntegrityModule {
             issues_found: 0,
             duration,
             summary: format!("監視対象ファイル {}件をスキャンしました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/firewall_monitor.rs
+++ b/src/modules/firewall_monitor.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -240,6 +240,10 @@ impl Module for FirewallMonitorModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -250,6 +254,7 @@ impl Module for FirewallMonitorModule {
                 "ファイアウォール関連ファイル {}件をスキャンしました",
                 items_scanned
             ),
+            snapshot,
         })
     }
 

--- a/src/modules/kernel_module.rs
+++ b/src/modules/kernel_module.rs
@@ -10,7 +10,7 @@ use crate::config::KernelModuleConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use tokio_util::sync::CancellationToken;
 
 /// `/proc/modules` の各行をパースした結果
@@ -244,6 +244,15 @@ impl Module for KernelModuleMonitor {
         let content = Self::read_proc_modules()?;
         let entries = Self::parse_proc_modules(&content);
         let items_scanned = entries.len();
+        let snapshot: BTreeMap<String, String> = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.name.clone(),
+                    format!("size={},state={}", entry.size, entry.state),
+                )
+            })
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -251,6 +260,7 @@ impl Module for KernelModuleMonitor {
             issues_found: 0,
             duration,
             summary: format!("カーネルモジュール {}件を検出しました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/ld_preload_monitor.rs
+++ b/src/modules/ld_preload_monitor.rs
@@ -13,7 +13,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -363,6 +363,11 @@ impl Module for LdPreloadMonitorModule {
 
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
         let mut issues_found = 0;
 
         // /etc/ld.so.preload の存在チェック
@@ -408,6 +413,7 @@ impl Module for LdPreloadMonitorModule {
                 "動的リンカ設定ファイル {}件をスキャンしました（問題: {}件）",
                 items_scanned, issues_found
             ),
+            snapshot: scan_snapshot,
         })
     }
 }

--- a/src/modules/log_tamper.rs
+++ b/src/modules/log_tamper.rs
@@ -23,7 +23,7 @@ use crate::config::LogTamperConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -352,6 +352,18 @@ impl Module for LogTamperModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, state)| {
+                (
+                    path.display().to_string(),
+                    format!(
+                        "size={},inode={},perm={:o}",
+                        state.size, state.inode, state.permissions
+                    ),
+                )
+            })
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -359,6 +371,7 @@ impl Module for LogTamperModule {
             issues_found: 0,
             duration,
             summary: format!("ログファイル {}件をスキャンしました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -22,6 +22,7 @@ pub mod tmp_exec_monitor;
 pub mod user_account;
 
 use crate::error::AppError;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 /// 起動時スキャン結果
@@ -37,6 +38,11 @@ pub struct InitialScanResult {
     pub duration: Duration,
     /// サマリーメッセージ
     pub summary: String,
+    /// スナップショットデータ（アイテム識別子 → ハッシュ/状態文字列）
+    ///
+    /// 永続化して次回起動時の差分検出に使用する。
+    /// BTreeMap を使用してキー順序を安定させる。
+    pub snapshot: BTreeMap<String, String>,
 }
 
 /// 防御モジュールが実装すべきトレイト

--- a/src/modules/mount_monitor.rs
+++ b/src/modules/mount_monitor.rs
@@ -11,7 +11,7 @@ use crate::config::MountMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -285,6 +285,15 @@ impl Module for MountMonitorModule {
         let start = std::time::Instant::now();
         let entries = Self::read_mounts(&self.config.mounts_path)?;
         let items_scanned = entries.len();
+        let snapshot: BTreeMap<String, String> = entries
+            .iter()
+            .map(|entry| {
+                (
+                    entry.mount_point.clone(),
+                    format!("{}:{}", entry.device, entry.fs_type),
+                )
+            })
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -292,6 +301,7 @@ impl Module for MountMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("マウントポイント {}件を検出しました", items_scanned),
+            snapshot,
         })
     }
 

--- a/src/modules/network_monitor.rs
+++ b/src/modules/network_monitor.rs
@@ -11,7 +11,7 @@ use crate::config::NetworkMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use tokio_util::sync::CancellationToken;
 
@@ -510,6 +510,7 @@ impl Module for NetworkMonitorModule {
                 "ネットワーク接続 {}件をスキャンしました（不審な接続: {}件）",
                 items_scanned, issues_found
             ),
+            snapshot: BTreeMap::new(),
         })
     }
 }

--- a/src/modules/pam_monitor.rs
+++ b/src/modules/pam_monitor.rs
@@ -13,7 +13,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -528,6 +528,11 @@ impl Module for PamMonitorModule {
 
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
         let mut issues_found = 0;
 
         for path in &self.config.watch_paths {
@@ -592,6 +597,7 @@ impl Module for PamMonitorModule {
                 "PAM 設定ファイル {}件をスキャンしました（危険パターン: {}件）",
                 items_scanned, issues_found
             ),
+            snapshot: scan_snapshot,
         })
     }
 }

--- a/src/modules/pkg_repo_monitor.rs
+++ b/src/modules/pkg_repo_monitor.rs
@@ -14,7 +14,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -264,6 +264,10 @@ impl Module for PkgRepoMonitorModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -274,6 +278,7 @@ impl Module for PkgRepoMonitorModule {
                 "パッケージリポジトリ設定ファイル {}件をスキャンしました",
                 items_scanned
             ),
+            snapshot,
         })
     }
 

--- a/src/modules/process_monitor.rs
+++ b/src/modules/process_monitor.rs
@@ -11,7 +11,7 @@ use crate::config::ProcessMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
@@ -293,6 +293,7 @@ impl Module for ProcessMonitorModule {
                 "プロセス {}件をスキャンしました（不審なプロセス: {}件）",
                 items_scanned, issues_found
             ),
+            snapshot: BTreeMap::new(),
         })
     }
 }

--- a/src/modules/security_files_monitor.rs
+++ b/src/modules/security_files_monitor.rs
@@ -13,7 +13,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -455,6 +455,11 @@ impl Module for SecurityFilesMonitorModule {
 
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
         let mut issues_found = 0;
 
         for path in &self.config.watch_paths {
@@ -513,6 +518,7 @@ impl Module for SecurityFilesMonitorModule {
                 "セキュリティ設定ファイル {}件をスキャンしました（危険パターン: {}件）",
                 items_scanned, issues_found
             ),
+            snapshot: scan_snapshot,
         })
     }
 }

--- a/src/modules/shell_config_monitor.rs
+++ b/src/modules/shell_config_monitor.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -310,6 +310,11 @@ impl Module for ShellConfigMonitorModule {
         let start = std::time::Instant::now();
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -317,6 +322,7 @@ impl Module for ShellConfigMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("シェル設定ファイル {}件をスキャンしました", items_scanned),
+            snapshot: scan_snapshot,
         })
     }
 

--- a/src/modules/ssh_brute_force.rs
+++ b/src/modules/ssh_brute_force.rs
@@ -9,7 +9,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use regex::Regex;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{BufRead, BufReader, Seek, SeekFrom};
 use std::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -267,6 +267,7 @@ impl Module for SshBruteForceModule {
             issues_found: 0,
             duration,
             summary,
+            snapshot: BTreeMap::new(),
         })
     }
 }

--- a/src/modules/ssh_key_monitor.rs
+++ b/src/modules/ssh_key_monitor.rs
@@ -11,7 +11,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 
@@ -323,6 +323,11 @@ impl Module for SshKeyMonitorModule {
 
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
 
         let duration = start.elapsed();
 
@@ -331,6 +336,7 @@ impl Module for SshKeyMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("SSH 公開鍵ファイル {}件をスキャンしました", items_scanned),
+            snapshot: scan_snapshot,
         })
     }
 }

--- a/src/modules/sudoers_monitor.rs
+++ b/src/modules/sudoers_monitor.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -332,6 +332,11 @@ impl Module for SudoersMonitorModule {
         let start = std::time::Instant::now();
         let snapshot = Self::scan_files(&self.config.watch_paths);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, snap)| (path.display().to_string(), snap.file_hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -339,6 +344,7 @@ impl Module for SudoersMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("sudoers ファイル {}件をスキャンしました", items_scanned),
+            snapshot: scan_snapshot,
         })
     }
 

--- a/src/modules/suid_sgid_monitor.rs
+++ b/src/modules/suid_sgid_monitor.rs
@@ -13,7 +13,7 @@ use crate::config::SuidSgidMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::MetadataExt;
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -323,6 +323,16 @@ impl Module for SuidSgidMonitorModule {
         let start = std::time::Instant::now();
         let snapshot = Self::scan_dirs(&self.config.watch_dirs);
         let items_scanned = snapshot.files.len();
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, info)| {
+                (
+                    path.display().to_string(),
+                    format!("mode={:o},uid={},size={}", info.mode, info.uid, info.size),
+                )
+            })
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -330,6 +340,7 @@ impl Module for SuidSgidMonitorModule {
             issues_found: 0,
             duration,
             summary: format!("SUID/SGID ファイル {}件を検出しました", items_scanned),
+            snapshot: scan_snapshot,
         })
     }
 

--- a/src/modules/systemd_service.rs
+++ b/src/modules/systemd_service.rs
@@ -12,7 +12,7 @@ use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
 use walkdir::WalkDir;
@@ -275,6 +275,10 @@ impl Module for SystemdServiceModule {
         let start = std::time::Instant::now();
         let files = Self::scan_files(&self.config.watch_paths);
         let items_scanned = files.len();
+        let snapshot: BTreeMap<String, String> = files
+            .iter()
+            .map(|(path, hash)| (path.display().to_string(), hash.clone()))
+            .collect();
         let duration = start.elapsed();
 
         Ok(InitialScanResult {
@@ -285,6 +289,7 @@ impl Module for SystemdServiceModule {
                 "systemd ユニットファイル {}件をスキャンしました",
                 items_scanned
             ),
+            snapshot,
         })
     }
 

--- a/src/modules/tmp_exec_monitor.rs
+++ b/src/modules/tmp_exec_monitor.rs
@@ -12,7 +12,7 @@ use crate::config::TmpExecMonitorConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use tokio_util::sync::CancellationToken;
@@ -289,6 +289,16 @@ impl Module for TmpExecMonitorModule {
         let snapshot = Self::scan_dirs(&self.config.watch_dirs);
         let items_scanned = snapshot.files.len();
         let issues_found = items_scanned;
+        let scan_snapshot: BTreeMap<String, String> = snapshot
+            .files
+            .iter()
+            .map(|(path, info)| {
+                (
+                    path.display().to_string(),
+                    format!("mode={:o},size={}", info.mode, info.size),
+                )
+            })
+            .collect();
 
         let duration = start.elapsed();
 
@@ -300,6 +310,7 @@ impl Module for TmpExecMonitorModule {
                 "一時ディレクトリから実行可能ファイル {}件を検出しました",
                 items_scanned
             ),
+            snapshot: scan_snapshot,
         })
     }
 }

--- a/src/modules/user_account.rs
+++ b/src/modules/user_account.rs
@@ -14,7 +14,7 @@ use crate::config::UserAccountConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::Path;
 use tokio_util::sync::CancellationToken;
 
@@ -514,6 +514,7 @@ impl Module for UserAccountModule {
         let mut issues_found = 0;
         let mut user_count = 0;
         let mut group_count = 0;
+        let mut snapshot: BTreeMap<String, String> = BTreeMap::new();
 
         if let Ok(content) = std::fs::read_to_string(&self.config.passwd_path) {
             let users = Self::parse_passwd(&content);
@@ -525,6 +526,10 @@ impl Module for UserAccountModule {
                 if entry.uid == 0 && username != "root" {
                     issues_found += 1;
                 }
+                snapshot.insert(
+                    username.clone(),
+                    format!("{}:{}:{}", entry.uid, entry.gid, entry.shell),
+                );
             }
         }
 
@@ -544,6 +549,7 @@ impl Module for UserAccountModule {
                 "ユーザー {}件, グループ {}件を読み取りました",
                 user_count, group_count
             ),
+            snapshot,
         })
     }
 


### PR DESCRIPTION
## 概要

起動時スキャン（initial_scan）の結果をJSONファイルに永続化し、次回起動時に前回の結果との差分を検出する機能を追加する。

Closes #87

## 変更内容

- `InitialScanResult` に `snapshot: BTreeMap<String, String>` フィールドを追加
- `src/core/scan_state.rs` を新規作成（保存・読み込み・差分検出ロジック）
- `StartupScanConfig` に `persist_state`（デフォルト: true）と `state_file` を追加
- `daemon.rs` に前回状態ロード→差分検出→イベント発行→状態保存フローを追加
- 全22モジュールの `initial_scan` にスナップショットデータを実装:
  - ファイルハッシュ系14モジュール: パス→SHA-256ハッシュ
  - カーネルモジュール: モジュール名→size/state
  - ユーザーアカウント: ユーザー名→uid:gid:shell
  - マウントポイント: マウントポイント→device:fstype
  - SUID/SGID: パス→mode/uid/size
  - 一時ディレクトリ: パス→mode/size
  - ログ改ざん検知: パス→size/inode/perm
  - 揮発性モジュール3つ: 空スナップショット（プロセス・ネットワーク・SSH）

## テスト計画

- [x] `cargo test` — 全712テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット適合
- [x] scan_state モジュールの単体テスト（保存・読み込み・差分検出）
- [x] 状態ファイル不在時のグレースフルなフォールバック確認
- [x] パース失敗時のログ警告動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)