### PR TITLE
feat: セキュリティイベントの SQLite 永続化 (#131)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
+- **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 
 ## ディレクトリ構成
@@ -79,6 +80,7 @@ src/
     daemon.rs          # デーモンライフサイクル管理
     action.rs          # アクションエンジン（ルールベースのアクション実行）
     event.rs           # イベントバス（SecurityEvent / EventBus / ログサブスクライバー）
+    event_store.rs     # イベントストア（SQLite 永続化）
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
     metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +271,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +474,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -462,6 +495,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -784,6 +826,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +934,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1103,6 +1162,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1680,6 +1753,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2260,13 +2339,14 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "clap",
  "inotify",
  "libc",
  "regex",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -21,6 +21,7 @@ walkdir = "2"
 inotify = "0.11"
 xattr = "1.6"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/config.example.toml
+++ b/config.example.toml
@@ -609,6 +609,22 @@ enabled = false
 # # ボディテンプレート（プレースホルダ: {{count}}, {{summary}}, {{period_secs}}）
 # body_template = '{"text": "ダイジェスト通知: {{period_secs}}秒間に{{count}}件のイベントが発生しました\n{{summary}}"}'
 
+[event_store]
+# イベントストア（SQLite 永続化）の有効/無効
+# 有効にすると SecurityEvent を SQLite データベースに永続保存する
+# 過去のイベント検索・分析・フォレンジック対応に利用可能
+enabled = false
+# SQLite データベースファイルパス
+database_path = "/var/lib/zettai-mamorukun/events.db"
+# イベント保持期間（日数）— この期間を超えた古いイベントは自動削除される
+retention_days = 90
+# バッチ挿入サイズ — この件数に達するとバッファをフラッシュする
+batch_size = 100
+# バッチフラッシュ間隔（秒）— バッチサイズに達しなくてもこの間隔でフラッシュ
+batch_interval_secs = 5
+# クリーンアップ実行間隔（時間）— 古いイベントの削除を実行する間隔
+cleanup_interval_hours = 24
+
 [status]
 # ステータスサーバー（Unix ソケット）の有効/無効
 # 有効にすると `zettai-mamorukun status` コマンドでデーモンの状態を確認できる

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct AppConfig {
     /// 起動時スキャン設定
     #[serde(default)]
     pub startup_scan: StartupScanConfig,
+
+    /// イベントストア設定
+    #[serde(default)]
+    pub event_store: EventStoreConfig,
 }
 
 /// デーモン動作設定
@@ -2546,6 +2550,65 @@ impl Default for MetricsConfig {
     }
 }
 
