### PR TITLE
feat: CLI イベント検索コマンドの実装 (#133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.64.0"
+version = "0.65.0"
 dependencies = [
  "clap",
  "inotify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.64.0"
+version = "0.65.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/src/core/event_store.rs
+++ b/src/core/event_store.rs
@@ -3,7 +3,8 @@
 use crate::config::EventStoreConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
 use crate::error::AppError;
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, OpenFlags, params};
+use serde::Serialize;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, watch};
@@ -350,6 +351,278 @@ impl EventStore {
     }
 }
 
+/// イベント検索クエリ条件
+pub struct EventQuery {
+    /// ソースモジュール名フィルタ
+    pub module: Option<String>,
+    /// 重要度フィルタ（"INFO", "WARNING", "CRITICAL"）
+    pub severity: Option<String>,
+    /// 開始タイムスタンプ（UNIX 秒、以上）
+    pub since: Option<i64>,
+    /// 終了タイムスタンプ（UNIX 秒、以下）
+    pub until: Option<i64>,
+    /// イベント種別フィルタ
+    pub event_type: Option<String>,
+    /// 表示件数上限
+    pub limit: u32,
+}
+
+/// 検索結果のイベントレコード
+#[derive(Debug, Serialize)]
+pub struct EventRecord {
+    /// レコード ID
+    pub id: i64,
+    /// タイムスタンプ（UNIX 秒）
+    pub timestamp: i64,
+    /// 重要度
+    pub severity: String,
+    /// ソースモジュール名
+    pub source_module: String,
+    /// イベント種別
+    pub event_type: String,
+    /// メッセージ
+    pub message: String,
+    /// 追加情報
+    pub details: Option<String>,
+}
+
+/// 読み取り専用で SQLite データベースを開く（CLI 検索用）
+pub fn open_readonly(db_path: &str) -> Result<Connection, AppError> {
+    Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| AppError::EventStore {
+        message: format!("データベースを開けません ({}): {}", db_path, e),
+    })
+}
+
+/// 指定された条件でイベントを検索する
+pub fn query_events(conn: &Connection, query: &EventQuery) -> Result<Vec<EventRecord>, AppError> {
+    let mut sql = String::from(
+        "SELECT id, timestamp, severity, source_module, event_type, message, details \
+         FROM security_events WHERE 1=1",
+    );
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+
+    if let Some(module) = &query.module {
+        sql.push_str(&format!(" AND source_module = ?{}", idx));
+        param_values.push(Box::new(module.clone()));
+        idx += 1;
+    }
+    if let Some(severity) = &query.severity {
+        sql.push_str(&format!(" AND severity = ?{}", idx));
+        param_values.push(Box::new(severity.to_uppercase()));
+        idx += 1;
+    }
+    if let Some(since) = query.since {
+        sql.push_str(&format!(" AND timestamp >= ?{}", idx));
+        param_values.push(Box::new(since));
+        idx += 1;
+    }
+    if let Some(until) = query.until {
+        sql.push_str(&format!(" AND timestamp <= ?{}", idx));
+        param_values.push(Box::new(until));
+        idx += 1;
+    }
+    if let Some(event_type) = &query.event_type {
+        sql.push_str(&format!(" AND event_type = ?{}", idx));
+        param_values.push(Box::new(event_type.clone()));
+        idx += 1;
+    }
+
+    sql.push_str(&format!(" ORDER BY timestamp DESC LIMIT ?{}", idx));
+    param_values.push(Box::new(query.limit));
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        param_values.iter().map(|p| p.as_ref()).collect();
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| AppError::EventStore {
+        message: format!("クエリの準備に失敗: {}", e),
+    })?;
+
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(EventRecord {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                severity: row.get(2)?,
+                source_module: row.get(3)?,
+                event_type: row.get(4)?,
+                message: row.get(5)?,
+                details: row.get(6)?,
+            })
+        })
+        .map_err(|e| AppError::EventStore {
+            message: format!("クエリの実行に失敗: {}", e),
+        })?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.map_err(|e| AppError::EventStore {
+            message: format!("行の読み取りに失敗: {}", e),
+        })?);
+    }
+
+    Ok(records)
+}
+
+/// UNIX タイムスタンプを "YYYY-MM-DD HH:MM:SS" (UTC) 形式に変換する
+pub fn format_timestamp(ts: i64) -> String {
+    let secs_per_day: i64 = 86400;
+    let secs_per_hour: i64 = 3600;
+    let secs_per_min: i64 = 60;
+
+    let days = ts / secs_per_day;
+    let remaining = ts % secs_per_day;
+    let hour = remaining / secs_per_hour;
+    let min = (remaining % secs_per_hour) / secs_per_min;
+    let sec = remaining % secs_per_min;
+
+    // 1970-01-01 からの日数を年月日に変換
+    let (year, month, day) = days_to_ymd(days);
+
+    format!(
+        "{:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+        year, month, day, hour, min, sec
+    )
+}
+
+/// UNIX タイムスタンプを ISO 8601 形式に変換する（JSON 出力用）
+pub fn format_timestamp_iso(ts: i64) -> String {
+    let secs_per_day: i64 = 86400;
+    let secs_per_hour: i64 = 3600;
+    let secs_per_min: i64 = 60;
+
+    let days = ts / secs_per_day;
+    let remaining = ts % secs_per_day;
+    let hour = remaining / secs_per_hour;
+    let min = (remaining % secs_per_hour) / secs_per_min;
+    let sec = remaining % secs_per_min;
+
+    let (year, month, day) = days_to_ymd(days);
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, min, sec
+    )
+}
+
+/// 1970-01-01 からの日数を (year, month, day) に変換する
+fn days_to_ymd(mut days: i64) -> (i64, u32, u32) {
+    // 1970-01-01 = day 0
+    let mut year = 1970;
+
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if days < days_in_year {
+            break;
+        }
+        days -= days_in_year;
+        year += 1;
+    }
+
+    let leap = is_leap_year(year);
+    let months_days = if leap {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut month = 0;
+    for (i, &d) in months_days.iter().enumerate() {
+        if days < d as i64 {
+            month = i as u32 + 1;
+            break;
+        }
+        days -= d as i64;
+    }
+
+    (year, month, days as u32 + 1)
+}
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+/// 日時文字列を UNIX タイムスタンプ（秒）に変換する
+///
+/// サポート形式:
+/// - `YYYY-MM-DD` → その日の 00:00:00 UTC
+/// - `YYYY-MM-DD HH:MM:SS` → UTC
+pub fn parse_datetime(s: &str) -> Result<i64, String> {
+    let parts: Vec<&str> = s.split(' ').collect();
+    let (date_str, time_str) = match parts.len() {
+        1 => (parts[0], "00:00:00"),
+        2 => (parts[0], parts[1]),
+        _ => return Err(format!("不正な日時形式です: {}", s)),
+    };
+
+    let date_parts: Vec<&str> = date_str.split('-').collect();
+    if date_parts.len() != 3 {
+        return Err(format!("不正な日付形式です (YYYY-MM-DD): {}", date_str));
+    }
+
+    let year: i64 = date_parts[0]
+        .parse()
+        .map_err(|_| format!("不正な年: {}", date_parts[0]))?;
+    let month: u32 = date_parts[1]
+        .parse()
+        .map_err(|_| format!("不正な月: {}", date_parts[1]))?;
+    let day: u32 = date_parts[2]
+        .parse()
+        .map_err(|_| format!("不正な日: {}", date_parts[2]))?;
+
+    if !(1..=12).contains(&month) {
+        return Err(format!("月は 1-12 の範囲で指定してください: {}", month));
+    }
+    if !(1..=31).contains(&day) {
+        return Err(format!("日は 1-31 の範囲で指定してください: {}", day));
+    }
+
+    let time_parts: Vec<&str> = time_str.split(':').collect();
+    if time_parts.len() != 3 {
+        return Err(format!("不正な時刻形式です (HH:MM:SS): {}", time_str));
+    }
+
+    let hour: u32 = time_parts[0]
+        .parse()
+        .map_err(|_| format!("不正な時: {}", time_parts[0]))?;
+    let min: u32 = time_parts[1]
+        .parse()
+        .map_err(|_| format!("不正な分: {}", time_parts[1]))?;
+    let sec: u32 = time_parts[2]
+        .parse()
+        .map_err(|_| format!("不正な秒: {}", time_parts[2]))?;
+
+    if hour >= 24 || min >= 60 || sec >= 60 {
+        return Err(format!("不正な時刻です: {}", time_str));
+    }
+
+    // 1970-01-01 からの日数を計算
+    let mut total_days: i64 = 0;
+    for y in 1970..year {
+        total_days += if is_leap_year(y) { 366 } else { 365 };
+    }
+
+    let leap = is_leap_year(year);
+    let months_days = if leap {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    for &d in months_days.iter().take(month as usize - 1) {
+        total_days += d as i64;
+    }
+    total_days += (day as i64) - 1;
+
+    let timestamp = total_days * 86400 + (hour as i64) * 3600 + (min as i64) * 60 + (sec as i64);
+
+    Ok(timestamp)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -598,5 +871,197 @@ mod tests {
         assert_eq!(config.batch_size, 100);
         assert_eq!(config.batch_interval_secs, 5);
         assert_eq!(config.cleanup_interval_hours, 24);
+    }
+
+    #[test]
+    fn test_parse_datetime_date_only() {
+        let ts = parse_datetime("2026-04-05").unwrap();
+        // 2026-04-05 00:00:00 UTC
+        assert_eq!(format_timestamp(ts), "2026-04-05 00:00:00");
+    }
+
+    #[test]
+    fn test_parse_datetime_full() {
+        let ts = parse_datetime("2026-04-05 12:34:56").unwrap();
+        assert_eq!(format_timestamp(ts), "2026-04-05 12:34:56");
+    }
+
+    #[test]
+    fn test_parse_datetime_epoch() {
+        let ts = parse_datetime("1970-01-01").unwrap();
+        assert_eq!(ts, 0);
+    }
+
+    #[test]
+    fn test_parse_datetime_invalid() {
+        assert!(parse_datetime("not-a-date").is_err());
+        assert!(parse_datetime("2026-13-01").is_err());
+        assert!(parse_datetime("2026-04-05 25:00:00").is_err());
+    }
+
+    #[test]
+    fn test_format_timestamp_roundtrip() {
+        let original = "2026-01-15 08:30:45";
+        let ts = parse_datetime(original).unwrap();
+        assert_eq!(format_timestamp(ts), original);
+    }
+
+    #[test]
+    fn test_format_timestamp_iso() {
+        let ts = parse_datetime("2026-04-05 12:34:56").unwrap();
+        assert_eq!(format_timestamp_iso(ts), "2026-04-05T12:34:56Z");
+    }
+
+    #[test]
+    fn test_query_events_empty() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let query = EventQuery {
+            module: None,
+            severity: None,
+            since: None,
+            until: None,
+            event_type: None,
+            limit: 100,
+        };
+        let results = query_events(&conn, &query).unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_query_events_with_data() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let events = vec![
+            SecurityEvent::new(
+                "file_modified",
+                Severity::Warning,
+                "file_integrity",
+                "ファイル変更",
+            ),
+            SecurityEvent::new(
+                "brute_force",
+                Severity::Critical,
+                "ssh_brute_force",
+                "SSH攻撃",
+            ),
+            SecurityEvent::new(
+                "process_anomaly",
+                Severity::Info,
+                "process_monitor",
+                "異常プロセス",
+            ),
+        ];
+        EventStore::insert_events(&mut conn, &events).unwrap();
+
+        // 全件取得
+        let query = EventQuery {
+            module: None,
+            severity: None,
+            since: None,
+            until: None,
+            event_type: None,
+            limit: 100,
+        };
+        let results = query_events(&conn, &query).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_query_events_filter_module() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let events = vec![
+            SecurityEvent::new(
+                "file_modified",
+                Severity::Warning,
+                "file_integrity",
+                "ファイル変更",
+            ),
+            SecurityEvent::new(
+                "brute_force",
+                Severity::Critical,
+                "ssh_brute_force",
+                "SSH攻撃",
+            ),
+        ];
+        EventStore::insert_events(&mut conn, &events).unwrap();
+
+        let query = EventQuery {
+            module: Some("ssh_brute_force".to_string()),
+            severity: None,
+            since: None,
+            until: None,
+            event_type: None,
+            limit: 100,
+        };
+        let results = query_events(&conn, &query).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].source_module, "ssh_brute_force");
+    }
+
+    #[test]
+    fn test_query_events_filter_severity() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let events = vec![
+            SecurityEvent::new("ev1", Severity::Info, "mod1", "情報"),
+            SecurityEvent::new("ev2", Severity::Critical, "mod2", "重大"),
+        ];
+        EventStore::insert_events(&mut conn, &events).unwrap();
+
+        let query = EventQuery {
+            module: None,
+            severity: Some("CRITICAL".to_string()),
+            since: None,
+            until: None,
+            event_type: None,
+            limit: 100,
+        };
+        let results = query_events(&conn, &query).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].severity, "CRITICAL");
+    }
+
+    #[test]
+    fn test_query_events_limit() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let events: Vec<SecurityEvent> = (0..10)
+            .map(|i| SecurityEvent::new("ev", Severity::Info, "mod", &format!("イベント{}", i)))
+            .collect();
+        EventStore::insert_events(&mut conn, &events).unwrap();
+
+        let query = EventQuery {
+            module: None,
+            severity: None,
+            since: None,
+            until: None,
+            event_type: None,
+            limit: 3,
+        };
+        let results = query_events(&conn, &query).unwrap();
+        assert_eq!(results.len(), 3);
+    }
+
+    #[test]
+    fn test_days_to_ymd() {
+        assert_eq!(days_to_ymd(0), (1970, 1, 1));
+        assert_eq!(days_to_ymd(365), (1971, 1, 1));
+        // 2000-03-01 (leap year)
+        assert_eq!(days_to_ymd(11017), (2000, 3, 1));
+    }
+
+    #[test]
+    fn test_leap_year() {
+        assert!(is_leap_year(2000));
+        assert!(is_leap_year(2024));
+        assert!(!is_leap_year(1900));
+        assert!(!is_leap_year(2023));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use zettai_mamorukun::config::AppConfig;
 use zettai_mamorukun::core::daemon::Daemon;
+use zettai_mamorukun::core::event_store;
 use zettai_mamorukun::core::status;
 use zettai_mamorukun::error::AppError;
 
@@ -51,6 +52,33 @@ enum Commands {
         /// JSON 形式で出力
         #[arg(long)]
         json: bool,
+    },
+    /// 永続化されたセキュリティイベントを検索する
+    SearchEvents {
+        /// ソースモジュール名でフィルタ
+        #[arg(long, value_name = "NAME")]
+        module: Option<String>,
+        /// 重要度でフィルタ (INFO, WARNING, CRITICAL)
+        #[arg(long, value_name = "LEVEL")]
+        severity: Option<String>,
+        /// 指定日時以降のイベントを表示 (YYYY-MM-DD or YYYY-MM-DD HH:MM:SS)
+        #[arg(long, value_name = "DATETIME")]
+        since: Option<String>,
+        /// 指定日時以前のイベントを表示 (YYYY-MM-DD or YYYY-MM-DD HH:MM:SS)
+        #[arg(long, value_name = "DATETIME")]
+        until: Option<String>,
+        /// イベント種別でフィルタ
+        #[arg(long, value_name = "TYPE")]
+        event_type: Option<String>,
+        /// 表示件数の上限
+        #[arg(long, default_value = "100", value_name = "N")]
+        limit: u32,
+        /// JSON Lines 形式で出力
+        #[arg(long)]
+        json: bool,
+        /// データベースファイルパス（省略時は設定ファイルの値を使用）
+        #[arg(long, value_name = "PATH")]
+        db: Option<String>,
     },
 }
 
