### PR TITLE
feat: ログローテーション対応 — 改ざん検知モジュールの誤検知防止 (#155)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -99,6 +99,10 @@ enabled = false
 scan_interval_secs = 30
 # 監視対象パスのリスト
 watch_paths = ["/var/log/syslog", "/var/log/auth.log", "/var/log/kern.log", "/var/log/messages"]
+# logrotate によるファイル変更を誤検知しないようにする（デフォルト: true）
+logrotate_aware = true
+# logrotate 検知後のイベント抑制時間（秒）（デフォルト: 300）
+logrotate_suppression_secs = 300
 
 [modules.systemd_service]
 # systemd サービス監視モジュールの有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -606,6 +606,14 @@ pub struct LogTamperConfig {
     /// 監視対象パスのリスト
     #[serde(default = "LogTamperConfig::default_watch_paths")]
     pub watch_paths: Vec<PathBuf>,
+
+    /// logrotate によるファイル変更を誤検知しないようにする
+    #[serde(default = "LogTamperConfig::default_logrotate_aware")]
+    pub logrotate_aware: bool,
+
+    /// logrotate 検知後のイベント抑制時間（秒）
+    #[serde(default = "LogTamperConfig::default_logrotate_suppression_secs")]
+    pub logrotate_suppression_secs: u64,
 }
 
 impl LogTamperConfig {
@@ -621,6 +629,14 @@ impl LogTamperConfig {
             PathBuf::from("/var/log/messages"),
         ]
     }
+
+    fn default_logrotate_aware() -> bool {
+        true
+    }
+
+    fn default_logrotate_suppression_secs() -> u64 {
+        300
+    }
 }
 
 impl Default for LogTamperConfig {
@@ -629,6 +645,8 @@ impl Default for LogTamperConfig {
             enabled: false,
             scan_interval_secs: Self::default_scan_interval_secs(),
             watch_paths: Self::default_watch_paths(),
+            logrotate_aware: Self::default_logrotate_aware(),
+            logrotate_suppression_secs: Self::default_logrotate_suppression_secs(),
         }
     }
 }

--- a/src/modules/log_tamper.rs
+++ b/src/modules/log_tamper.rs
@@ -25,7 +25,7 @@ use crate::error::AppError;
 use crate::modules::{InitialScanResult, Module};
 use std::collections::{BTreeMap, HashMap};
 use std::os::unix::fs::MetadataExt;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
 /// ファイルの状態を保持する構造体
@@ -171,6 +171,105 @@ impl LogTamperModule {
     }
 }
 
