### PR TITLE
feat: 相関ルールプリセット集の実装 (#153)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -707,6 +707,12 @@ window_secs = 600
 max_events = 10000
 # クリーンアップ間隔（秒）
 cleanup_interval_secs = 30
+# プリセットルール（権限昇格・ラテラルムーブメント・ランサムウェア等 8 種）の有効/無効
+# true にすると組み込みプリセットが自動的に追加される
+enable_presets = true
+# 無効にするプリセットのリスト（プリセット名を指定、"preset:" プレフィックスは省略可）
+# 例: ["container_escape", "network_reconnaissance"]
+disabled_presets = []
 
 # 多段階攻撃パターン: SSH ブルートフォース → ユーザー追加 → cron 変更
 [[correlation.rules]]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2971,6 +2971,14 @@ pub struct CorrelationConfig {
     /// 相関ルールのリスト
     #[serde(default)]
     pub rules: Vec<CorrelationRuleConfig>,
+
+    /// プリセットルールの有効/無効（デフォルト: true）
+    #[serde(default = "CorrelationConfig::default_enable_presets")]
+    pub enable_presets: bool,
+
+    /// 無効にするプリセットのリスト
+    #[serde(default)]
+    pub disabled_presets: Vec<String>,
 }
 
 impl CorrelationConfig {
@@ -2985,6 +2993,10 @@ impl CorrelationConfig {
     fn default_cleanup_interval_secs() -> u64 {
         30
     }
+
+    fn default_enable_presets() -> bool {
+        true
+    }
 }
 
 impl Default for CorrelationConfig {
@@ -2995,6 +3007,8 @@ impl Default for CorrelationConfig {
             max_events: Self::default_max_events(),
             cleanup_interval_secs: Self::default_cleanup_interval_secs(),
             rules: Vec::new(),
+            enable_presets: Self::default_enable_presets(),
+            disabled_presets: Vec::new(),
         }
     }
 }

--- a/src/core/correlation.rs
+++ b/src/core/correlation.rs
@@ -45,8 +45,12 @@ pub struct CorrelationRuntimeConfig {
     pub max_events: usize,
     /// クリーンアップ間隔（秒）
     pub cleanup_interval_secs: u64,
-    /// ルール設定（受信側でコンパイルする）
+    /// ルール設定（マージ済み、受信側でコンパイルする）
     pub rules: Vec<crate::config::CorrelationRuleConfig>,
+    /// プリセットルールの有効/無効
+    pub enable_presets: bool,
+    /// 無効にするプリセットのリスト
+    pub disabled_presets: Vec<String>,
 }
 
 /// 相関マッチ結果
@@ -237,13 +241,22 @@ impl CorrelationEngine {
         config: &CorrelationConfig,
         event_bus: &EventBus,
     ) -> Result<(Self, watch::Sender<CorrelationRuntimeConfig>), AppError> {
-        let rules = Self::compile_rules(&config.rules, config.window_secs)?;
+        use crate::core::correlation_presets;
+
+        let effective_rules = correlation_presets::merge_rules(
+            &config.rules,
+            config.enable_presets,
+            &config.disabled_presets,
+        );
+        let rules = Self::compile_rules(&effective_rules, config.window_secs)?;
 
         let runtime_config = CorrelationRuntimeConfig {
             window_secs: config.window_secs,
             max_events: config.max_events,
             cleanup_interval_secs: config.cleanup_interval_secs,
-            rules: config.rules.clone(),
+            rules: effective_rules,
+            enable_presets: config.enable_presets,
+            disabled_presets: config.disabled_presets.clone(),
         };
 
         let (config_sender, config_receiver) = watch::channel(runtime_config);
@@ -762,6 +775,8 @@ mod tests {
             window_secs: 600,
             max_events: 100,
             cleanup_interval_secs: 30,
+            enable_presets: false,
+            disabled_presets: vec![],
             rules: vec![CorrelationRuleConfig {
                 name: "test_rule".to_string(),
                 description: "テストルール".to_string(),
@@ -842,6 +857,8 @@ mod tests {
             window_secs: 600,
             max_events: 100,
             cleanup_interval_secs: 30,
+            enable_presets: false,
+            disabled_presets: vec![],
             rules: vec![CorrelationRuleConfig {
                 name: "catch_all".to_string(),
                 description: "全イベントにマッチ".to_string(),
@@ -901,6 +918,8 @@ mod tests {
             window_secs: 600,
             max_events: 100,
             cleanup_interval_secs: 30,
+            enable_presets: false,
+            disabled_presets: vec![],
             rules: vec![CorrelationRuleConfig {
                 name: "simple_rule".to_string(),
                 description: "シンプルルール".to_string(),
@@ -1089,6 +1108,8 @@ mod tests {
             window_secs: 600,
             max_events: 100,
             cleanup_interval_secs: 30,
+            enable_presets: false,
+            disabled_presets: vec![],
             rules: vec![CorrelationRuleConfig {
                 name: "original_rule".to_string(),
                 description: "元のルール".to_string(),
@@ -1125,6 +1146,8 @@ mod tests {
                 max_events: 50,
                 cleanup_interval_secs: 15,
                 rules: new_rules,
+                enable_presets: false,
+                disabled_presets: vec![],
             })
             .unwrap();
 

--- a/src/core/correlation_presets.rs
+++ b/src/core/correlation_presets.rs
@@ -1,0 +1,325 @@
+//! 相関ルールプリセット集
+//!
+//! よくある攻撃パターンのプリセットルールを提供する。
+
+use crate::config::{CorrelationRuleConfig, CorrelationStepConfig};
+
+/// 全プリセットルールを返す
+pub fn all_presets() -> Vec<CorrelationRuleConfig> {
+    vec![
+        privilege_escalation(),
+        lateral_movement(),
+        ransomware_indicators(),
+        persistence_mechanism(),
+        kernel_tampering(),
+        container_escape(),
+        credential_theft(),
+        network_reconnaissance(),
+    ]
+}
+
+/// プリセットルールとユーザー定義ルールをマージする
+///
+/// ユーザーが同名のルール（`preset:` プレフィックス付き）を定義している場合は
+/// ユーザー定義を優先する。
+pub fn merge_rules(
+    user_rules: &[CorrelationRuleConfig],
+    enable_presets: bool,
+    disabled_presets: &[String],
+) -> Vec<CorrelationRuleConfig> {
+    let mut merged = Vec::new();
+
+    if enable_presets {
+        let presets = all_presets();
+        for preset in presets {
+            // ユーザーが同名ルールを定義している場合はスキップ
+            let user_override = user_rules.iter().any(|r| r.name == preset.name);
+            // disabled_presets に含まれる場合もスキップ
+            let disabled = disabled_presets
+                .iter()
+                .any(|d| preset.name == format!("preset:{d}") || preset.name == *d);
+            if !user_override && !disabled {
+                merged.push(preset);
+            }
+        }
+    }
+
+    // ユーザー定義ルールを追加
+    merged.extend(user_rules.iter().cloned());
+
+    merged
+}
+
+/// ステップを簡潔に作成するヘルパー関数
+fn step(name: &str, event_type: &str, min_severity: Option<&str>) -> CorrelationStepConfig {
+    CorrelationStepConfig {
+        name: name.to_string(),
+        event_type: event_type.to_string(),
+        source_module: None,
+        min_severity: min_severity.map(|s| s.to_string()),
+    }
+}
+
+/// プリセットルールを作成するヘルパー関数
+fn preset_rule(
+    name: &str,
+    description: &str,
+    within_secs: u64,
+    steps: Vec<CorrelationStepConfig>,
+) -> CorrelationRuleConfig {
+    CorrelationRuleConfig {
+        name: format!("preset:{name}"),
+        description: description.to_string(),
+        steps,
+        within_secs: Some(within_secs),
+    }
+}
+
+/// 1. 権限昇格パターン
+fn privilege_escalation() -> CorrelationRuleConfig {
+    preset_rule(
+        "privilege_escalation",
+        "sudoers 変更後に SUID ファイル作成または capabilities 変更を検知",
+        1800, // 30分
+        vec![
+            step(
+                "sudoers_changed",
+                "sudoers_(lines_added|file_added)",
+                Some("warning"),
+            ),
+            step("suid_or_caps", "(suid_sgid_new|capabilities_changed)", None),
+        ],
+    )
+}
+
+/// 2. ラテラルムーブメント
+fn lateral_movement() -> CorrelationRuleConfig {
+    preset_rule(
+        "lateral_movement",
+        "SSH ブルートフォース成功後にユーザー追加・SSH 鍵設置・cron 永続化を検知",
+        3600, // 1時間
+        vec![
+            step("ssh_attack", "ssh_brute_force", Some("warning")),
+            step("user_created", "user_added", None),
+            step("ssh_key_installed", "ssh_key_(added|file_added)", None),
+            step("persistence", "cron_(modified|added)", None),
+        ],
+    )
+}
+
+/// 3. ランサムウェア兆候
+fn ransomware_indicators() -> CorrelationRuleConfig {
+    preset_rule(
+        "ransomware_indicators",
+        "大量のファイル変更・プロセス異常・ネットワーク異常からランサムウェアの兆候を検知",
+        900, // 15分
+        vec![
+            step(
+                "mass_file_changes",
+                "file_(modified|added|removed)",
+                Some("warning"),
+            ),
+            step(
+                "process_anomaly",
+                "process_(anomaly|exec_suspicious_path)",
+                None,
+            ),
+            step(
+                "network_anomaly",
+                "(traffic_bytes_anomaly|suspicious_port_connection|connection_count_exceeded)",
+                None,
+            ),
+        ],
+    )
+}
+
+/// 4. 永続化メカニズム
+fn persistence_mechanism() -> CorrelationRuleConfig {
+    preset_rule(
+        "persistence_mechanism",
+        "systemd サービス追加・cron 変更・シェル設定変更の組み合わせで永続化を検知",
+        3600, // 1時間
+        vec![
+            step("systemd_persistence", "systemd_(added|modified)", None),
+            step("cron_persistence", "cron_(modified|added)", None),
+            step(
+                "shell_persistence",
+                "shell_config_(lines_added|added)",
+                None,
+            ),
+        ],
+    )
+}
+
+/// 5. カーネルレベル攻撃
+fn kernel_tampering() -> CorrelationRuleConfig {
+    preset_rule(
+        "kernel_tampering",
+        "カーネルモジュール追加・パラメータ変更・seccomp 無効化からカーネルレベルの攻撃を検知",
+        1800, // 30分
+        vec![
+            step("kernel_module", "kernel_module_loaded", Some("warning")),
+            step(
+                "kernel_params",
+                "kernel_param_(changed|below_minimum)",
+                None,
+            ),
+            step(
+                "seccomp_weakened",
+                "(seccomp_disabled|seccomp_mode_changed)",
+                None,
+            ),
+        ],
+    )
+}
+
+/// 6. コンテナエスケープ兆候
+fn container_escape() -> CorrelationRuleConfig {
+    preset_rule(
+        "container_escape",
+        "名前空間変更・マウント変更・capabilities 変更からコンテナエスケープの兆候を検知",
+        600, // 10分
+        vec![
+            step(
+                "namespace_change",
+                "(namespace_inode_changed|container_env_appeared)",
+                None,
+            ),
+            step("mount_change", "mount_(added|modified)", None),
+            step(
+                "caps_change",
+                "(capabilities_changed|capabilities_new_process)",
+                None,
+            ),
+        ],
+    )
+}
+
+/// 7. 認証情報窃取
+fn credential_theft() -> CorrelationRuleConfig {
+    preset_rule(
+        "credential_theft",
+        "PAM 設定変更・sudoers 変更・SSH 鍵追加の組み合わせで認証情報窃取を検知",
+        1800, // 30分
+        vec![
+            step(
+                "pam_tampered",
+                "pam_(lines_added|dangerous_permit|dangerous_exec)",
+                Some("warning"),
+            ),
+            step("sudoers_tampered", "sudoers_(lines_added|file_added)", None),
+            step("ssh_key_theft", "ssh_key_(added|file_added)", None),
+        ],
+    )
+}
+
+/// 8. ネットワーク偵察
+fn network_reconnaissance() -> CorrelationRuleConfig {
+    preset_rule(
+        "network_reconnaissance",
+        "新規ポート開設・ネットワーク接続増加・DNS 設定変更からネットワーク偵察を検知",
+        1800, // 30分
+        vec![
+            step(
+                "new_port",
+                "(new_listening_port|unauthorized_listening_port)",
+                None,
+            ),
+            step(
+                "connection_surge",
+                "(connection_count_exceeded|traffic_bytes_anomaly)",
+                None,
+            ),
+            step("dns_tampered", "dns_(modified|added)", None),
+        ],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_all_presets_returns_eight_rules() {
+        let presets = all_presets();
+        assert_eq!(presets.len(), 8);
+        // 全てに preset: プレフィックスがある
+        for p in &presets {
+            assert!(
+                p.name.starts_with("preset:"),
+                "プリセット名に prefix がありません: {}",
+                p.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_all_presets_have_steps() {
+        let presets = all_presets();
+        for p in &presets {
+            assert!(!p.steps.is_empty(), "ステップが空です: {}", p.name);
+            assert!(p.within_secs.is_some(), "within_secs が未設定: {}", p.name);
+        }
+    }
+
+    #[test]
+    fn test_merge_rules_adds_presets() {
+        let user_rules = vec![];
+        let merged = merge_rules(&user_rules, true, &[]);
+        assert_eq!(merged.len(), 8);
+    }
+
+    #[test]
+    fn test_merge_rules_disabled_presets() {
+        let merged = merge_rules(&[], true, &["preset:container_escape".to_string()]);
+        assert_eq!(merged.len(), 7);
+        assert!(!merged.iter().any(|r| r.name == "preset:container_escape"));
+    }
+
+    #[test]
+    fn test_merge_rules_disabled_presets_without_prefix() {
+        let merged = merge_rules(&[], true, &["container_escape".to_string()]);
+        assert_eq!(merged.len(), 7);
+        assert!(!merged.iter().any(|r| r.name == "preset:container_escape"));
+    }
+
+    #[test]
+    fn test_merge_rules_user_override() {
+        let user_rules = vec![CorrelationRuleConfig {
+            name: "preset:privilege_escalation".to_string(),
+            description: "カスタム".to_string(),
+            steps: vec![step("custom", "custom_event", None)],
+            within_secs: Some(60),
+        }];
+        let merged = merge_rules(&user_rules, true, &[]);
+        // プリセット7 + ユーザー1 = 8 (プリセット版はオーバーライドされる)
+        assert_eq!(merged.len(), 8);
+        let custom = merged
+            .iter()
+            .find(|r| r.name == "preset:privilege_escalation")
+            .expect("カスタムルールが見つかりません");
+        assert_eq!(custom.description, "カスタム");
+    }
+
+    #[test]
+    fn test_merge_rules_presets_disabled() {
+        let merged = merge_rules(&[], false, &[]);
+        assert_eq!(merged.len(), 0);
+    }
+
+    #[test]
+    fn test_preset_rules_compile() {
+        // 全プリセットのルールが正規表現として有効であることを検証
+        let presets = all_presets();
+        for preset in &presets {
+            for s in &preset.steps {
+                regex::Regex::new(&s.event_type).unwrap_or_else(|e| {
+                    panic!(
+                        "プリセット '{}' ステップ '{}' の正規表現エラー: {}",
+                        preset.name, s.name, e
+                    );
+                });
+            }
+        }
+    }
+}

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -153,9 +153,19 @@ impl Daemon {
                 match CorrelationEngine::new(&self.config.correlation, &bus) {
                     Ok((engine, sender)) => {
                         correlation_config_sender = Some(sender);
+                        let effective_rules = crate::core::correlation_presets::merge_rules(
+                            &self.config.correlation.rules,
+                            self.config.correlation.enable_presets,
+                            &self.config.correlation.disabled_presets,
+                        );
                         engine.spawn();
                         tracing::info!(
-                            rules = self.config.correlation.rules.len(),
+                            total_rules = effective_rules.len(),
+                            preset_rules = effective_rules
+                                .iter()
+                                .filter(|r| r.name.starts_with("preset:"))
+                                .count(),
+                            user_rules = self.config.correlation.rules.len(),
                             window_secs = self.config.correlation.window_secs,
                             "相関分析エンジンを起動しました"
                         );
@@ -484,17 +494,30 @@ impl Daemon {
 
                             // 相関分析エンジンのリロード
                             if let Some(ref sender) = correlation_config_sender {
+                                let effective_rules =
+                                    crate::core::correlation_presets::merge_rules(
+                                        &new_config.correlation.rules,
+                                        new_config.correlation.enable_presets,
+                                        &new_config.correlation.disabled_presets,
+                                    );
                                 let runtime_config = CorrelationRuntimeConfig {
                                     window_secs: new_config.correlation.window_secs,
                                     max_events: new_config.correlation.max_events,
                                     cleanup_interval_secs: new_config
                                         .correlation
                                         .cleanup_interval_secs,
-                                    rules: new_config.correlation.rules.clone(),
+                                    rules: effective_rules.clone(),
+                                    enable_presets: new_config.correlation.enable_presets,
+                                    disabled_presets: new_config
+                                        .correlation
+                                        .disabled_presets
+                                        .clone(),
                                 };
                                 if sender.send(runtime_config).is_ok() {
                                     tracing::info!(
-                                        rules = new_config.correlation.rules.len(),
+                                        total_rules = effective_rules.len(),
+                                        preset_rules = effective_rules.iter().filter(|r| r.name.starts_with("preset:")).count(),
+                                        user_rules = new_config.correlation.rules.len(),
                                         "相関分析エンジンの設定をリロードしました"
                                     );
                                 } else {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub mod action;
 pub mod correlation;
+pub mod correlation_presets;
 pub mod daemon;
 pub mod event;
 pub mod event_store;


### PR DESCRIPTION
## 概要

Closes #153

イベント相関分析エンジンに、よくある攻撃パターンの相関ルールをプリセットとして同梱する機能を追加。設定不要で高度な多段階攻撃パターン検知が利用可能になる。

## 変更内容

- **新規**: `src/core/correlation_presets.rs` — 8種のプリセットルールと `merge_rules()` 関数
- **変更**: `src/config.rs` — `CorrelationConfig` に `enable_presets`/`disabled_presets` フィールド追加
- **変更**: `src/core/correlation.rs` — 初期化時にプリセットマージを適用
- **変更**: `src/core/daemon.rs` — 起動時・リロード時のプリセット統合
- **変更**: `config.example.toml` — プリセット設定例を追加

## プリセットルール（8種）

| プリセット名 | 説明 | 時間窓 |
|---|---|---|
| `preset:privilege_escalation` | 権限昇格パターン | 30分 |
| `preset:lateral_movement` | ラテラルムーブメント | 1時間 |
| `preset:ransomware_indicators` | ランサムウェア兆候 | 15分 |
| `preset:persistence_mechanism` | 永続化メカニズム | 1時間 |
| `preset:kernel_tampering` | カーネルレベル攻撃 | 30分 |
| `preset:container_escape` | コンテナエスケープ兆候 | 10分 |
| `preset:credential_theft` | 認証情報窃取 | 30分 |
| `preset:network_reconnaissance` | ネットワーク偵察 | 30分 |

## 設定

```toml
[correlation]
enabled = true
# プリセット有効（デフォルト: true）
enable_presets = true
# 個別プリセットの無効化
disabled_presets = ["container_escape"]
```

## テスト計画

- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` — 1264テスト全パス（新規8テスト含む）
- [x] プリセット全ルールの正規表現コンパイル検証
- [x] merge_rules のユーザー定義優先テスト
- [x] disabled_presets のフィルタリングテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)