### PR TITLE
feat: Syslog TLS 対応（RFC 5425 形式の暗号化ログ転送） (#223)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
-- **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP プロトコル対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
+- **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +223,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -255,6 +279,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -444,6 +477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +548,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -812,7 +857,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1044,6 +1089,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1484,6 +1539,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,7 +1624,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -1634,12 +1702,23 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1658,6 +1737,7 @@ version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2497,6 +2577,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
@@ -2851,6 +2940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -2966,21 +3064,26 @@ dependencies = [
  "libc",
  "pem",
  "ratatui",
+ "rcgen",
  "regex",
  "reqwest",
  "rusqlite",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "toml",
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
  "walkdir",
+ "webpki-roots 0.26.11",
  "wiremock",
  "x509-parser",
  "xattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.9.0"
+version = "1.10.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -31,8 +31,13 @@ glob = "0.3"
 ratatui = "0.29"
 crossterm = "0.28"
 gethostname = "1.0"
+tokio-rustls = "0.26"
+rustls-pki-types = "1"
+webpki-roots = "0.26"
+rustls-pemfile = "2"
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }
 wiremock = "0.6"
+rcgen = "0.13"

--- a/config.example.toml
+++ b/config.example.toml
@@ -710,7 +710,8 @@ enabled = false
 # Syslog 転送（RFC 5424 形式）の有効/無効
 # 有効にすると SecurityEvent を外部 Syslog サーバ（SIEM 等）に転送する
 enabled = false
-# プロトコル（"udp" or "tcp"）
+# プロトコル（"udp", "tcp", or "tls"）
+# TLS を指定すると RFC 5425 形式の暗号化ログ転送を行う
 protocol = "udp"
 # Syslog サーバのアドレス
 server = "127.0.0.1"
@@ -724,6 +725,14 @@ facility = "local0"
 hostname = ""
 # アプリケーション名
 app_name = "zettai-mamorukun"
+
+[syslog.tls]
+# CA 証明書ファイルパス（PEM 形式）
+# 未指定の場合はシステムのルート証明書を使用
+# ca_cert_path = "/etc/zettai-mamorukun/ca.pem"
+# ホスト名検証（デフォルト: true）
+# 自己署名証明書を使う場合は false に設定
+verify_hostname = true
 
 [event_store]
 # イベントストア（SQLite 永続化）の有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -3003,6 +3003,33 @@ impl Default for ModuleWatchdogConfig {
     }
 }
 