+/// ローテーション生成物のサフィックスパターン（圧縮拡張子）
+const ROTATION_COMPRESSED_EXTENSIONS: &[&str] = &[".gz", ".bz2", ".xz", ".zst"];
+
+/// ファイルパスがローテーション生成物かどうかを判定する
+///
+/// パターン: `.1`, `.2`, ..., `.gz`, `.bz2`, `.xz`, `.zst`, `-YYYYMMDD`, `.log.1` 等
+fn is_rotation_artifact(path: &Path) -> bool {
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return false,
+    };
+
+    // 圧縮拡張子で終わるか（例: syslog.1.gz, messages.gz）
+    for ext in ROTATION_COMPRESSED_EXTENSIONS {
+        if file_name.ends_with(ext) {
+            return true;
+        }
+    }
+
+    // 末尾が `.数字` か（例: syslog.1, auth.log.2）
+    if let Some(pos) = file_name.rfind('.') {
+        let suffix = &file_name[pos + 1..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            return true;
+        }
+    }
+
+    // 末尾が `-YYYYMMDD` パターンか（例: access-20260407）
+    if file_name.len() >= 9 {
+        let tail = &file_name[file_name.len() - 9..];
+        if tail.starts_with('-') && tail[1..].chars().all(|c| c.is_ascii_digit()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// ローテーション生成物のベースパスを抽出する
+///
+/// 例: `/var/log/syslog.1` → `/var/log/syslog`
+fn extract_base_path(path: &Path) -> PathBuf {
+    let file_name = match path.file_name().and_then(|n| n.to_str()) {
+        Some(name) => name,
+        None => return path.to_path_buf(),
+    };
+    let parent = path.parent().unwrap_or_else(|| Path::new(""));
+
+    // 圧縮拡張子を除去してから再帰的に処理
+    for ext in ROTATION_COMPRESSED_EXTENSIONS {
+        if let Some(stripped) = file_name.strip_suffix(ext) {
+            return extract_base_path(&parent.join(stripped));
+        }
+    }
+
+    // 末尾の `.数字` を除去
+    if let Some(pos) = file_name.rfind('.') {
+        let suffix = &file_name[pos + 1..];
+        if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+            return parent.join(&file_name[..pos]);
+        }
+    }
+
+    // 末尾の `-YYYYMMDD` を除去
+    if file_name.len() >= 9 {
+        let tail = &file_name[file_name.len() - 9..];
+        if tail.starts_with('-') && tail[1..].chars().all(|c| c.is_ascii_digit()) {
+            return parent.join(&file_name[..file_name.len() - 9]);
+        }
+    }
+
+    path.to_path_buf()
+}
+
+/// ローテーション抑制を考慮して Severity を決定する
+fn resolve_severity(
+    base_severity: Severity,
+    path: &Path,
+    logrotate_aware: bool,
+    suppression_map: &HashMap<PathBuf, std::time::Instant>,
+) -> Severity {
+    if !logrotate_aware {
+        return base_severity;
+    }
+
+    // パス自体が抑制マップにあるか
+    if suppression_map.contains_key(path) {
+        return Severity::Info;
+    }
+
+    // ベースパスが抑制マップにあるか
+    let base = extract_base_path(path);
+    if base != path && suppression_map.contains_key(&base) {
+        return Severity::Info;
+    }
+
+    base_severity
+}
+
 impl Module for LogTamperModule {
     fn name(&self) -> &str {
         "log_tamper"
@@ -227,12 +326,16 @@ impl Module for LogTamperModule {
         let scan_interval_secs = self.config.scan_interval_secs;
         let cancel_token = self.cancel_token.clone();
         let event_bus = self.event_bus.clone();
+        let logrotate_aware = self.config.logrotate_aware;
+        let logrotate_suppression_secs = self.config.logrotate_suppression_secs;
 
         tokio::spawn(async move {
             let mut interval =
                 tokio::time::interval(std::time::Duration::from_secs(scan_interval_secs));
             // 最初の tick は即座に発火するのでスキップ
             interval.tick().await;
+
+            let mut suppression_map: HashMap<PathBuf, std::time::Instant> = HashMap::new();
 
             loop {
                 tokio::select! {
@@ -241,21 +344,90 @@ impl Module for LogTamperModule {
                         break;
                     }
                     _ = interval.tick() => {
+                        // 期限切れの抑制エントリを除去
+                        let suppression_duration = std::time::Duration::from_secs(logrotate_suppression_secs);
+                        suppression_map.retain(|_, instant| instant.elapsed() < suppression_duration);
+
                         let current = LogTamperModule::scan_files(&watch_paths);
                         let report = LogTamperModule::detect_changes(&baseline, &current);
 
                         if report.has_changes() {
-                            for path in &report.size_decreased {
-                                tracing::warn!(
+                            // rotated を先に処理して抑制マップを更新
+                            for path in &report.rotated {
+                                if logrotate_aware {
+                                    let base = extract_base_path(path);
+                                    suppression_map.insert(base, std::time::Instant::now());
+                                    suppression_map.insert(path.clone(), std::time::Instant::now());
+                                }
+                                let severity = resolve_severity(Severity::Info, path, logrotate_aware, &suppression_map);
+                                let suppressed = severity != Severity::Info || logrotate_aware;
+                                tracing::info!(
                                     path = %path.display(),
-                                    change = "size_decreased",
-                                    "ログファイルのサイズ減少を検知しました（切り詰め・改ざんの可能性）"
+                                    change = "rotated",
+                                    suppressed_by_logrotate = logrotate_aware && suppressed,
+                                    "ログファイルのローテーションを検知しました"
                                 );
                                 if let Some(ref bus) = event_bus {
                                     bus.publish(
                                         SecurityEvent::new(
+                                            "log_rotated",
+                                            severity,
+                                            "log_tamper",
+                                            format!("ログファイルのローテーションを検知しました: {}", path.display()),
+                                        )
+                                        .with_details(path.display().to_string()),
+                                    );
+                                }
+                            }
+                            // new_files: ローテーション生成物なら抑制マップに追加
+                            for path in &report.new_files {
+                                if logrotate_aware && is_rotation_artifact(path) {
+                                    let base = extract_base_path(path);
+                                    suppression_map.insert(base, std::time::Instant::now());
+                                    suppression_map.insert(path.clone(), std::time::Instant::now());
+                                }
+                                let severity = resolve_severity(Severity::Info, path, logrotate_aware, &suppression_map);
+                                let suppressed = severity == Severity::Info && logrotate_aware && is_rotation_artifact(path);
+                                tracing::info!(
+                                    path = %path.display(),
+                                    change = "new_file",
+                                    suppressed_by_logrotate = suppressed,
+                                    "新規ログファイルを検知しました"
+                                );
+                                if let Some(ref bus) = event_bus {
+                                    bus.publish(
+                                        SecurityEvent::new(
+                                            "log_new_file",
+                                            severity,
+                                            "log_tamper",
+                                            format!("新規ログファイルを検知しました: {}", path.display()),
+                                        )
+                                        .with_details(path.display().to_string()),
+                                    );
+                                }
+                            }
+                            for path in &report.size_decreased {
+                                let severity = resolve_severity(Severity::Warning, path, logrotate_aware, &suppression_map);
+                                let suppressed = severity == Severity::Info;
+                                if suppressed {
+                                    tracing::info!(
+                                        path = %path.display(),
+                                        change = "size_decreased",
+                                        suppressed_by_logrotate = true,
+                                        "ログファイルのサイズ減少を検知しました（logrotate による抑制中）"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        path = %path.display(),
+                                        change = "size_decreased",
+                                        "ログファイルのサイズ減少を検知しました（切り詰め・改ざんの可能性）"
+                                    );
+                                }
+                                if let Some(ref bus) = event_bus {
+                                    bus.publish(
+                                        SecurityEvent::new(
                                             "log_size_decreased",
-                                            Severity::Warning,
+                                            severity,
                                             "log_tamper",
                                             format!("ログファイルのサイズ減少を検知しました: {}", path.display()),
                                         )
@@ -264,16 +436,27 @@ impl Module for LogTamperModule {
                                 }
                             }
                             for path in &report.deleted {
-                                tracing::warn!(
-                                    path = %path.display(),
-                                    change = "deleted",
-                                    "ログファイルの削除を検知しました"
-                                );
+                                let severity = resolve_severity(Severity::Warning, path, logrotate_aware, &suppression_map);
+                                let suppressed = severity == Severity::Info;
+                                if suppressed {
+                                    tracing::info!(
+                                        path = %path.display(),
+                                        change = "deleted",
+                                        suppressed_by_logrotate = true,
+                                        "ログファイルの削除を検知しました（logrotate による抑制中）"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        path = %path.display(),
+                                        change = "deleted",
+                                        "ログファイルの削除を検知しました"
+                                    );
+                                }
                                 if let Some(ref bus) = event_bus {
                                     bus.publish(
                                         SecurityEvent::new(
                                             "log_deleted",
-                                            Severity::Warning,
+                                            severity,
                                             "log_tamper",
                                             format!("ログファイルの削除を検知しました: {}", path.display()),
                                         )
@@ -282,54 +465,29 @@ impl Module for LogTamperModule {
                                 }
                             }
                             for path in &report.permission_changed {
-                                tracing::warn!(
-                                    path = %path.display(),
-                                    change = "permission_changed",
-                                    "ログファイルのパーミッション変更を検知しました"
-                                );
+                                let severity = resolve_severity(Severity::Warning, path, logrotate_aware, &suppression_map);
+                                let suppressed = severity == Severity::Info;
+                                if suppressed {
+                                    tracing::info!(
+                                        path = %path.display(),
+                                        change = "permission_changed",
+                                        suppressed_by_logrotate = true,
+                                        "ログファイルのパーミッション変更を検知しました（logrotate による抑制中）"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        path = %path.display(),
+                                        change = "permission_changed",
+                                        "ログファイルのパーミッション変更を検知しました"
+                                    );
+                                }
                                 if let Some(ref bus) = event_bus {
                                     bus.publish(
                                         SecurityEvent::new(
                                             "log_permission_changed",
-                                            Severity::Warning,
+                                            severity,
                                             "log_tamper",
                                             format!("ログファイルのパーミッション変更を検知しました: {}", path.display()),
-                                        )
-                                        .with_details(path.display().to_string()),
-                                    );
-                                }
-                            }
-                            for path in &report.rotated {
-                                tracing::info!(
-                                    path = %path.display(),
-                                    change = "rotated",
-                                    "ログファイルのローテーションを検知しました"
-                                );
-                                if let Some(ref bus) = event_bus {
-                                    bus.publish(
-                                        SecurityEvent::new(
-                                            "log_rotated",
-                                            Severity::Info,
-                                            "log_tamper",
-                                            format!("ログファイルのローテーションを検知しました: {}", path.display()),
-                                        )
-                                        .with_details(path.display().to_string()),
-                                    );
-                                }
-                            }
-                            for path in &report.new_files {
-                                tracing::info!(
-                                    path = %path.display(),
-                                    change = "new_file",
-                                    "新規ログファイルを検知しました"
-                                );
-                                if let Some(ref bus) = event_bus {
-                                    bus.publish(
-                                        SecurityEvent::new(
-                                            "log_new_file",
-                                            Severity::Info,
-                                            "log_tamper",
-                                            format!("新規ログファイルを検知しました: {}", path.display()),
                                         )
                                         .with_details(path.display().to_string()),
                                     );
@@ -564,6 +722,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 0,
             watch_paths: vec![],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         let result = module.init();
@@ -580,6 +740,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 30,
             watch_paths: vec![file],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         let result = module.init();
@@ -592,6 +754,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 30,
             watch_paths: vec![PathBuf::from("/nonexistent-path-zettai-log-test")],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         let result = module.init();
@@ -617,6 +781,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 30,
             watch_paths: vec![non_canonical],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         let result = module.init();
@@ -636,6 +802,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 3600,
             watch_paths: vec![file],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         module.init().unwrap();
@@ -690,6 +858,8 @@ mod tests {
             enabled: true,
             scan_interval_secs: 30,
             watch_paths: vec![file1, file2],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let mut module = LogTamperModule::new(config, None);
         module.init().unwrap();
@@ -706,11 +876,132 @@ mod tests {
             enabled: true,
             scan_interval_secs: 30,
             watch_paths: vec![],
+            logrotate_aware: true,
+            logrotate_suppression_secs: 300,
         };
         let module = LogTamperModule::new(config, None);
 
         let result = module.initial_scan().await.unwrap();
         assert_eq!(result.items_scanned, 0);
         assert_eq!(result.issues_found, 0);
+    }
+
+    // --- is_rotation_artifact テスト ---
+
+    #[test]
+    fn test_is_rotation_artifact_numbered_suffix() {
+        assert!(is_rotation_artifact(Path::new("/var/log/syslog.1")));
+        assert!(is_rotation_artifact(Path::new("/var/log/auth.log.2")));
+        assert!(is_rotation_artifact(Path::new("/var/log/messages.10")));
+    }
+
+    #[test]
+    fn test_is_rotation_artifact_compressed() {
+        assert!(is_rotation_artifact(Path::new("/var/log/syslog.1.gz")));
+        assert!(is_rotation_artifact(Path::new("/var/log/auth.log.2.bz2")));
+        assert!(is_rotation_artifact(Path::new("/var/log/kern.log.3.xz")));
+        assert!(is_rotation_artifact(Path::new("/var/log/messages.1.zst")));
+    }
+
+    #[test]
+    fn test_is_rotation_artifact_date_suffix() {
+        assert!(is_rotation_artifact(Path::new("/var/log/access-20260407")));
+        assert!(is_rotation_artifact(Path::new("/var/log/error-20251231")));
+    }
+
+    #[test]
+    fn test_is_rotation_artifact_not_rotated() {
+        assert!(!is_rotation_artifact(Path::new("/var/log/syslog")));
+        assert!(!is_rotation_artifact(Path::new("/var/log/auth.log")));
+        assert!(!is_rotation_artifact(Path::new("/var/log/kern.log")));
+        assert!(!is_rotation_artifact(Path::new("/var/log/messages")));
+    }
+
+    // --- extract_base_path テスト ---
+
+    #[test]
+    fn test_extract_base_path_numbered() {
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/syslog.1")),
+            PathBuf::from("/var/log/syslog")
+        );
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/auth.log.2")),
+            PathBuf::from("/var/log/auth.log")
+        );
+    }
+
+    #[test]
+    fn test_extract_base_path_compressed() {
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/syslog.1.gz")),
+            PathBuf::from("/var/log/syslog")
+        );
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/auth.log.2.bz2")),
+            PathBuf::from("/var/log/auth.log")
+        );
+    }
+
+    #[test]
+    fn test_extract_base_path_date() {
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/access-20260407")),
+            PathBuf::from("/var/log/access")
+        );
+    }
+
+    #[test]
+    fn test_extract_base_path_no_rotation() {
+        assert_eq!(
+            extract_base_path(Path::new("/var/log/syslog")),
+            PathBuf::from("/var/log/syslog")
+        );
+    }
+
+    // --- resolve_severity テスト ---
+
+    #[test]
+    fn test_resolve_severity_no_suppression() {
+        let map = HashMap::new();
+        assert_eq!(
+            resolve_severity(Severity::Warning, Path::new("/var/log/syslog"), true, &map),
+            Severity::Warning
+        );
+    }
+
+    #[test]
+    fn test_resolve_severity_suppressed_direct() {
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("/var/log/syslog"), std::time::Instant::now());
+        assert_eq!(
+            resolve_severity(Severity::Warning, Path::new("/var/log/syslog"), true, &map),
+            Severity::Info
+        );
+    }
+
+    #[test]
+    fn test_resolve_severity_suppressed_via_base() {
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("/var/log/syslog"), std::time::Instant::now());
+        assert_eq!(
+            resolve_severity(
+                Severity::Warning,
+                Path::new("/var/log/syslog.1"),
+                true,
+                &map
+            ),
+            Severity::Info
+        );
+    }
+
+    #[test]
+    fn test_resolve_severity_disabled() {
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("/var/log/syslog"), std::time::Instant::now());
+        assert_eq!(
+            resolve_severity(Severity::Warning, Path::new("/var/log/syslog"), false, &map),
+            Severity::Warning
+        );
     }
 }


### PR DESCRIPTION
## Summary

- ログファイル改ざん検知モジュール（`log_tamper`）に logrotate 対応を追加し、ローテーションによる正常なファイル変更の誤検知を防止
- `LogTamperConfig` に `logrotate_aware`（デフォルト true）と `logrotate_suppression_secs`（デフォルト 300秒）を追加
- ローテーション検知後の一定時間、関連ファイルの変更イベント Severity を Info に自動降格

## 変更内容

- `is_rotation_artifact()`: `.1`, `.gz`, `.bz2`, `.xz`, `.zst`, `-YYYYMMDD` パターンのローテーション生成物を判定
- `extract_base_path()`: ローテーション生成物からベースパスを抽出（圧縮拡張子の再帰的除去対応）
- `resolve_severity()`: 抑制マップに基づき Severity を調整
- `start()` メソッド: 抑制マップ管理、処理順序変更（rotated → new_files → size_decreased → deleted → permission_changed）
- 新規テスト 12 件追加、既存テスト全 38 件パス

Closes #155

## Test plan

- [x] `cargo test` — 全 38 テスト合格
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット準拠
- [x] `unwrap()` / `expect()` が本番コードで使用されていないことを確認
- [x] 設計レビュー承認済み
- [x] コードレビュー・テスト検証合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)