### PR TITLE
feat: TLS 証明書有効期限監視モジュールの実装 (#141)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,7 @@ src/
     sudoers_monitor.rs # sudoers ファイル監視モジュール
     suid_sgid_monitor.rs # SUID/SGID ファイル監視モジュール
     systemd_service.rs # systemd サービス監視モジュール
+    tls_cert_monitor.rs # TLS 証明書有効期限監視モジュール
     tmp_exec_monitor.rs # 一時ディレクトリ実行ファイル検知モジュール
     user_account.rs    # ユーザーアカウント監視モジュール
     xattr_monitor.rs   # ファイルシステム xattr（拡張属性）監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +133,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
@@ -237,6 +282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +304,29 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "digest"
@@ -897,6 +971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,12 +988,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -927,6 +1051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +1070,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -970,6 +1113,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1013,7 +1162,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -1034,7 +1183,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1204,6 +1353,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -1466,11 +1624,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1491,6 +1669,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2246,6 +2455,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,12 +2586,13 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "clap",
  "csv",
  "inotify",
  "libc",
+ "pem",
  "regex",
  "reqwest",
  "rusqlite",
@@ -2373,7 +2600,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "toml",
@@ -2381,6 +2608,7 @@ dependencies = [
  "tracing-subscriber",
  "walkdir",
  "wiremock",
+ "x509-parser",
  "xattr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "0.68.0"
+version = "0.69.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -23,6 +23,8 @@ xattr = "1.6"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 csv = "1"
+x509-parser = "0.16"
+pem = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/config.example.toml
+++ b/config.example.toml
@@ -514,6 +514,20 @@ suspicious_ports = [4444, 5555, 6666, 8888, 1337]
 # 接続数閾値
 max_connections = 1000
 
+[modules.tls_cert_monitor]
+# TLS 証明書有効期限監視モジュールの有効/無効
+enabled = false
+# チェック間隔（秒）
+check_interval_secs = 3600
+# 監視対象ディレクトリのリスト
+watch_dirs = ["/etc/ssl/certs", "/etc/pki/tls/certs"]
+# 警告を発行する残日数の閾値
+warning_days = 30
+# 重大アラートを発行する残日数の閾値
+critical_days = 7
+# 対象ファイル拡張子
+file_extensions = [".pem", ".crt", ".cer"]
+
 [modules.ssh_brute_force]
 # SSH ブルートフォース検知モジュールの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -289,6 +289,10 @@ pub struct ModulesConfig {
     /// プロセス起動監視モジュールの設定
     #[serde(default)]
     pub process_exec_monitor: ProcessExecMonitorConfig,
+
+    /// TLS 証明書有効期限監視モジュールの設定
+    #[serde(default)]
+    pub tls_cert_monitor: TlsCertMonitorConfig,
 }
 
 /// ファイル整合性監視モジュールの設定
@@ -715,6 +719,72 @@ impl Default for SshKeyMonitorConfig {
             enabled: false,
             scan_interval_secs: Self::default_scan_interval_secs(),
             watch_paths: Self::default_watch_paths(),
+        }
+    }
+}
+
+/// TLS 証明書有効期限監視モジュールの設定
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct TlsCertMonitorConfig {
+    /// モジュールの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// チェック間隔（秒）
+    #[serde(default = "TlsCertMonitorConfig::default_check_interval_secs")]
+    pub check_interval_secs: u64,
+
+    /// 監視対象ディレクトリのリスト
+    #[serde(default = "TlsCertMonitorConfig::default_watch_dirs")]
+    pub watch_dirs: Vec<PathBuf>,
+
+    /// 警告を発行する残日数の閾値
+    #[serde(default = "TlsCertMonitorConfig::default_warning_days")]
+    pub warning_days: u32,
+
+    /// 重大アラートを発行する残日数の閾値
+    #[serde(default = "TlsCertMonitorConfig::default_critical_days")]
+    pub critical_days: u32,
+
+    /// 対象ファイル拡張子
+    #[serde(default = "TlsCertMonitorConfig::default_file_extensions")]
+    pub file_extensions: Vec<String>,
+}
+
+impl TlsCertMonitorConfig {
+    fn default_check_interval_secs() -> u64 {
+        3600
+    }
+
+    fn default_watch_dirs() -> Vec<PathBuf> {
+        vec![
+            PathBuf::from("/etc/ssl/certs"),
+            PathBuf::from("/etc/pki/tls/certs"),
+        ]
+    }
+
+    fn default_warning_days() -> u32 {
+        30
+    }
+
+    fn default_critical_days() -> u32 {
+        7
+    }
+
+    fn default_file_extensions() -> Vec<String> {
+        vec![".pem".to_string(), ".crt".to_string(), ".cer".to_string()]
+    }
+}
+
+impl Default for TlsCertMonitorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            check_interval_secs: Self::default_check_interval_secs(),
+            watch_dirs: Self::default_watch_dirs(),
+            warning_days: Self::default_warning_days(),
+            critical_days: Self::default_critical_days(),
+            file_extensions: Self::default_file_extensions(),
         }
     }
 }