+/// Syslog TLS 設定
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct SyslogTlsConfig {
+    /// CA 証明書ファイルパス（PEM 形式）
+    #[serde(default)]
+    pub ca_cert_path: Option<String>,
+
+    /// ホスト名検証の有効/無効（デフォルト: true）
+    #[serde(default = "SyslogTlsConfig::default_verify_hostname")]
+    pub verify_hostname: bool,
+}
+
+impl SyslogTlsConfig {
+    fn default_verify_hostname() -> bool {
+        true
+    }
+}
+
+impl Default for SyslogTlsConfig {
+    fn default() -> Self {
+        Self {
+            ca_cert_path: None,
+            verify_hostname: true,
+        }
+    }
+}
+
 /// Syslog 転送設定
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct SyslogConfig {
@@ -3010,7 +3037,7 @@ pub struct SyslogConfig {
     #[serde(default)]
     pub enabled: bool,
 
-    /// プロトコル（"udp" or "tcp"）
+    /// プロトコル（"udp", "tcp", or "tls"）
     #[serde(default = "SyslogConfig::default_protocol")]
     pub protocol: String,
 
@@ -3033,6 +3060,10 @@ pub struct SyslogConfig {
     /// アプリケーション名
     #[serde(default = "SyslogConfig::default_app_name")]
     pub app_name: String,
+
+    /// TLS 設定
+    #[serde(default)]
+    pub tls: SyslogTlsConfig,
 }
 
 impl SyslogConfig {
@@ -3067,6 +3098,7 @@ impl Default for SyslogConfig {
             facility: Self::default_facility(),
             hostname: String::new(),
             app_name: Self::default_app_name(),
+            tls: SyslogTlsConfig::default(),
         }
     }
 }
@@ -3753,10 +3785,10 @@ impl AppConfig {
 
         // syslog 設定の検証
         if self.syslog.enabled {
-            let valid_protocols = ["udp", "tcp"];
+            let valid_protocols = ["udp", "tcp", "tls"];
             if !valid_protocols.contains(&self.syslog.protocol.as_str()) {
                 errors.push(format!(
-                    "syslog.protocol: 無効な値 '{}' (有効値: udp, tcp)",
+                    "syslog.protocol: 無効な値 '{}' (有効値: udp, tcp, tls)",
                     self.syslog.protocol
                 ));
             }

--- a/src/core/syslog.rs
+++ b/src/core/syslog.rs
@@ -1,21 +1,34 @@
-//! Syslog イベント転送 — RFC 5424 形式で外部 SIEM に SecurityEvent を転送
+//! Syslog イベント転送 — RFC 5424 / RFC 5425 形式で外部 SIEM に SecurityEvent を転送
 
 use crate::config::SyslogConfig;
 use crate::core::event::{EventBus, SecurityEvent, Severity};
+use std::sync::Arc;
 use std::time::SystemTime;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::{broadcast, watch};
+use tokio_rustls::TlsConnector;
+use tokio_rustls::rustls;
 
 /// ホットリロード対象のランタイム設定
 #[derive(Debug, Clone)]
 pub struct SyslogRuntimeConfig {
+    /// プロトコル（"udp", "tcp", "tls"）
     pub protocol: String,
+    /// Syslog サーバのアドレス
     pub server: String,
+    /// Syslog サーバのポート
     pub port: u16,
+    /// Syslog facility
     pub facility: String,
+    /// ホスト名
     pub hostname: String,
+    /// アプリケーション名
     pub app_name: String,
+    /// TLS CA 証明書ファイルパス（PEM 形式）
+    pub tls_ca_cert_path: Option<String>,
+    /// TLS ホスト名検証の有効/無効
+    pub tls_verify_hostname: bool,
 }
 
 impl From<&SyslogConfig> for SyslogRuntimeConfig {
@@ -27,6 +40,8 @@ impl From<&SyslogConfig> for SyslogRuntimeConfig {
             facility: config.facility.clone(),
             hostname: config.hostname.clone(),
             app_name: config.app_name.clone(),
+            tls_ca_cert_path: config.tls.ca_cert_path.clone(),
+            tls_verify_hostname: config.tls.verify_hostname,
         }
     }
 }
@@ -103,7 +118,9 @@ impl SyslogForwarder {
                             let new_config = config_receiver.borrow_and_update().clone();
                             let needs_reconnect = new_config.protocol != runtime.protocol
                                 || new_config.server != runtime.server
-                                || new_config.port != runtime.port;
+                                || new_config.port != runtime.port
+                                || new_config.tls_ca_cert_path != runtime.tls_ca_cert_path
+                                || new_config.tls_verify_hostname != runtime.tls_verify_hostname;
                             runtime = new_config;
                             if needs_reconnect {
                                 tracing::info!(
@@ -261,10 +278,110 @@ fn sd_escape(s: &str) -> String {
         .replace(']', "\\]")
 }
 
-/// トランスポート層（UDP / TCP）
+/// TLS クライアント設定を構築する
+fn build_tls_config(config: &SyslogRuntimeConfig) -> Result<rustls::ClientConfig, String> {
+    // CryptoProvider がまだインストールされていなければ ring を設定
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut root_store = rustls::RootCertStore::empty();
+
+    if let Some(ref ca_path) = config.tls_ca_cert_path {
+        let pem_data = std::fs::read(ca_path)
+            .map_err(|e| format!("CA 証明書ファイルの読み込みに失敗: {}: {}", ca_path, e))?;
+        let mut cursor = std::io::Cursor::new(pem_data);
+        let certs = rustls_pemfile::certs(&mut cursor)
+            .filter_map(|r| r.ok())
+            .collect::<Vec<_>>();
+        if certs.is_empty() {
+            return Err(format!(
+                "CA 証明書ファイルに有効な証明書が見つかりません: {}",
+                ca_path
+            ));
+        }
+        for cert in certs {
+            root_store
+                .add(cert)
+                .map_err(|e| format!("CA 証明書の追加に失敗: {}", e))?;
+        }
+    } else {
+        root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    }
+
+    if config.tls_verify_hostname {
+        rustls::ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
+            .pipe(Ok)
+    } else {
+        tracing::warn!(
+            "Syslog TLS: ホスト名検証が無効です。本番環境では有効にすることを推奨します"
+        );
+        let config = rustls::ClientConfig::builder()
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(NoVerifier))
+            .with_no_client_auth();
+        Ok(config)
+    }
+}
+
+/// ホスト名検証をスキップするカスタム証明書検証器
+///
+/// CA 証明書による署名検証は行わず、サーバ証明書の SAN/CN とホスト名の一致も検証しない。
+/// 自己署名証明書を使用するテスト環境等での利用を想定。
+#[derive(Debug)]
+struct NoVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls_pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls_pki_types::CertificateDer<'_>],
+        _server_name: &rustls_pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls_pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls_pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// パイプライン演算子的なヘルパートレイト
+trait Pipe: Sized {
+    fn pipe<T>(self, f: impl FnOnce(Self) -> T) -> T {
+        f(self)
+    }
+}
+
+impl<T> Pipe for T {}
+
+/// トランスポート層（UDP / TCP / TLS）
 enum Transport {
     Udp(UdpSocket),
     Tcp(TcpStream),
+    Tls(Box<tokio_rustls::client::TlsStream<TcpStream>>),
     Disconnected,
 }
 
@@ -308,6 +425,47 @@ impl Transport {
                     Transport::Disconnected
                 }
             },
+            "tls" => {
+                let tls_config = match build_tls_config(config) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Syslog: TLS 設定の構築に失敗しました");
+                        return Transport::Disconnected;
+                    }
+                };
+                let connector = TlsConnector::from(Arc::new(tls_config));
+                let tcp_stream = match TcpStream::connect(&addr).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::warn!(error = %e, addr = %addr, "Syslog: TLS 用 TCP 接続に失敗しました");
+                        return Transport::Disconnected;
+                    }
+                };
+                let server_name = match rustls_pki_types::ServerName::try_from(
+                    config.server.clone(),
+                ) {
+                    Ok(name) => name,
+                    Err(e) => {
+                        tracing::warn!(error = %e, server = %config.server, "Syslog: サーバ名の解析に失敗しました");
+                        return Transport::Disconnected;
+                    }
+                };
+                match connector.connect(server_name, tcp_stream).await {
+                    Ok(tls_stream) => {
+                        tracing::info!(
+                            protocol = "tls",
+                            server = %config.server,
+                            port = config.port,
+                            "Syslog: TLS 接続を確立しました"
+                        );
+                        Transport::Tls(Box::new(tls_stream))
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Syslog: TLS ハンドシェイクに失敗しました");
+                        Transport::Disconnected
+                    }
+                }
+            }
             _ => {
                 tracing::error!(protocol = %config.protocol, "Syslog: 不明なプロトコル");
                 Transport::Disconnected
@@ -332,6 +490,14 @@ impl Transport {
                     .map_err(|e| format!("TCP 送信エラー: {}", e))?;
                 Ok(())
             }
+            Transport::Tls(stream) => {
+                let framed = format!("{}\n", message);
+                stream
+                    .write_all(framed.as_bytes())
+                    .await
+                    .map_err(|e| format!("TLS 送信エラー: {}", e))?;
+                Ok(())
+            }
             Transport::Disconnected => {
                 *self = Self::connect(config).await;
                 match self {
@@ -350,6 +516,14 @@ impl Transport {
                             .map_err(|e| format!("TCP 送信エラー（再接続後）: {}", e))?;
                         Ok(())
                     }
+                    Transport::Tls(stream) => {
+                        let framed = format!("{}\n", message);
+                        stream
+                            .write_all(framed.as_bytes())
+                            .await
+                            .map_err(|e| format!("TLS 送信エラー（再接続後）: {}", e))?;
+                        Ok(())
+                    }
                     Transport::Disconnected => {
                         Err("Syslog サーバへの接続に失敗しました".to_string())
                     }
@@ -362,6 +536,7 @@ impl Transport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::SyslogTlsConfig;
 
     #[test]
     fn test_facility_code() {
@@ -415,6 +590,8 @@ mod tests {
             facility: "local0".to_string(),
             hostname: "test-host".to_string(),
             app_name: "zettai-mamorukun".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -445,6 +622,8 @@ mod tests {
             facility: "auth".to_string(),
             hostname: "prod-server".to_string(),
             app_name: "zettai-mamorukun".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -464,6 +643,8 @@ mod tests {
             facility: "local0".to_string(),
             hostname: "host".to_string(),
             app_name: "app".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -508,6 +689,7 @@ mod tests {
             facility: "auth".to_string(),
             hostname: "my-server".to_string(),
             app_name: "test-app".to_string(),
+            tls: SyslogTlsConfig::default(),
         };
         let runtime = SyslogRuntimeConfig::from(&config);
         assert_eq!(runtime.protocol, "tcp");
@@ -516,6 +698,34 @@ mod tests {
         assert_eq!(runtime.facility, "auth");
         assert_eq!(runtime.hostname, "my-server");
         assert_eq!(runtime.app_name, "test-app");
+        assert!(runtime.tls_ca_cert_path.is_none());
+        assert!(runtime.tls_verify_hostname);
+    }
+
+    #[test]
+    fn test_syslog_runtime_config_from_syslog_config_with_tls() {
+        let config = SyslogConfig {
+            enabled: true,
+            protocol: "tls".to_string(),
+            server: "siem.example.com".to_string(),
+            port: 6514,
+            facility: "local0".to_string(),
+            hostname: "tls-host".to_string(),
+            app_name: "zettai-tls".to_string(),
+            tls: SyslogTlsConfig {
+                ca_cert_path: Some("/etc/ssl/ca.pem".to_string()),
+                verify_hostname: false,
+            },
+        };
+        let runtime = SyslogRuntimeConfig::from(&config);
+        assert_eq!(runtime.protocol, "tls");
+        assert_eq!(runtime.server, "siem.example.com");
+        assert_eq!(runtime.port, 6514);
+        assert_eq!(
+            runtime.tls_ca_cert_path,
+            Some("/etc/ssl/ca.pem".to_string())
+        );
+        assert!(!runtime.tls_verify_hostname);
     }
 
     #[test]
@@ -538,6 +748,7 @@ mod tests {
             facility: "local0".to_string(),
             hostname: "test".to_string(),
             app_name: "test".to_string(),
+            tls: SyslogTlsConfig::default(),
         };
         let bus = EventBus::new(16);
         let (forwarder, sender) = SyslogForwarder::new(&config, &bus);
@@ -564,6 +775,7 @@ mod tests {
             facility: "local0".to_string(),
             hostname: "test-host".to_string(),
             app_name: "zettai-test".to_string(),
+            tls: SyslogTlsConfig::default(),
         };
         let bus = EventBus::new(16);
         let (forwarder, _sender) = SyslogForwarder::new(&config, &bus);
@@ -612,6 +824,7 @@ mod tests {
             facility: "auth".to_string(),
             hostname: "tcp-test".to_string(),
             app_name: "zettai-tcp".to_string(),
+            tls: SyslogTlsConfig::default(),
         };
         let bus = EventBus::new(16);
         let (forwarder, _sender) = SyslogForwarder::new(&config, &bus);
@@ -668,6 +881,7 @@ mod tests {
             facility: "local0".to_string(),
             hostname: "reload-test".to_string(),
             app_name: "zettai-reload".to_string(),
+            tls: SyslogTlsConfig::default(),
         };
         let bus = EventBus::new(16);
         let (forwarder, sender) = SyslogForwarder::new(&config, &bus);
@@ -681,6 +895,8 @@ mod tests {
             facility: "auth".to_string(),
             hostname: "reload-test".to_string(),
             app_name: "zettai-reload".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
         };
         sender.send(new_runtime).unwrap();
 
@@ -706,5 +922,125 @@ mod tests {
             }
             _ => panic!("リロード後の UDP メッセージを受信できませんでした"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_syslog_forwarder_receives_and_sends_tls() {
+        use rcgen::{CertificateParams, KeyPair};
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+        use tokio::net::TcpListener;
+        use tokio_rustls::TlsAcceptor;
+
+        // CryptoProvider を初期化
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        // 自己署名 CA 証明書とサーバ証明書を生成
+        let ca_key_pair = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(vec!["Test CA".to_string()]).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key_pair).unwrap();
+
+        let server_key_pair = KeyPair::generate().unwrap();
+        let server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        let server_cert = server_params
+            .signed_by(&server_key_pair, &ca_cert, &ca_key_pair)
+            .unwrap();
+
+        // CA 証明書を一時ファイルに書き出す
+        let ca_pem = ca_cert.pem();
+        let ca_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(ca_file.path(), ca_pem.as_bytes()).unwrap();
+
+        // TLS サーバ設定
+        let server_cert_der = CertificateDer::from(server_cert.der().to_vec());
+        let server_key_der =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_key_pair.serialize_der()));
+
+        let tls_server_config = rustls::ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![server_cert_der], server_key_der)
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(tls_server_config));
+
+        // ローカル TLS サーバを起動
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
+
+        let accept_handle = tokio::spawn(async move {
+            let (tcp_stream, _) = listener.accept().await.unwrap();
+            let mut tls_stream = acceptor.accept(tcp_stream).await.unwrap();
+            let mut buf = [0u8; 4096];
+            let len = tokio::io::AsyncReadExt::read(&mut tls_stream, &mut buf)
+                .await
+                .unwrap();
+            String::from_utf8_lossy(&buf[..len]).to_string()
+        });
+
+        // SyslogForwarder を TLS モードで起動
+        let config = SyslogConfig {
+            enabled: true,
+            protocol: "tls".to_string(),
+            server: "localhost".to_string(),
+            port: server_addr.port(),
+            facility: "local0".to_string(),
+            hostname: "tls-test-host".to_string(),
+            app_name: "zettai-tls-test".to_string(),
+            tls: SyslogTlsConfig {
+                ca_cert_path: Some(ca_file.path().to_string_lossy().into_owned()),
+                verify_hostname: true,
+            },
+        };
+        let bus = EventBus::new(16);
+        let (forwarder, _sender) = SyslogForwarder::new(&config, &bus);
+        forwarder.spawn();
+
+        // 接続確立を少し待つ
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // イベントを発行
+        bus.publish(SecurityEvent::new(
+            "tls_test_event",
+            Severity::Warning,
+            "tls_module",
+            "TLS テストメッセージ",
+        ));
+
+        // メッセージの受信を待つ
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), accept_handle)
+            .await
+            .expect("TLS メッセージ受信がタイムアウトしました")
+            .expect("TLS サーバタスクがパニックしました");
+
+        // PRI: local0(16)*8 + warning(4) = 132
+        assert!(
+            received.contains("<132>1 "),
+            "PRI 値が正しくありません: {}",
+            received
+        );
+        assert!(
+            received.contains("tls-test-host"),
+            "ホスト名が含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("zettai-tls-test"),
+            "アプリ名が含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("eventType=\"tls_test_event\""),
+            "イベントタイプが含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("TLS テストメッセージ"),
+            "メッセージが含まれていません: {}",
+            received
+        );
+        assert!(
+            received.ends_with('\n'),
+            "改行で終わっていません: {}",
+            received
+        );
     }
 }