+/// イベントストア（SQLite 永続化）設定
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct EventStoreConfig {
+    /// イベントストアの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// SQLite データベースファイルパス
+    #[serde(default = "EventStoreConfig::default_database_path")]
+    pub database_path: String,
+
+    /// イベント保持期間（日数）
+    #[serde(default = "EventStoreConfig::default_retention_days")]
+    pub retention_days: u64,
+
+    /// バッチ挿入サイズ
+    #[serde(default = "EventStoreConfig::default_batch_size")]
+    pub batch_size: usize,
+
+    /// バッチフラッシュ間隔（秒）
+    #[serde(default = "EventStoreConfig::default_batch_interval_secs")]
+    pub batch_interval_secs: u64,
+
+    /// クリーンアップ実行間隔（時間）
+    #[serde(default = "EventStoreConfig::default_cleanup_interval_hours")]
+    pub cleanup_interval_hours: u64,
+}
+
+impl EventStoreConfig {
+    fn default_database_path() -> String {
+        "/var/lib/zettai-mamorukun/events.db".to_string()
+    }
+    fn default_retention_days() -> u64 {
+        90
+    }
+    fn default_batch_size() -> usize {
+        100
+    }
+    fn default_batch_interval_secs() -> u64 {
+        5
+    }
+    fn default_cleanup_interval_hours() -> u64 {
+        24
+    }
+}
+
+impl Default for EventStoreConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            database_path: Self::default_database_path(),
+            retention_days: Self::default_retention_days(),
+            batch_size: Self::default_batch_size(),
+            batch_interval_secs: Self::default_batch_interval_secs(),
+            cleanup_interval_hours: Self::default_cleanup_interval_hours(),
+        }
+    }
+}
+
 /// ステータスサーバー設定
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct StatusConfig {
@@ -2621,6 +2684,23 @@ impl AppConfig {
         // metrics 設定の検証
         if self.metrics.enabled && self.metrics.interval_secs == 0 {
             errors.push("metrics.interval_secs: 0 より大きい値を指定してください".to_string());
+        }
+
+        // event_store 設定の検証
+        if self.event_store.enabled {
+            if self.event_store.database_path.is_empty() {
+                errors.push("event_store.database_path: 空文字列は指定できません".to_string());
+            }
+            if self.event_store.retention_days == 0 {
+                errors.push(
+                    "event_store.retention_days: 0 より大きい値を指定してください".to_string(),
+                );
+            }
+            if self.event_store.batch_interval_secs == 0 {
+                errors.push(
+                    "event_store.batch_interval_secs: 0 より大きい値を指定してください".to_string(),
+                );
+            }
         }
 
         // 各モジュールの interval 検証

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -2,6 +2,7 @@ use crate::config::AppConfig;
 use crate::config::DigestConfig;
 use crate::core::action::{ActionEngine, ActionEngineConfig, DigestCollector, InFlightTracker};
 use crate::core::event::{self, EventBus, SecurityEvent, Severity};
+use crate::core::event_store::{EventStore, EventStoreRuntimeConfig};
 use crate::core::health::HealthChecker;
 use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
@@ -52,6 +53,7 @@ impl Daemon {
         let mut inflight_tracker: Option<InFlightTracker> = None;
         let mut metrics_config_sender: Option<watch::Sender<u64>> = None;
         let mut digest_config_sender: Option<watch::Sender<DigestConfig>> = None;
+        let mut event_store_config_sender: Option<watch::Sender<EventStoreRuntimeConfig>> = None;
         let event_bus = if self.config.event_bus.enabled {
             let bus = EventBus::with_filters(
                 self.config.event_bus.channel_capacity,
@@ -100,6 +102,24 @@ impl Daemon {
                     min_events = digest_cfg.min_events,
                     "ダイジェストコレクターを起動しました"
                 );
+            }
+
+            // イベントストアの起動
+            if self.config.event_store.enabled {
+                match EventStore::new(&self.config.event_store, &bus) {
+                    Ok((store, sender)) => {
+                        event_store_config_sender = Some(sender);
+                        store.spawn();
+                        tracing::info!(
+                            database_path = %self.config.event_store.database_path,
+                            retention_days = self.config.event_store.retention_days,
+                            "イベントストアを起動しました"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "イベントストアの初期化に失敗しました");
+                    }
+                }
             }
 
             tracing::info!(
@@ -366,6 +386,27 @@ impl Daemon {
                                 } else {
                                     tracing::warn!(
                                         "ダイジェストコレクターの設定リロードに失敗しました（受信側が閉じています）"
+                                    );
+                                }
+                            }
+
+                            // イベントストアのリロード
+                            if let Some(ref sender) = event_store_config_sender {
+                                if new_config.event_store.database_path
+                                    != self.config.event_store.database_path
+                                {
+                                    tracing::warn!(
+                                        "event_store.database_path の変更はホットリロードに対応していません。デーモンを再起動してください"
+                                    );
+                                }
+                                let new_runtime = EventStoreRuntimeConfig::from(&new_config.event_store);
+                                if sender.send(new_runtime).is_ok() {
+                                    tracing::info!(
+                                        "イベントストアの設定をリロードしました"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        "イベントストアの設定リロードに失敗しました（受信側が閉じています）"
                                     );
                                 }
                             }

--- a/src/core/event_store.rs
+++ b/src/core/event_store.rs
@@ -1,0 +1,602 @@
+//! イベントストア — SecurityEvent の SQLite 永続化
+
+use crate::config::EventStoreConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use crate::error::AppError;
+use rusqlite::{Connection, params};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::{broadcast, watch};
+
+/// ホットリロード対象のランタイム設定
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventStoreRuntimeConfig {
+    /// イベント保持期間（日数）
+    pub retention_days: u64,
+    /// バッチ挿入サイズ
+    pub batch_size: usize,
+    /// バッチフラッシュ間隔（秒）
+    pub batch_interval_secs: u64,
+    /// クリーンアップ実行間隔（時間）
+    pub cleanup_interval_hours: u64,
+}
+
+impl From<&EventStoreConfig> for EventStoreRuntimeConfig {
+    fn from(config: &EventStoreConfig) -> Self {
+        Self {
+            retention_days: config.retention_days,
+            batch_size: config.batch_size,
+            batch_interval_secs: config.batch_interval_secs,
+            cleanup_interval_hours: config.cleanup_interval_hours,
+        }
+    }
+}
+
+/// イベントストア — イベントバスのサブスクライバーとして動作し、
+/// SecurityEvent を SQLite に永続保存する
+pub struct EventStore {
+    receiver: broadcast::Receiver<SecurityEvent>,
+    config_receiver: watch::Receiver<EventStoreRuntimeConfig>,
+    conn: Arc<StdMutex<Connection>>,
+    batch_size: usize,
+    batch_interval: Duration,
+    cleanup_interval: Duration,
+}
+
+/// SQLite データベースを初期化する（テーブル作成・PRAGMA 設定）
+fn init_database(conn: &Connection) -> Result<(), AppError> {
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = NORMAL;
+         PRAGMA busy_timeout = 5000;",
+    )
+    .map_err(|e| AppError::EventStore {
+        message: format!("PRAGMA 設定に失敗: {}", e),
+    })?;
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS security_events (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp     INTEGER NOT NULL,
+            severity      TEXT    NOT NULL,
+            source_module TEXT    NOT NULL,
+            event_type    TEXT    NOT NULL,
+            message       TEXT    NOT NULL,
+            details       TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_security_events_timestamp
+            ON security_events (timestamp);
+        CREATE INDEX IF NOT EXISTS idx_security_events_module_severity
+            ON security_events (source_module, severity);",
+    )
+    .map_err(|e| AppError::EventStore {
+        message: format!("テーブル作成に失敗: {}", e),
+    })?;
+
+    Ok(())
+}
+
+impl EventStore {
+    /// 設定とイベントバスから EventStore を構築する
+    pub fn new(
+        config: &EventStoreConfig,
+        event_bus: &EventBus,
+    ) -> Result<(Self, watch::Sender<EventStoreRuntimeConfig>), AppError> {
+        let conn = Connection::open(&config.database_path).map_err(|e| AppError::EventStore {
+            message: format!("データベースを開けません ({}): {}", config.database_path, e),
+        })?;
+
+        init_database(&conn)?;
+
+        let runtime_config = EventStoreRuntimeConfig::from(config);
+        let (config_sender, config_receiver) = watch::channel(runtime_config.clone());
+
+        Ok((
+            Self {
+                receiver: event_bus.subscribe(),
+                config_receiver,
+                conn: Arc::new(StdMutex::new(conn)),
+                batch_size: runtime_config.batch_size,
+                batch_interval: Duration::from_secs(runtime_config.batch_interval_secs),
+                cleanup_interval: Duration::from_secs(runtime_config.cleanup_interval_hours * 3600),
+            },
+            config_sender,
+        ))
+    }
+
+    /// インメモリデータベースで EventStore を構築する（テスト用）
+    #[cfg(test)]
+    pub fn new_in_memory(
+        event_bus: &EventBus,
+        config: &EventStoreConfig,
+    ) -> Result<(Self, watch::Sender<EventStoreRuntimeConfig>), AppError> {
+        let conn = Connection::open_in_memory().map_err(|e| AppError::EventStore {
+            message: format!("インメモリデータベースの作成に失敗: {}", e),
+        })?;
+
+        init_database(&conn)?;
+
+        let runtime_config = EventStoreRuntimeConfig::from(config);
+        let (config_sender, config_receiver) = watch::channel(runtime_config.clone());
+
+        Ok((
+            Self {
+                receiver: event_bus.subscribe(),
+                config_receiver,
+                conn: Arc::new(StdMutex::new(conn)),
+                batch_size: runtime_config.batch_size,
+                batch_interval: Duration::from_secs(runtime_config.batch_interval_secs),
+                cleanup_interval: Duration::from_secs(runtime_config.cleanup_interval_hours * 3600),
+            },
+            config_sender,
+        ))
+    }
+
+    /// 非同期タスクとしてイベントストアを起動する
+    pub fn spawn(self) {
+        tokio::spawn(async move {
+            Self::run_loop(
+                self.receiver,
+                self.config_receiver,
+                self.conn,
+                self.batch_size,
+                self.batch_interval,
+                self.cleanup_interval,
+            )
+            .await;
+        });
+    }
+
+    async fn run_loop(
+        mut receiver: broadcast::Receiver<SecurityEvent>,
+        mut config_receiver: watch::Receiver<EventStoreRuntimeConfig>,
+        conn: Arc<StdMutex<Connection>>,
+        mut batch_size: usize,
+        batch_interval: Duration,
+        cleanup_interval: Duration,
+    ) {
+        let mut buffer: Vec<SecurityEvent> = Vec::new();
+        let mut batch_ticker = tokio::time::interval(batch_interval);
+        batch_ticker.tick().await; // 最初の tick をスキップ
+
+        let mut cleanup_ticker = tokio::time::interval(cleanup_interval);
+        cleanup_ticker.tick().await; // 最初の tick をスキップ
+
+        let mut retention_days: u64 = {
+            let cfg = config_receiver.borrow();
+            cfg.retention_days
+        };
+
+        loop {
+            tokio::select! {
+                result = receiver.recv() => {
+                    match result {
+                        Ok(event) => {
+                            buffer.push(event);
+                            if buffer.len() >= batch_size {
+                                let events = std::mem::take(&mut buffer);
+                                Self::flush_batch(&conn, events).await;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                skipped = n,
+                                "イベントストア: {} 件のイベントをスキップ（遅延）",
+                                n
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            if !buffer.is_empty() {
+                                let events = std::mem::take(&mut buffer);
+                                Self::flush_batch(&conn, events).await;
+                            }
+                            tracing::info!("イベントバスが閉じられました。イベントストアを終了します");
+                            break;
+                        }
+                    }
+                }
+                _ = batch_ticker.tick() => {
+                    if !buffer.is_empty() {
+                        let events = std::mem::take(&mut buffer);
+                        Self::flush_batch(&conn, events).await;
+                    }
+                }
+                _ = cleanup_ticker.tick() => {
+                    Self::cleanup_old_events(&conn, retention_days).await;
+                }
+                result = config_receiver.changed() => {
+                    match result {
+                        Ok(()) => {
+                            let new_config = config_receiver.borrow_and_update().clone();
+                            tracing::info!(
+                                retention_days = new_config.retention_days,
+                                batch_size = new_config.batch_size,
+                                batch_interval_secs = new_config.batch_interval_secs,
+                                cleanup_interval_hours = new_config.cleanup_interval_hours,
+                                "イベントストア: 設定をリロードしました"
+                            );
+                            batch_size = new_config.batch_size;
+                            retention_days = new_config.retention_days;
+
+                            let new_batch_interval = Duration::from_secs(new_config.batch_interval_secs);
+                            batch_ticker = tokio::time::interval(new_batch_interval);
+                            batch_ticker.tick().await;
+
+                            let new_cleanup_interval = Duration::from_secs(new_config.cleanup_interval_hours * 3600);
+                            cleanup_ticker = tokio::time::interval(new_cleanup_interval);
+                            cleanup_ticker.tick().await;
+                        }
+                        Err(_) => {
+                            tracing::info!("設定チャネルが閉じられました。イベントストアを終了します");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn flush_batch(conn: &Arc<StdMutex<Connection>>, events: Vec<SecurityEvent>) {
+        let count = events.len();
+        let conn = Arc::clone(conn);
+        let result = tokio::task::spawn_blocking(move || {
+            // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+            let mut conn = conn.lock().unwrap();
+            Self::insert_events(&mut conn, &events)
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => {
+                tracing::debug!(
+                    count = count,
+                    "イベントストア: {} 件のイベントを保存しました",
+                    count
+                );
+            }
+            Ok(Err(e)) => {
+                tracing::error!(error = %e, count = count, "イベントストア: バッチ挿入に失敗");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "イベントストア: spawn_blocking タスクがパニックしました");
+            }
+        }
+    }
+
+    fn insert_events(conn: &mut Connection, events: &[SecurityEvent]) -> Result<(), AppError> {
+        let tx = conn.transaction().map_err(|e| AppError::EventStore {
+            message: format!("トランザクション開始に失敗: {}", e),
+        })?;
+
+        {
+            let mut stmt = tx
+                .prepare_cached(
+                    "INSERT INTO security_events (timestamp, severity, source_module, event_type, message, details)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                )
+                .map_err(|e| AppError::EventStore {
+                    message: format!("プリペアドステートメントの作成に失敗: {}", e),
+                })?;
+
+            for event in events {
+                let timestamp = event
+                    .timestamp
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as i64;
+                let severity = match event.severity {
+                    Severity::Info => "INFO",
+                    Severity::Warning => "WARNING",
+                    Severity::Critical => "CRITICAL",
+                };
+
+                stmt.execute(params![
+                    timestamp,
+                    severity,
+                    event.source_module,
+                    event.event_type,
+                    event.message,
+                    event.details,
+                ])
+                .map_err(|e| AppError::EventStore {
+                    message: format!("イベント挿入に失敗: {}", e),
+                })?;
+            }
+        }
+
+        tx.commit().map_err(|e| AppError::EventStore {
+            message: format!("コミットに失敗: {}", e),
+        })?;
+
+        Ok(())
+    }
+
+    async fn cleanup_old_events(conn: &Arc<StdMutex<Connection>>, retention_days: u64) {
+        let conn = Arc::clone(conn);
+        let result = tokio::task::spawn_blocking(move || {
+            let cutoff = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs()
+                .saturating_sub(retention_days * 86400) as i64;
+
+            // unwrap safety: Mutex が poisoned になるのはパニック時のみ
+            let conn = conn.lock().unwrap();
+            conn.execute(
+                "DELETE FROM security_events WHERE timestamp < ?1",
+                params![cutoff],
+            )
+        })
+        .await;
+
+        match result {
+            Ok(Ok(deleted)) => {
+                if deleted > 0 {
+                    tracing::info!(
+                        deleted = deleted,
+                        retention_days = retention_days,
+                        "イベントストア: {} 件の古いイベントを削除しました",
+                        deleted
+                    );
+                }
+            }
+            Ok(Err(e)) => {
+                tracing::error!(error = %e, "イベントストア: クリーンアップに失敗");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "イベントストア: spawn_blocking タスクがパニックしました");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::event::EventBus;
+
+    fn test_config() -> EventStoreConfig {
+        EventStoreConfig {
+            enabled: true,
+            database_path: String::new(),
+            retention_days: 90,
+            batch_size: 10,
+            batch_interval_secs: 1,
+            cleanup_interval_hours: 24,
+        }
+    }
+
+    #[test]
+    fn test_init_database() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        // テーブルが作成されていることを確認
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='security_events'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_init_database_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name LIKE 'idx_security_events_%'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_insert_events() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let events = vec![
+            SecurityEvent::new(
+                "test_event",
+                Severity::Info,
+                "test_module",
+                "テストイベント1",
+            ),
+            SecurityEvent::new(
+                "test_event",
+                Severity::Warning,
+                "test_module",
+                "テストイベント2",
+            ),
+            SecurityEvent::new(
+                "critical_event",
+                Severity::Critical,
+                "another_module",
+                "重大イベント",
+            )
+            .with_details("詳細情報"),
+        ];
+
+        EventStore::insert_events(&mut conn, &events).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+
+        // details が正しく保存されていることを確認
+        let details: Option<String> = conn
+            .query_row(
+                "SELECT details FROM security_events WHERE event_type = 'critical_event'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(details.as_deref(), Some("詳細情報"));
+    }
+
+    #[test]
+    fn test_insert_events_empty() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        EventStore::insert_events(&mut conn, &[]).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_event_store_new_in_memory() {
+        let bus = EventBus::new(16);
+        let config = test_config();
+        let result = EventStore::new_in_memory(&bus, &config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_runtime_config_from_event_store_config() {
+        let config = EventStoreConfig {
+            enabled: true,
+            database_path: "/tmp/test.db".to_string(),
+            retention_days: 30,
+            batch_size: 50,
+            batch_interval_secs: 10,
+            cleanup_interval_hours: 12,
+        };
+        let runtime = EventStoreRuntimeConfig::from(&config);
+        assert_eq!(runtime.retention_days, 30);
+        assert_eq!(runtime.batch_size, 50);
+        assert_eq!(runtime.batch_interval_secs, 10);
+        assert_eq!(runtime.cleanup_interval_hours, 12);
+    }
+
+    #[tokio::test]
+    async fn test_event_store_receives_and_stores_events() {
+        let bus = EventBus::new(16);
+        let config = EventStoreConfig {
+            enabled: true,
+            database_path: String::new(),
+            retention_days: 90,
+            batch_size: 2,
+            batch_interval_secs: 60,
+            cleanup_interval_hours: 24,
+        };
+        let (store, _sender) = EventStore::new_in_memory(&bus, &config).unwrap();
+        let conn = Arc::clone(&store.conn);
+        store.spawn();
+
+        // イベントを発行（batch_size=2 なので2件でフラッシュされる）
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Info,
+            "test_module",
+            "テストイベント1",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Warning,
+            "test_module",
+            "テストイベント2",
+        ));
+
+        // イベントストアが処理する時間を与える
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let count: i64 = {
+            let conn = conn.lock().unwrap();
+            conn.query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+                .unwrap()
+        };
+        assert_eq!(count, 2);
+    }
+
+    #[tokio::test]
+    async fn test_event_store_batch_timer_flush() {
+        let bus = EventBus::new(16);
+        let config = EventStoreConfig {
+            enabled: true,
+            database_path: String::new(),
+            retention_days: 90,
+            batch_size: 100, // 大きいバッチサイズ
+            batch_interval_secs: 1,
+            cleanup_interval_hours: 24,
+        };
+        let (store, _sender) = EventStore::new_in_memory(&bus, &config).unwrap();
+        let conn = Arc::clone(&store.conn);
+        store.spawn();
+
+        // 1件だけ発行（batch_size に達しない）
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Info,
+            "test_module",
+            "テストイベント",
+        ));
+
+        // バッチタイマー（1秒）でフラッシュされるのを待つ
+        tokio::time::sleep(Duration::from_secs(2)).await;
+
+        let count: i64 = {
+            let conn = conn.lock().unwrap();
+            conn.query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+                .unwrap()
+        };
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_event_store_config_reload() {
+        let bus = EventBus::new(16);
+        let config = test_config();
+        let (store, sender) = EventStore::new_in_memory(&bus, &config).unwrap();
+        store.spawn();
+
+        // 設定変更を送信
+        let new_config = EventStoreRuntimeConfig {
+            retention_days: 30,
+            batch_size: 50,
+            batch_interval_secs: 10,
+            cleanup_interval_hours: 12,
+        };
+        sender.send(new_config).unwrap();
+
+        // 変更が処理される時間を与える
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        // パニックせずに動作することを確認
+    }
+
+    #[tokio::test]
+    async fn test_event_store_config_channel_closed() {
+        let bus = EventBus::new(16);
+        let config = test_config();
+        let (store, sender) = EventStore::new_in_memory(&bus, &config).unwrap();
+        store.spawn();
+
+        // sender をドロップしてチャネルを閉じる
+        drop(sender);
+
+        // イベントストアが正常に終了することを確認
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    #[test]
+    fn test_event_store_config_default() {
+        let config = EventStoreConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.database_path, "/var/lib/zettai-mamorukun/events.db");
+        assert_eq!(config.retention_days, 90);
+        assert_eq!(config.batch_size, 100);
+        assert_eq!(config.batch_interval_secs, 5);
+        assert_eq!(config.cleanup_interval_hours, 24);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub mod action;
 pub mod daemon;
 pub mod event;
+pub mod event_store;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,4 +67,8 @@ pub enum AppError {
     /// ステータスサーバーエラー
     #[error("ステータスサーバーエラー: {message}")]
     StatusServer { message: String },
+
+    /// イベントストアエラー
+    #[error("イベントストアエラー: {message}")]
+    EventStore { message: String },
 }


### PR DESCRIPTION
## Summary
- SecurityEvent を SQLite データベースに永続保存するイベントストア機能を追加
- イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
- `rusqlite` クレート（bundled）を使用、WAL モードで書き込みパフォーマンスを確保

## 変更内容
- `src/core/event_store.rs`: EventStore 本体（バッチ挿入、クリーンアップ、ホットリロード）
- `src/config.rs`: EventStoreConfig 追加（enabled, database_path, retention_days, batch_size 等）
- `src/core/daemon.rs`: EventStore の初期化・ホットリロード統合
- `src/error.rs`: EventStore エラーバリアント追加
- `config.example.toml`: event_store セクション追加
- `CLAUDE.md`: ドキュメント更新

## Test plan
- [x] 全38テスト通過（`cargo test`）
- [x] `cargo clippy -- -D warnings` 警告なし
- [x] `cargo fmt --check` フォーマット準拠
- [x] `cargo build --release` ビルド成功

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)