@@ -214,6 +242,142 @@ fn run_check_config_diff(config_path: &Path) -> Result<(), Box<dyn std::error::E
     Ok(())
 }
 
+/// イベント検索を実行する
+#[allow(clippy::too_many_arguments)]
+fn run_search_events(
+    config_path: &Path,
+    module: &Option<String>,
+    severity: &Option<String>,
+    since: &Option<String>,
+    until: &Option<String>,
+    event_type: &Option<String>,
+    limit: u32,
+    json: bool,
+    db: &Option<String>,
+) {
+    // severity の値を検証
+    if let Some(sev) = severity {
+        let upper = sev.to_uppercase();
+        if upper != "INFO" && upper != "WARNING" && upper != "CRITICAL" {
+            eprintln!(
+                "エラー: 不正な重要度です: {} (INFO, WARNING, CRITICAL のいずれかを指定してください)",
+                sev
+            );
+            process::exit(1);
+        }
+    }
+
+    // 日時パース
+    let since_ts = since.as_ref().map(|s| {
+        event_store::parse_datetime(s).unwrap_or_else(|e| {
+            eprintln!("エラー: --since の値が不正です: {}", e);
+            process::exit(1);
+        })
+    });
+
+    let until_ts = until.as_ref().map(|s| {
+        event_store::parse_datetime(s).unwrap_or_else(|e| {
+            eprintln!("エラー: --until の値が不正です: {}", e);
+            process::exit(1);
+        })
+    });
+
+    // DB パスを決定: --db > 設定ファイル
+    let db_path = if let Some(path) = db {
+        path.clone()
+    } else {
+        match AppConfig::load(config_path) {
+            Ok(config) => config.event_store.database_path,
+            Err(_) => {
+                // 設定ファイルが読めない場合はデフォルトパスを使用
+                "/var/lib/zettai-mamorukun/events.db".to_string()
+            }
+        }
+    };
+
+    // DB を開く
+    let conn = match event_store::open_readonly(&db_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("エラー: {}", e);
+            process::exit(1);
+        }
+    };
+
+    // クエリ実行
+    let query = event_store::EventQuery {
+        module: module.clone(),
+        severity: severity.as_ref().map(|s| s.to_uppercase()),
+        since: since_ts,
+        until: until_ts,
+        event_type: event_type.clone(),
+        limit,
+    };
+
+    let records = match event_store::query_events(&conn, &query) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("エラー: {}", e);
+            process::exit(1);
+        }
+    };
+
+    if records.is_empty() {
+        eprintln!("該当するイベントはありません。");
+        return;
+    }
+
+    if json {
+        print_json(&records);
+    } else {
+        print_table(&records);
+    }
+
+    eprintln!("{} 件のイベントが見つかりました。", records.len());
+}
+
+/// JSON Lines 形式でイベントを出力する
+fn print_json(records: &[event_store::EventRecord]) {
+    for record in records {
+        // timestamp を ISO 8601 に変換した構造体を出力
+        let json_obj = serde_json::json!({
+            "id": record.id,
+            "timestamp": event_store::format_timestamp_iso(record.timestamp),
+            "severity": record.severity,
+            "source_module": record.source_module,
+            "event_type": record.event_type,
+            "message": record.message,
+            "details": record.details,
+        });
+        // unwrap safety: serde_json::to_string は基本的な型で失敗しない
+        println!("{}", serde_json::to_string(&json_obj).unwrap());
+    }
+}
+
+/// テーブル形式でイベントを出力する
+fn print_table(records: &[event_store::EventRecord]) {
+    println!(
+        "{:<6}| {:<19} | {:<8} | {:<20} | {:<18} | メッセージ",
+        "ID", "日時", "重要度", "モジュール", "種別"
+    );
+    println!(
+        "{}|{}|{}|{}|{}|{}",
+        "-".repeat(6),
+        "-".repeat(21),
+        "-".repeat(10),
+        "-".repeat(22),
+        "-".repeat(20),
+        "-".repeat(30)
+    );
+    for record in records {
+        let ts = event_store::format_timestamp(record.timestamp);
+        println!(
+            "{:<6}| {} | {:<8} | {:<20} | {:<18} | {}",
+            record.id, ts, record.severity, record.source_module, record.event_type, record.message
+        );
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
@@ -239,6 +403,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     process::exit(1);
                 }
             }