--- a/src/core/module_manager.rs
+++ b/src/core/module_manager.rs
@@ -38,6 +38,7 @@ use crate::modules::ssh_key_monitor::SshKeyMonitorModule;
 use crate::modules::sudoers_monitor::SudoersMonitorModule;
 use crate::modules::suid_sgid_monitor::SuidSgidMonitorModule;
 use crate::modules::systemd_service::SystemdServiceModule;
+use crate::modules::tls_cert_monitor::TlsCertMonitorModule;
 use crate::modules::tmp_exec_monitor::TmpExecMonitorModule;
 use crate::modules::usb_monitor::UsbMonitorModule;
 use crate::modules::user_account::UserAccountModule;
@@ -682,6 +683,16 @@ impl ModuleManager {
             ProcessExecMonitorModule,
             "プロセス起動監視モジュール"
         );
+        start_module!(
+            modules,
+            config,
+            event_bus,
+            startup_scan_enabled,
+            scan_report,
+            tls_cert_monitor,
+            TlsCertMonitorModule,
+            "TLS 証明書有効期限監視モジュール"
+        );
 
         scan_report.total_duration = scan_start.elapsed();
 
@@ -1022,6 +1033,13 @@ impl ModuleManager {
             process_exec_monitor,
             ProcessExecMonitorModule,
             "プロセス起動監視モジュール"
+        );
+        scan_only_module!(
+            config,
+            scan_report,
+            tls_cert_monitor,
+            TlsCertMonitorModule,
+            "TLS 証明書有効期限監視モジュール"
         );
 
         scan_report.total_duration = scan_start.elapsed();

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -34,6 +34,7 @@ pub mod ssh_key_monitor;
 pub mod sudoers_monitor;
 pub mod suid_sgid_monitor;
 pub mod systemd_service;
+pub mod tls_cert_monitor;
 pub mod tmp_exec_monitor;
 pub mod usb_monitor;
 pub mod user_account;

