### PR TITLE
feat: CLI ダッシュボード（TUI）— ratatui ベースのリアルタイム監視ダッシュボード (#217)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +180,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,12 +263,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -279,6 +339,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -348,6 +442,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -588,6 +688,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -814,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +983,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -889,6 +1019,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -939,6 +1078,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -950,10 +1095,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -989,6 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1076,6 +1240,35 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -1260,6 +1453,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1594,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1378,7 +1614,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1437,6 +1673,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1535,6 +1777,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,10 +1836,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -1624,7 +1915,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1960,6 +2251,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2495,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2182,6 +2518,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2495,7 +2837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -2606,11 +2948,13 @@ name = "zettai-mamorukun"
 version = "1.6.0"
 dependencies = [
  "clap",
+ "crossterm",
  "csv",
  "glob",
  "inotify",
  "libc",
  "pem",
+ "ratatui",
  "regex",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -28,6 +28,8 @@ pem = "3"
 tracing-journald = "0.3"
 libc = "0.2"
 glob = "0.3"
+ratatui = "0.29"
+crossterm = "0.28"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/core/dashboard.rs
+++ b/src/core/dashboard.rs
@@ -1,0 +1,706 @@
+//! CLI ダッシュボード（TUI）— ratatui ベースのリアルタイム監視ダッシュボード
+
+use crate::core::status::{self, StatusResponse};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use tokio::sync::mpsc;
+
+const MAX_EVENTS: usize = 200;
+
+/// TUI で表示するイベント
+#[derive(Debug, Clone)]
+struct DashboardEvent {
+    severity: String,
+    source_module: String,
+    event_type: String,
+    message: String,
+}
+
+/// アクティブなパネル
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActivePanel {
+    Modules,
+    Events,
+    Metrics,
+}
+
+impl ActivePanel {
+    fn next(self) -> Self {
+        match self {
+            ActivePanel::Modules => ActivePanel::Events,
+            ActivePanel::Events => ActivePanel::Metrics,
+            ActivePanel::Metrics => ActivePanel::Modules,
+        }
+    }
+}
+
+/// バックグラウンドタスクから TUI スレッドへ送るメッセージ
+enum AppMessage {
+    StatusUpdate(StatusResponse),
+    StatusError,
+    NewEvent(DashboardEvent),
+    EventStreamConnected,
+    EventStreamDisconnected,
+}
+
+/// TUI アプリケーション状態
+struct App {
+    status: Option<StatusResponse>,
+    connected: bool,
+    event_stream_connected: bool,
+    events: VecDeque<DashboardEvent>,
+    active_panel: ActivePanel,
+    module_scroll: usize,
+    event_scroll: usize,
+    metrics_scroll: usize,
+    should_quit: bool,
+}
+
+impl App {
+    fn new() -> Self {
+        Self {
+            status: None,
+            connected: false,
+            event_stream_connected: false,
+            events: VecDeque::with_capacity(MAX_EVENTS),
+            active_panel: ActivePanel::Modules,
+            module_scroll: 0,
+            event_scroll: 0,
+            metrics_scroll: 0,
+            should_quit: false,
+        }
+    }
+
+    fn push_event(&mut self, event: DashboardEvent) {
+        if self.events.len() >= MAX_EVENTS {
+            self.events.pop_front();
+        }
+        self.events.push_back(event);
+    }
+
+    fn update_status(&mut self, response: StatusResponse) {
+        self.status = Some(response);
+        self.connected = true;
+    }
+
+    fn scroll_up(&mut self) {
+        match self.active_panel {
+            ActivePanel::Modules => self.module_scroll = self.module_scroll.saturating_sub(1),
+            ActivePanel::Events => self.event_scroll = self.event_scroll.saturating_sub(1),
+            ActivePanel::Metrics => self.metrics_scroll = self.metrics_scroll.saturating_sub(1),
+        }
+    }
+
+    fn scroll_down(&mut self) {
+        match self.active_panel {
+            ActivePanel::Modules => self.module_scroll = self.module_scroll.saturating_add(1),
+            ActivePanel::Events => self.event_scroll = self.event_scroll.saturating_add(1),
+            ActivePanel::Metrics => self.metrics_scroll = self.metrics_scroll.saturating_add(1),
+        }
+    }
+}
+
+struct DashboardLayout {
+    header: Rect,
+    modules: Rect,
+    events: Rect,
+    metrics: Rect,
+    footer: Rect,
+}
+
+fn build_layout(area: Rect) -> DashboardLayout {
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(10),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    let main = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(outer[1]);
+
+    let right = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(60), Constraint::Percentage(40)])
+        .split(main[1]);
+
+    DashboardLayout {
+        header: outer[0],
+        modules: main[0],
+        events: right[0],
+        metrics: right[1],
+        footer: outer[2],
+    }
+}
+
+/// ダッシュボードを起動する
+pub async fn run_dashboard(
+    status_socket: impl AsRef<Path>,
+    event_stream_socket: impl AsRef<Path>,
+) -> Result<(), String> {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    let status_path = status_socket.as_ref().to_path_buf();
+    let tx_status = tx.clone();
+    tokio::spawn(async move {
+        status_polling_task(status_path, tx_status).await;
+    });
+
+    let event_path = event_stream_socket.as_ref().to_path_buf();
+    let tx_events = tx;
+    tokio::spawn(async move {
+        event_stream_task(event_path, tx_events).await;
+    });
+
+    let mut terminal = ratatui::init();
+    let result = run_app(&mut terminal, rx);
+    ratatui::restore();
+    result
+}
+
+fn run_app(
+    terminal: &mut ratatui::DefaultTerminal,
+    mut rx: mpsc::UnboundedReceiver<AppMessage>,
+) -> Result<(), String> {
+    let mut app = App::new();
+
+    loop {
+        while let Ok(msg) = rx.try_recv() {
+            match msg {
+                AppMessage::StatusUpdate(resp) => app.update_status(resp),
+                AppMessage::StatusError => app.connected = false,
+                AppMessage::NewEvent(ev) => app.push_event(ev),
+                AppMessage::EventStreamConnected => app.event_stream_connected = true,
+                AppMessage::EventStreamDisconnected => app.event_stream_connected = false,
+            }
+        }
+
+        terminal
+            .draw(|frame| render(frame, &app))
+            .map_err(|e| format!("描画エラー: {}", e))?;
+
+        if event::poll(std::time::Duration::from_millis(100))
+            .map_err(|e| format!("イベントポーリングエラー: {}", e))?
+            && let Event::Key(key) =
+                event::read().map_err(|e| format!("キーイベント読み取りエラー: {}", e))?
+            && key.kind == KeyEventKind::Press
+        {
+            handle_key(&mut app, key.code);
+        }
+
+        if app.should_quit {
+            return Ok(());
+        }
+    }
+}
+
+fn handle_key(app: &mut App, code: KeyCode) {
+    match code {
+        KeyCode::Char('q') => app.should_quit = true,
+        KeyCode::Tab => app.active_panel = app.active_panel.next(),
+        KeyCode::Up => app.scroll_up(),
+        KeyCode::Down => app.scroll_down(),
+        _ => {}
+    }
+}
+
+async fn status_polling_task(socket_path: PathBuf, tx: mpsc::UnboundedSender<AppMessage>) {
+    loop {
+        match status::query_status(&socket_path).await {
+            Ok(response) => {
+                if tx.send(AppMessage::StatusUpdate(response)).is_err() {
+                    break;
+                }
+            }
+            Err(_) => {
+                if tx.send(AppMessage::StatusError).is_err() {
+                    break;
+                }
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+}
+
+async fn event_stream_task(socket_path: PathBuf, tx: mpsc::UnboundedSender<AppMessage>) {
+    use tokio::io::AsyncBufReadExt;
+    use tokio::net::UnixStream;
+
+    loop {
+        match UnixStream::connect(&socket_path).await {
+            Ok(stream) => {
+                let _ = tx.send(AppMessage::EventStreamConnected);
+                let reader = tokio::io::BufReader::new(stream);
+                let mut lines = reader.lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&line) {
+                        let event = DashboardEvent {
+                            severity: parsed
+                                .get("severity")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("?")
+                                .to_string(),
+                            source_module: parsed
+                                .get("source_module")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("?")
+                                .to_string(),
+                            event_type: parsed
+                                .get("event_type")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("?")
+                                .to_string(),
+                            message: parsed
+                                .get("message")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                        };
+                        if tx.send(AppMessage::NewEvent(event)).is_err() {
+                            return;
+                        }
+                    }
+                }
+                let _ = tx.send(AppMessage::EventStreamDisconnected);
+            }
+            Err(_) => {
+                let _ = tx.send(AppMessage::EventStreamDisconnected);
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    }
+}
+
+fn render(frame: &mut Frame, app: &App) {
+    let layout = build_layout(frame.area());
+    render_header(frame, &layout, app);
+    render_modules(frame, &layout, app);
+    render_events(frame, &layout, app);
+    render_metrics(frame, &layout, app);
+    render_footer(frame, &layout, app);
+}
+
+fn render_header(frame: &mut Frame, layout: &DashboardLayout, app: &App) {
+    let version = app
+        .status
+        .as_ref()
+        .map(|s| s.version.clone())
+        .unwrap_or_else(|| "---".to_string());
+    let uptime = app
+        .status
+        .as_ref()
+        .map(|s| format_uptime(s.uptime_secs))
+        .unwrap_or_else(|| "---".to_string());
+    let status_indicator = if app.connected { "●" } else { "○" };
+    let status_color = if app.connected {
+        Color::Green
+    } else {
+        Color::Red
+    };
+    let event_indicator = if app.event_stream_connected {
+        "●"
+    } else {
+        "○"
+    };
+    let event_color = if app.event_stream_connected {
+        Color::Green
+    } else {
+        Color::Red
+    };
+
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            format!(" ぜったいまもるくん v{}", version),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("  |  稼働: "),
+        Span::raw(uptime),
+        Span::raw("  |  ステータス: "),
+        Span::styled(status_indicator, Style::default().fg(status_color)),
+        Span::raw("  イベント: "),
+        Span::styled(event_indicator, Style::default().fg(event_color)),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+
+    frame.render_widget(header, layout.header);
+}
+
+fn render_modules(frame: &mut Frame, layout: &DashboardLayout, app: &App) {
+    let border_style = if app.active_panel == ActivePanel::Modules {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+
+    let modules = app
+        .status
+        .as_ref()
+        .map(|s| s.modules.clone())
+        .unwrap_or_default();
+
+    let module_count = modules.len();
+    let visible_height = layout.modules.height.saturating_sub(2) as usize;
+    let max_scroll = module_count.saturating_sub(visible_height);
+    let scroll = app.module_scroll.min(max_scroll);
+
+    let items: Vec<ListItem> = modules
+        .iter()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|m| {
+            let restart_count = app
+                .status
+                .as_ref()
+                .and_then(|s| s.module_restarts.get(m))
+                .copied()
+                .unwrap_or(0);
+            let suffix = if restart_count > 0 {
+                format!(" (再起動: {}回)", restart_count)
+            } else {
+                String::new()
+            };
+            ListItem::new(format!("● {}{}", m, suffix)).style(Style::default().fg(Color::Green))
+        })
+        .collect();
+
+    let title = format!("モジュール ({})", module_count);
+    let list = List::new(items).block(
+        Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(border_style),
+    );
+
+    frame.render_widget(list, layout.modules);
+}
+
+fn render_events(frame: &mut Frame, layout: &DashboardLayout, app: &App) {
+    let border_style = if app.active_panel == ActivePanel::Events {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+
+    let visible_height = layout.events.height.saturating_sub(2) as usize;
+    let total = app.events.len();
+    let max_scroll = total.saturating_sub(visible_height);
+    let scroll = app.event_scroll.min(max_scroll);
+
+    let items: Vec<ListItem> = app
+        .events
+        .iter()
+        .rev()
+        .skip(scroll)
+        .take(visible_height)
+        .map(|ev| {
+            let (severity_style, severity_label) = match ev.severity.as_str() {
+                "CRITICAL" => (
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                    "CRIT",
+                ),
+                "WARNING" => (Style::default().fg(Color::Yellow), "WARN"),
+                _ => (Style::default().fg(Color::Blue), "INFO"),
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("[{}]", severity_label), severity_style),
+                Span::raw(format!(
+                    " {} ({}): {}",
+                    ev.event_type, ev.source_module, ev.message
+                )),
+            ]))
+        })
+        .collect();
+
+    let title = format!("イベント ({})", total);
+    let list = List::new(items).block(
+        Block::default()
+            .title(title)
+            .borders(Borders::ALL)
+            .border_style(border_style),
+    );
+
+    frame.render_widget(list, layout.events);
+}
+
+fn render_metrics(frame: &mut Frame, layout: &DashboardLayout, app: &App) {
+    let border_style = if app.active_panel == ActivePanel::Metrics {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+
+    let visible_height = layout.metrics.height.saturating_sub(2) as usize;
+
+    let lines = if let Some(metrics) = app.status.as_ref().and_then(|s| s.metrics.as_ref()) {
+        let mut lines = vec![
+            Line::from(vec![
+                Span::raw("合計: "),
+                Span::styled(
+                    metrics.total_events.to_string(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    format!("INFO: {}", metrics.info_count),
+                    Style::default().fg(Color::Blue),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    format!("WARNING: {}", metrics.warning_count),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::raw("  "),
+                Span::styled(
+                    format!("CRITICAL: {}", metrics.critical_count),
+                    Style::default().fg(Color::Red),
+                ),
+            ]),
+            Line::raw(""),
+            Line::raw("モジュール別上位:"),
+        ];
+
+        let mut sorted: Vec<_> = metrics.module_counts.iter().collect();
+        sorted.sort_by_key(|(_, v)| std::cmp::Reverse(**v));
+        for (module, count) in sorted.iter().take(10) {
+            lines.push(Line::from(format!("  {}: {}", module, count)));
+        }
+
+        lines
+    } else {
+        vec![Line::raw(
+            "メトリクスデータなし（デーモン未接続または無効）",
+        )]
+    };
+
+    let max_scroll_offset = lines.len().saturating_sub(visible_height);
+    let scroll = app.metrics_scroll.min(max_scroll_offset);
+
+    let paragraph = Paragraph::new(lines).scroll((scroll as u16, 0)).block(
+        Block::default()
+            .title("メトリクス")
+            .borders(Borders::ALL)
+            .border_style(border_style),
+    );
+
+    frame.render_widget(paragraph, layout.metrics);
+}
+
+fn render_footer(frame: &mut Frame, layout: &DashboardLayout, app: &App) {
+    let active_name = match app.active_panel {
+        ActivePanel::Modules => "モジュール",
+        ActivePanel::Events => "イベント",
+        ActivePanel::Metrics => "メトリクス",
+    };
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled(" [Tab]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" パネル切替  "),
+        Span::styled("[↑↓]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" スクロール  "),
+        Span::styled("[q]", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" 終了  "),
+        Span::raw(format!("| 選択: {}", active_name)),
+    ]))
+    .style(Style::default().fg(Color::DarkGray));
+
+    frame.render_widget(footer, layout.footer);
+}
+
+fn format_uptime(secs: u64) -> String {
+    let hours = secs / 3600;
+    let minutes = (secs % 3600) / 60;
+    let seconds = secs % 60;
+    if hours > 0 {
+        format!("{}h {}m {}s", hours, minutes, seconds)
+    } else if minutes > 0 {
+        format!("{}m {}s", minutes, seconds)
+    } else {
+        format!("{}s", seconds)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::status::MetricsSummary;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_app_new() {
+        let app = App::new();
+        assert!(app.status.is_none());
+        assert!(!app.connected);
+        assert!(!app.event_stream_connected);
+        assert!(app.events.is_empty());
+        assert_eq!(app.active_panel, ActivePanel::Modules);
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn test_push_event_within_limit() {
+        let mut app = App::new();
+        for i in 0..10 {
+            app.push_event(DashboardEvent {
+                severity: "INFO".to_string(),
+                source_module: "test".to_string(),
+                event_type: format!("event_{}", i),
+                message: "test".to_string(),
+            });
+        }
+        assert_eq!(app.events.len(), 10);
+    }
+
+    #[test]
+    fn test_push_event_overflow() {
+        let mut app = App::new();
+        for i in 0..MAX_EVENTS + 10 {
+            app.push_event(DashboardEvent {
+                severity: "INFO".to_string(),
+                source_module: "test".to_string(),
+                event_type: format!("event_{}", i),
+                message: "test".to_string(),
+            });
+        }
+        assert_eq!(app.events.len(), MAX_EVENTS);
+        assert_eq!(
+            app.events.front().map(|e| e.event_type.as_str()),
+            Some("event_10")
+        );
+    }
+
+    #[test]
+    fn test_update_status() {
+        let mut app = App::new();
+        assert!(!app.connected);
+
+        app.update_status(StatusResponse {
+            version: "1.6.0".to_string(),
+            uptime_secs: 100,
+            modules: vec!["mod_a".to_string()],
+            metrics: None,
+            module_restarts: HashMap::new(),
+        });
+
+        assert!(app.connected);
+        assert!(app.status.is_some());
+        assert_eq!(app.status.as_ref().map(|s| s.uptime_secs), Some(100));
+    }
+
+    #[test]
+    fn test_active_panel_cycle() {
+        assert_eq!(ActivePanel::Modules.next(), ActivePanel::Events);
+        assert_eq!(ActivePanel::Events.next(), ActivePanel::Metrics);
+        assert_eq!(ActivePanel::Metrics.next(), ActivePanel::Modules);
+    }
+
+    #[test]
+    fn test_scroll() {
+        let mut app = App::new();
+        app.active_panel = ActivePanel::Modules;
+
+        app.scroll_down();
+        assert_eq!(app.module_scroll, 1);
+        app.scroll_down();
+        assert_eq!(app.module_scroll, 2);
+        app.scroll_up();
+        assert_eq!(app.module_scroll, 1);
+        app.scroll_up();
+        assert_eq!(app.module_scroll, 0);
+        app.scroll_up();
+        assert_eq!(app.module_scroll, 0);
+    }
+
+    #[test]
+    fn test_format_uptime() {
+        assert_eq!(format_uptime(0), "0s");
+        assert_eq!(format_uptime(59), "59s");
+        assert_eq!(format_uptime(60), "1m 0s");
+        assert_eq!(format_uptime(3661), "1h 1m 1s");
+        assert_eq!(format_uptime(7200), "2h 0m 0s");
+    }
+
+    #[test]
+    fn test_build_layout() {
+        let area = Rect::new(0, 0, 120, 40);
+        let layout = build_layout(area);
+
+        assert_eq!(layout.header.height, 3);
+        assert_eq!(layout.footer.height, 1);
+        assert!(layout.modules.width > 0);
+        assert!(layout.events.width > 0);
+        assert!(layout.metrics.width > 0);
+    }
+
+    #[test]
+    fn test_render_does_not_panic() {
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal creation");
+
+        let mut app = App::new();
+        app.update_status(StatusResponse {
+            version: "1.7.0".to_string(),
+            uptime_secs: 3600,
+            modules: vec!["module_a".to_string(), "module_b".to_string()],
+            metrics: Some(MetricsSummary {
+                total_events: 100,
+                info_count: 80,
+                warning_count: 15,
+                critical_count: 5,
+                module_counts: HashMap::from([("module_a".to_string(), 60)]),
+            }),
+            module_restarts: HashMap::from([("module_b".to_string(), 2)]),
+        });
+
+        app.push_event(DashboardEvent {
+            severity: "CRITICAL".to_string(),
+            source_module: "module_a".to_string(),
+            event_type: "file_modified".to_string(),
+            message: "test critical event".to_string(),
+        });
+        app.push_event(DashboardEvent {
+            severity: "WARNING".to_string(),
+            source_module: "module_b".to_string(),
+            event_type: "process_anomaly".to_string(),
+            message: "test warning event".to_string(),
+        });
+        app.push_event(DashboardEvent {
+            severity: "INFO".to_string(),
+            source_module: "module_a".to_string(),
+            event_type: "scan_complete".to_string(),
+            message: "test info event".to_string(),
+        });
+
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+
+    #[test]
+    fn test_render_disconnected_state() {
+        let backend = ratatui::backend::TestBackend::new(80, 24);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal creation");
+
+        let app = App::new();
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+
+    #[test]
+    fn test_render_with_active_panels() {
+        let backend = ratatui::backend::TestBackend::new(120, 40);
+        let mut terminal = ratatui::Terminal::new(backend).expect("test terminal creation");
+
+        let mut app = App::new();
+        app.active_panel = ActivePanel::Events;
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+
+        app.active_panel = ActivePanel::Metrics;
+        terminal.draw(|frame| render(frame, &app)).unwrap();
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ pub mod action;
 pub mod correlation;
 pub mod correlation_presets;
 pub mod daemon;
+pub mod dashboard;
 pub mod event;
 pub mod event_store;
 pub mod event_stream;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process;
 use zettai_mamorukun::config::AppConfig;
 use zettai_mamorukun::core::daemon::Daemon;
+use zettai_mamorukun::core::dashboard;
 use zettai_mamorukun::core::event_store;
 use zettai_mamorukun::core::event_stream;
 use zettai_mamorukun::core::status;
@@ -102,6 +103,15 @@ enum Commands {
         /// 出力フォーマット (json, text)
         #[arg(long, default_value = "json")]
         format: String,
+    },
+    /// リアルタイム監視ダッシュボードを表示する
+    Dashboard {
+        /// ステータスソケットのパス
+        #[arg(long, default_value = "/var/run/zettai-mamorukun/status.sock")]
+        status_socket: PathBuf,
+        /// イベントストリームソケットのパス
+        #[arg(long, default_value = "/var/run/zettai-mamorukun/event_stream.sock")]
+        event_stream_socket: PathBuf,
     },
     /// 永続化されたセキュリティイベントを検索する
     SearchEvents {
@@ -864,6 +874,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             format,
         }) => {
             match event_stream::stream_events(socket_path, format).await {
+                Ok(()) => {}
+                Err(e) => {
+                    eprintln!("エラー: {}", e);
+                    process::exit(1);
+                }
+            }
+            return Ok(());
+        }
+        Some(Commands::Dashboard {
+            status_socket,
+            event_stream_socket,
+        }) => {
+            match dashboard::run_dashboard(status_socket, event_stream_socket).await {
                 Ok(()) => {}
                 Err(e) => {
                     eprintln!("エラー: {}", e);


### PR DESCRIPTION
## 概要

ターミナル上でリアルタイムにイベントストリーム・メトリクス・モジュール状態を一覧表示する対話型ダッシュボード（ratatui ベース）を実装。

Closes #217

## 変更内容

- `src/core/dashboard.rs` — TUI ダッシュボード全体の実装（約 715 行）
  - **ヘッダー**: バージョン、稼働時間、ステータス/イベントストリーム接続状態表示
  - **モジュール一覧パネル**: 全モジュールの稼働状態・再起動回数をリスト表示
  - **イベントストリームパネル**: 最新の SecurityEvent をリアルタイム表示（Severity 色分け）
  - **メトリクスパネル**: イベント件数（Severity 別、モジュール別上位 10）
  - **キーボード操作**: `q` 終了、`Tab` パネル切替、矢印キースクロール
- `src/main.rs` — `dashboard` サブコマンド追加
- `Cargo.toml` — ratatui 0.29, crossterm 0.28 依存追加、バージョン v1.7.0

## 技術設計

- 非同期データ取得（tokio タスク）+ 同期 TUI ループの mpsc チャネル連携
- status ソケットから 1 秒間隔でポーリング
- event_stream ソケットから NDJSON リアルタイム受信（自動再接続付き）
- イベントバッファ: VecDeque 最大 200 件の FIFO
- テスト: 11 件（App 状態管理、レイアウト、レンダリング）

## テスト計画

- [x] `cargo test` — 全 38 テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット OK