+            return Ok(());
+        }
+        Some(Commands::SearchEvents {
+            module,
+            severity,
+            since,
+            until,
+            event_type,
+            limit,
+            json,
+            db,
+        }) => {
+            run_search_events(
+                &cli.config,
+                module,
+                severity,
+                since,
+                until,
+                event_type,
+                *limit,
+                *json,
+                db,
+            );
             return Ok(());
         }
         Some(Commands::ScanDiff {


### PR DESCRIPTION
## 概要

SQLite に永続化されたセキュリティイベントを CLI から検索・フィルタリングする `search-events` サブコマンドを実装。

Closes #133

## 変更内容

- `src/core/event_store.rs`: `EventQuery`, `EventRecord`, `query_events()`, `open_readonly()`, 日時パース/フォーマット関数を追加
- `src/main.rs`: `SearchEvents` サブコマンドとテーブル/JSON 出力を追加
- `Cargo.toml`: バージョンを v0.65.0 に更新

## フィルタリングオプション

| オプション | 説明 |
|---|---|
| `--module` | ソースモジュール名 |
| `--severity` | INFO / WARNING / CRITICAL |
| `--since` / `--until` | 日時範囲（YYYY-MM-DD or YYYY-MM-DD HH:MM:SS） |
| `--event-type` | イベント種別 |
| `--limit` | 表示件数上限（デフォルト: 100） |
| `--json` | JSON Lines 形式で出力 |
| `--db` | DB ファイルパス |

## テスト

- 日時パース/フォーマットのユニットテスト
- クエリ関数のユニットテスト（フィルタ、件数制限）
- 全 1113 テスト通過、clippy 警告なし、fmt チェック通過

## テスト方法

```bash
cargo test
cargo clippy -- -D warnings
cargo fmt --check
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)