--- a/src/modules/tls_cert_monitor.rs
+++ b/src/modules/tls_cert_monitor.rs
@@ -1,0 +1,748 @@
+//! TLS 証明書有効期限監視モジュール
+//!
+//! 指定ディレクトリ内の PEM 形式 TLS 証明書ファイルを定期スキャンし、
+//! 有効期限が近い・期限切れの証明書を検知してアラートを発行する。
+//!
+//! 検知対象:
+//! - 有効期限切れの証明書（Critical）
+//! - 有効期限が間近の証明書（Critical / Warning）
+//! - 読み取りエラーが発生したファイル（Info）
+
+use crate::config::TlsCertMonitorConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use crate::error::AppError;
+use crate::modules::{InitialScanResult, Module};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tokio_util::sync::CancellationToken;
+
+/// 単一ファイルのチェック結果
+struct CertCheckResult {
+    /// スナップショット文字列（"expires:YYYY-MM-DD" or "expired:YYYY-MM-DD"）
+    snapshot_info: String,
+    /// 問題があるかどうか（期限切れ or 閾値以内）
+    is_issue: bool,
+}
+
+/// 証明書のスキャン結果
+struct CertScanResult {
+    /// スキャンした証明書ファイル数
+    items_scanned: usize,
+    /// 問題が検知された証明書数
+    issues_found: usize,
+    /// ファイルパス → 有効期限の文字列マップ
+    snapshot: BTreeMap<String, String>,
+}
+
+/// TLS 証明書有効期限監視モジュール
+pub struct TlsCertMonitorModule {
+    config: TlsCertMonitorConfig,
+    cancel_token: CancellationToken,
+    event_bus: Option<EventBus>,
+}
+
+impl TlsCertMonitorModule {
+    /// 新しい TLS 証明書有効期限監視モジュールを作成する
+    pub fn new(config: TlsCertMonitorConfig, event_bus: Option<EventBus>) -> Self {
+        Self {
+            config,
+            cancel_token: CancellationToken::new(),
+            event_bus,
+        }
+    }
+
+    /// キャンセルトークンのクローンを返す
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// 指定ファイルの拡張子が監視対象か判定する
+    fn has_target_extension(path: &Path, extensions: &[String]) -> bool {
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n,
+            None => return false,
+        };
+        extensions.iter().any(|ext| name.ends_with(ext.as_str()))
+    }
+
+    /// 監視対象ディレクトリをスキャンし、証明書の有効期限をチェックする
+    fn scan_certs(
+        watch_dirs: &[PathBuf],
+        file_extensions: &[String],
+        warning_days: u32,
+        critical_days: u32,
+        event_bus: &Option<EventBus>,
+    ) -> CertScanResult {
+        let mut items_scanned: usize = 0;
+        let mut issues_found: usize = 0;
+        let mut snapshot = BTreeMap::new();
+        let now = std::time::SystemTime::now();
+
+        for dir in watch_dirs {
+            if !dir.exists() {
+                tracing::debug!(dir = %dir.display(), "監視対象ディレクトリが存在しません。スキップします");
+                continue;
+            }
+
+            let walker = walkdir::WalkDir::new(dir)
+                .follow_links(true)
+                .into_iter()
+                .filter_map(|e| e.ok());
+
+            for entry in walker {
+                let path = entry.path();
+                if !path.is_file() {
+                    continue;
+                }
+                if !Self::has_target_extension(path, file_extensions) {
+                    continue;
+                }
+
+                match Self::check_cert_file(path, now, warning_days, critical_days, event_bus) {
+                    Ok(Some(check_result)) => {
+                        items_scanned += 1;
+                        snapshot.insert(path.display().to_string(), check_result.snapshot_info);
+                        if check_result.is_issue {
+                            issues_found += 1;
+                        }
+                    }
+                    Ok(None) => {
+                        // No CERTIFICATE blocks found in this PEM file
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            path = %path.display(),
+                            error = %e,
+                            "証明書ファイルの読み取りに失敗しました"
+                        );
+                        if let Some(bus) = event_bus {
+                            bus.publish(
+                                SecurityEvent::new(
+                                    "tls_cert_read_error",
+                                    Severity::Info,
+                                    "tls_cert_monitor",
+                                    format!(
+                                        "TLS 証明書ファイルの読み取りに失敗しました: {}",
+                                        path.display()
+                                    ),
+                                )
+                                .with_details(format!("{e}")),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        CertScanResult {
+            items_scanned,
+            issues_found,
+            snapshot,
+        }
+    }
+
+    /// 単一の証明書ファイルをチェックし、有効期限情報を返す
+    fn check_cert_file(
+        path: &Path,
+        now: std::time::SystemTime,
+        warning_days: u32,
+        critical_days: u32,
+        event_bus: &Option<EventBus>,
+    ) -> Result<Option<CertCheckResult>, AppError> {
+        let data = std::fs::read(path).map_err(|e| AppError::FileIo {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+
+        let pems = pem::parse_many(&data).map_err(|e| AppError::ModuleConfig {
+            message: format!("PEM パースエラー ({}): {e}", path.display()),
+        })?;
+
+        if pems.is_empty() {
+            return Ok(None);
+        }
+
+        let mut result: Option<CertCheckResult> = None;
+
+        for p in &pems {
+            if p.tag() != "CERTIFICATE" {
+                continue;
+            }
+
+            let (_, cert) = match x509_parser::parse_x509_certificate(p.contents()) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::debug!(
+                        path = %path.display(),
+                        error = %e,
+                        "X.509 証明書のパースに失敗しました"
+                    );
+                    continue;
+                }
+            };
+
+            let not_after = cert.validity().not_after;
+            let dt = not_after.to_datetime();
+            let ts = dt.unix_timestamp();
+            // unwrap safety: unix_timestamp from a valid x509 cert is always non-negative
+            let expiry_secs = ts as u64;
+
+            let now_secs = now
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+
+            let days_remaining = if expiry_secs >= now_secs {
+                ((expiry_secs - now_secs) / 86400) as i64
+            } else {
+                -(((now_secs - expiry_secs) / 86400) as i64)
+            };
+
+            let date_str = format!("{:04}-{:02}-{:02}", dt.year(), dt.month() as u8, dt.day(),);
+
+            let subject = cert
+                .subject()
+                .iter_common_name()
+                .next()
+                .and_then(|cn| cn.as_str().ok())
+                .unwrap_or("unknown");
+
+            let (snapshot_info, is_issue) = if days_remaining < 0 {
+                tracing::warn!(
+                    path = %path.display(),
+                    subject = subject,
+                    expired_days_ago = -days_remaining,
+                    "TLS 証明書の有効期限が切れています"
+                );
+                if let Some(bus) = event_bus {
+                    bus.publish(
+                        SecurityEvent::new(
+                            "tls_cert_expired",
+                            Severity::Critical,
+                            "tls_cert_monitor",
+                            format!(
+                                "TLS 証明書の有効期限が切れています: {} (CN={}、{}日前に失効)",
+                                path.display(),
+                                subject,
+                                -days_remaining,
+                            ),
+                        )
+                        .with_details(path.display().to_string()),
+                    );
+                }
+                (format!("expired:{date_str}"), true)
+            } else if days_remaining <= i64::from(critical_days) {
+                tracing::warn!(
+                    path = %path.display(),
+                    subject = subject,
+                    days_remaining = days_remaining,
+                    "TLS 証明書の有効期限が間近です（重大）"
+                );
+                if let Some(bus) = event_bus {
+                    bus.publish(
+                        SecurityEvent::new(
+                            "tls_cert_expiring_critical",
+                            Severity::Critical,
+                            "tls_cert_monitor",
+                            format!(
+                                "TLS 証明書の有効期限が間近です: {} (CN={}、残り{}日)",
+                                path.display(),
+                                subject,
+                                days_remaining,
+                            ),
+                        )
+                        .with_details(path.display().to_string()),
+                    );
+                }
+                (format!("expires:{date_str}"), true)
+            } else if days_remaining <= i64::from(warning_days) {
+                tracing::info!(
+                    path = %path.display(),
+                    subject = subject,
+                    days_remaining = days_remaining,
+                    "TLS 証明書の有効期限が近づいています"
+                );
+                if let Some(bus) = event_bus {
+                    bus.publish(
+                        SecurityEvent::new(
+                            "tls_cert_expiring_warning",
+                            Severity::Warning,
+                            "tls_cert_monitor",
+                            format!(
+                                "TLS 証明書の有効期限が近づいています: {} (CN={}、残り{}日)",
+                                path.display(),
+                                subject,
+                                days_remaining,
+                            ),
+                        )
+                        .with_details(path.display().to_string()),
+                    );
+                }
+                (format!("expires:{date_str}"), true)
+            } else {
+                (format!("expires:{date_str}"), false)
+            };
+
+            // Keep the most critical result (issue takes priority over non-issue)
+            match &result {
+                None => {
+                    result = Some(CertCheckResult {
+                        snapshot_info,
+                        is_issue,
+                    });
+                }
+                Some(existing) if !existing.is_issue && is_issue => {
+                    result = Some(CertCheckResult {
+                        snapshot_info,
+                        is_issue,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl Module for TlsCertMonitorModule {
+    fn name(&self) -> &str {
+        "tls_cert_monitor"
+    }
+
+    fn init(&mut self) -> Result<(), AppError> {
+        if self.config.check_interval_secs == 0 {
+            return Err(AppError::ModuleConfig {
+                message: "check_interval_secs は 0 より大きい値を指定してください".to_string(),
+            });
+        }
+
+        for dir in &self.config.watch_dirs {
+            if !dir.exists() {
+                tracing::warn!(
+                    dir = %dir.display(),
+                    "監視対象ディレクトリが存在しません"
+                );
+            }
+        }
+
+        tracing::info!(
+            watch_dirs = ?self.config.watch_dirs,
+            check_interval_secs = self.config.check_interval_secs,
+            warning_days = self.config.warning_days,
+            critical_days = self.config.critical_days,
+            "TLS 証明書有効期限監視モジュールを初期化しました"
+        );
+
+        Ok(())
+    }
+
+    async fn start(&mut self) -> Result<(), AppError> {
+        let watch_dirs = self.config.watch_dirs.clone();
+        let file_extensions = self.config.file_extensions.clone();
+        let check_interval_secs = self.config.check_interval_secs;
+        let warning_days = self.config.warning_days;
+        let critical_days = self.config.critical_days;
+        let cancel_token = self.cancel_token.clone();
+        let event_bus = self.event_bus.clone();
+
+        let result = Self::scan_certs(
+            &watch_dirs,
+            &file_extensions,
+            warning_days,
+            critical_days,
+            &event_bus,
+        );
+        tracing::info!(
+            items_scanned = result.items_scanned,
+            issues_found = result.issues_found,
+            "TLS 証明書の初回スキャンが完了しました"
+        );
+
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(std::time::Duration::from_secs(check_interval_secs));
+            // 最初の tick は即座に発火するのでスキップ
+            interval.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("TLS 証明書有効期限監視モジュールを停止します");
+                        break;
+                    }
+                    _ = interval.tick() => {
+                        let result = TlsCertMonitorModule::scan_certs(
+                            &watch_dirs,
+                            &file_extensions,
+                            warning_days,
+                            critical_days,
+                            &event_bus,
+                        );
+                        tracing::debug!(
+                            items_scanned = result.items_scanned,
+                            issues_found = result.issues_found,
+                            "TLS 証明書の定期スキャンが完了しました"
+                        );
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn stop(&mut self) -> Result<(), AppError> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+
+    async fn initial_scan(&self) -> Result<InitialScanResult, AppError> {
+        let start = std::time::Instant::now();
+
+        let result = Self::scan_certs(
+            &self.config.watch_dirs,
+            &self.config.file_extensions,
+            self.config.warning_days,
+            self.config.critical_days,
+            &None,
+        );
+
+        let duration = start.elapsed();
+
+        Ok(InitialScanResult {
+            items_scanned: result.items_scanned,
+            issues_found: result.issues_found,
+            duration,
+            summary: format!(
+                "TLS 証明書 {}件をスキャンしました（問題: {}件）",
+                result.items_scanned, result.issues_found,
+            ),
+            snapshot: result.snapshot,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// テスト用の自己署名証明書を生成する
+    fn generate_test_cert_pem() -> String {
+        let output = std::process::Command::new("openssl")
+            .args([
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                "/dev/null",
+                "-nodes",
+                "-subj",
+                "/CN=test-cert",
+                "-days",
+                "365",
+            ])
+            .output()
+            .expect("openssl コマンドの実行に失敗しました");
+        assert!(output.status.success(), "openssl が失敗しました");
+        String::from_utf8(output.stdout).unwrap()
+    }
+
+    #[test]
+    fn test_init_zero_interval() {
+        let config = TlsCertMonitorConfig {
+            enabled: true,
+            check_interval_secs: 0,
+            watch_dirs: vec![],
+            warning_days: 30,
+            critical_days: 7,
+            file_extensions: vec![".pem".to_string()],
+        };
+        let mut module = TlsCertMonitorModule::new(config, None);
+        assert!(module.init().is_err());
+    }
+
+    #[test]
+    fn test_init_valid() {
+        let config = TlsCertMonitorConfig {
+            enabled: true,
+            check_interval_secs: 3600,
+            watch_dirs: vec![PathBuf::from("/tmp/nonexistent-tls-test")],
+            warning_days: 30,
+            critical_days: 7,
+            file_extensions: vec![".pem".to_string()],
+        };
+        let mut module = TlsCertMonitorModule::new(config, None);
+        assert!(module.init().is_ok());
+    }
+
+    #[test]
+    fn test_has_target_extension() {
+        let exts = vec![".pem".to_string(), ".crt".to_string(), ".cer".to_string()];
+        assert!(TlsCertMonitorModule::has_target_extension(
+            Path::new("/etc/ssl/certs/server.pem"),
+            &exts
+        ));
+        assert!(TlsCertMonitorModule::has_target_extension(
+            Path::new("/etc/ssl/certs/server.crt"),
+            &exts
+        ));
+        assert!(TlsCertMonitorModule::has_target_extension(
+            Path::new("/etc/ssl/certs/server.cer"),
+            &exts
+        ));
+        assert!(!TlsCertMonitorModule::has_target_extension(
+            Path::new("/etc/ssl/certs/server.key"),
+            &exts
+        ));
+        assert!(!TlsCertMonitorModule::has_target_extension(
+            Path::new("/etc/ssl/certs/server.txt"),
+            &exts
+        ));
+    }
+
+    #[test]
+    fn test_scan_empty_directory() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let result = TlsCertMonitorModule::scan_certs(
+            &[tmpdir.path().to_path_buf()],
+            &[".pem".to_string()],
+            30,
+            7,
+            &None,
+        );
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.snapshot.is_empty());
+    }
+
+    #[test]
+    fn test_scan_nonexistent_directory() {
+        let result = TlsCertMonitorModule::scan_certs(
+            &[PathBuf::from("/tmp/nonexistent-zettai-tls-dir-12345")],
+            &[".pem".to_string()],
+            30,
+            7,
+            &None,
+        );
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+    }
+
+    #[test]
+    fn test_check_cert_file_expired() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("test.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        // Set "now" to 2 years in the future so the 365-day cert is expired
+        let future_now =
+            std::time::SystemTime::now() + std::time::Duration::from_secs(2 * 365 * 86400);
+
+        let result =
+            TlsCertMonitorModule::check_cert_file(&cert_path, future_now, 30, 7, &None).unwrap();
+
+        assert!(result.is_some());
+        let check = result.unwrap();
+        assert!(check.is_issue);
+        assert!(
+            check.snapshot_info.starts_with("expired:"),
+            "expected expired: prefix, got: {}",
+            check.snapshot_info
+        );
+    }
+
+    #[test]
+    fn test_check_cert_file_critical() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("test.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        // Set "now" to 362 days in the future (3 days before 365-day cert expires)
+        let future_now = std::time::SystemTime::now() + std::time::Duration::from_secs(362 * 86400);
+
+        let result =
+            TlsCertMonitorModule::check_cert_file(&cert_path, future_now, 30, 7, &None).unwrap();
+
+        assert!(result.is_some());
+        let check = result.unwrap();
+        assert!(check.is_issue);
+        assert!(
+            check.snapshot_info.starts_with("expires:"),
+            "expected expires: prefix, got: {}",
+            check.snapshot_info
+        );
+    }
+
+    #[test]
+    fn test_check_cert_file_warning() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("test.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        // Set "now" to 345 days in the future (20 days before 365-day cert expires)
+        let future_now = std::time::SystemTime::now() + std::time::Duration::from_secs(345 * 86400);
+
+        let result =
+            TlsCertMonitorModule::check_cert_file(&cert_path, future_now, 30, 7, &None).unwrap();
+
+        assert!(result.is_some());
+        let check = result.unwrap();
+        assert!(check.is_issue);
+        assert!(check.snapshot_info.starts_with("expires:"));
+    }
+
+    #[test]
+    fn test_check_cert_file_ok() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("test.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        let result = TlsCertMonitorModule::check_cert_file(
+            &cert_path,
+            std::time::SystemTime::now(),
+            30,
+            7,
+            &None,
+        )
+        .unwrap();
+
+        assert!(result.is_some());
+        let check = result.unwrap();
+        assert!(!check.is_issue);
+        assert!(check.snapshot_info.starts_with("expires:"));
+    }
+
+    #[test]
+    fn test_scan_valid_cert() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("valid.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        let result = TlsCertMonitorModule::scan_certs(
+            &[tmpdir.path().to_path_buf()],
+            &[".pem".to_string()],
+            30,
+            7,
+            &None,
+        );
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert_eq!(result.snapshot.len(), 1);
+    }
+
+    #[test]
+    fn test_scan_file_extension_filtering() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let pem = generate_test_cert_pem();
+
+        // .pem file — should be scanned
+        std::fs::write(tmpdir.path().join("server.pem"), &pem).unwrap();
+
+        // .key file — should be skipped due to extension
+        std::fs::write(tmpdir.path().join("server.key"), &pem).unwrap();
+
+        let result = TlsCertMonitorModule::scan_certs(
+            &[tmpdir.path().to_path_buf()],
+            &[".pem".to_string(), ".crt".to_string()],
+            30,
+            7,
+            &None,
+        );
+        assert_eq!(result.items_scanned, 1);
+    }
+
+    #[test]
+    fn test_scan_invalid_pem_content() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("invalid.pem");
+        std::fs::write(&cert_path, "this is not a valid PEM file").unwrap();
+
+        let result = TlsCertMonitorModule::scan_certs(
+            &[tmpdir.path().to_path_buf()],
+            &[".pem".to_string()],
+            30,
+            7,
+            &None,
+        );
+        assert_eq!(result.items_scanned, 0);
+    }
+
+    #[tokio::test]
+    async fn test_start_and_stop() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let config = TlsCertMonitorConfig {
+            enabled: true,
+            check_interval_secs: 3600,
+            watch_dirs: vec![tmpdir.path().to_path_buf()],
+            warning_days: 30,
+            critical_days: 7,
+            file_extensions: vec![".pem".to_string()],
+        };
+        let mut module = TlsCertMonitorModule::new(config, None);
+        module.init().unwrap();
+
+        let cancel_token = module.cancel_token();
+        module.start().await.unwrap();
+
+        module.stop().await.unwrap();
+        assert!(cancel_token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_with_valid_cert() {
+        let tmpdir = tempfile::TempDir::new().unwrap();
+        let cert_path = tmpdir.path().join("test.pem");
+        let pem = generate_test_cert_pem();
+        std::fs::write(&cert_path, &pem).unwrap();
+
+        let config = TlsCertMonitorConfig {
+            enabled: true,
+            check_interval_secs: 3600,
+            watch_dirs: vec![tmpdir.path().to_path_buf()],
+            warning_days: 30,
+            critical_days: 7,
+            file_extensions: vec![".pem".to_string()],
+        };
+        let module = TlsCertMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 1);
+        assert_eq!(result.issues_found, 0);
+        assert!(result.summary.contains("1件をスキャン"));
+    }
+
+    #[tokio::test]
+    async fn test_initial_scan_empty_dirs() {
+        let config = TlsCertMonitorConfig {
+            enabled: true,
+            check_interval_secs: 3600,
+            watch_dirs: vec![],
+            warning_days: 30,
+            critical_days: 7,
+            file_extensions: vec![".pem".to_string()],
+        };
+        let module = TlsCertMonitorModule::new(config, None);
+
+        let result = module.initial_scan().await.unwrap();
+        assert_eq!(result.items_scanned, 0);
+        assert_eq!(result.issues_found, 0);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let config = TlsCertMonitorConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.check_interval_secs, 3600);
+        assert_eq!(config.warning_days, 30);
+        assert_eq!(config.critical_days, 7);
+        assert_eq!(config.watch_dirs.len(), 2);
+        assert_eq!(config.file_extensions.len(), 3);
+    }
+}


### PR DESCRIPTION
## 概要

指定ディレクトリ配下の TLS 証明書ファイル（PEM 形式）の有効期限を定期チェックし、期限切れ・期限間近の場合にアラートを発行する監視モジュールを追加する。

Closes #141

## 変更内容

- `src/modules/tls_cert_monitor.rs`: TLS 証明書有効期限監視モジュールの実装（16件の単体テスト含む）
- `src/config.rs`: `TlsCertMonitorConfig` の追加
- `src/modules/mod.rs`: モジュール登録
- `src/core/module_manager.rs`: `start_module!` / `scan_only_module!` マクロ呼び出し追加
- `config.example.toml`: 設定例の追加
- `Cargo.toml`: `x509-parser`, `pem` 依存追加、バージョン 0.69.0 へ更新
- `CLAUDE.md`: ディレクトリ構成の更新

## 機能詳細

- **PEM 形式証明書のスキャン**: `walkdir` で再帰的にディレクトリを走査し、`.pem`, `.crt`, `.cer` ファイルを対象
- **有効期限チェック**: `x509-parser` で証明書を解析し、`not_after` フィールドから残日数を算出
- **Severity マッピング**:
  - 期限切れ → `Critical` (`tls_cert_expired`)
  - `critical_days`（デフォルト: 7日）以内 → `Critical` (`tls_cert_expiring_critical`)
  - `warning_days`（デフォルト: 30日）以内 → `Warning` (`tls_cert_expiring_warning`)
  - 読み取りエラー → `Info` (`tls_cert_read_error`)
- **起動時スキャン対応**
- **設定ホットリロード対応**

## テスト計画

- [x] `cargo fmt --check` — クリーン
- [x] `cargo clippy -- -D warnings` — クリーン
- [x] `cargo test` — 全 1102 テスト合格（新規 16 + 既存 1086）

🤖 Generated with [Claude Code](https://claude.com/claude-code)