### PR DESCRIPTION
## 概要

Syslog イベント転送機能（v1.9.0, #221）に TLS（RFC 5425）対応を追加し、暗号化された安全なログ転送を実現する。

Closes #223

## 変更内容

- `SyslogConfig` に `SyslogTlsConfig` サブ構造体を追加（`[syslog.tls]` セクション）
  - `ca_cert_path`: CA 証明書ファイルパス（PEM 形式）
  - `verify_hostname`: ホスト名検証の有効/無効（デフォルト: true）
- `Transport` enum に `Tls(Box<TlsStream<TcpStream>>)` バリアントを追加
- `tokio-rustls` / `rustls-pki-types` / `webpki-roots` / `rustls-pemfile` を依存に追加
- CA 証明書未指定時は webpki-roots のルート証明書をフォールバック使用
- `verify_hostname: false` 時は `NoVerifier` で検証スキップ（警告ログ付き）
- ホットリロード: TLS 設定変更時に再接続をトリガー
- `config.example.toml` に `[syslog.tls]` セクションを追加
- CLAUDE.md の Syslog Forwarder 説明を更新

## 設定例

```toml
[syslog]
enabled = true
protocol = "tls"
server = "siem.example.com"
port = 6514

[syslog.tls]
ca_cert_path = "/etc/zettai-mamorukun/ca.pem"
verify_hostname = true
```

## テスト

- `test_syslog_forwarder_receives_and_sends_tls`: rcgen で自己署名証明書を生成し、ローカル TLS サーバとの E2E テスト
- `test_syslog_runtime_config_from_syslog_config_with_tls`: TLS 設定のマッピングテスト
- 既存テスト全て通過（1893 テスト）
- `cargo fmt --check` / `cargo clippy -- -D warnings` クリーン