### PR TITLE
feat: Syslog クライアント証明書認証（mTLS 対応） (#225)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
-- **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
+- **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -733,6 +733,9 @@ app_name = "zettai-mamorukun"
 # ホスト名検証（デフォルト: true）
 # 自己署名証明書を使う場合は false に設定
 verify_hostname = true
+# クライアント証明書（mTLS 認証用、PEM 形式）
+# client_cert_path = "/etc/zettai-mamorukun/client.pem"
+# client_key_path = "/etc/zettai-mamorukun/client-key.pem"
 
 [event_store]
 # イベントストア（SQLite 永続化）の有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -3013,6 +3013,14 @@ pub struct SyslogTlsConfig {
     /// ホスト名検証の有効/無効（デフォルト: true）
     #[serde(default = "SyslogTlsConfig::default_verify_hostname")]
     pub verify_hostname: bool,
+
+    /// クライアント証明書ファイルパス（PEM 形式、mTLS 用）
+    #[serde(default)]
+    pub client_cert_path: Option<String>,
+
+    /// クライアント秘密鍵ファイルパス（PEM 形式、mTLS 用）
+    #[serde(default)]
+    pub client_key_path: Option<String>,
 }
 
 impl SyslogTlsConfig {
@@ -3026,6 +3034,8 @@ impl Default for SyslogTlsConfig {
         Self {
             ca_cert_path: None,
             verify_hostname: true,
+            client_cert_path: None,
+            client_key_path: None,
         }
     }
 }

--- a/src/core/syslog.rs
+++ b/src/core/syslog.rs
@@ -435,7 +435,6 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
     }
 }
 
-
 /// トランスポート層（UDP / TCP / TLS）
 enum Transport {
     Udp(UdpSocket),

--- a/src/core/syslog.rs
+++ b/src/core/syslog.rs
@@ -29,6 +29,10 @@ pub struct SyslogRuntimeConfig {
     pub tls_ca_cert_path: Option<String>,
     /// TLS ホスト名検証の有効/無効
     pub tls_verify_hostname: bool,
+    /// TLS クライアント証明書ファイルパス（PEM 形式、mTLS 用）
+    pub tls_client_cert_path: Option<String>,
+    /// TLS クライアント秘密鍵ファイルパス（PEM 形式、mTLS 用）
+    pub tls_client_key_path: Option<String>,
 }
 
 impl From<&SyslogConfig> for SyslogRuntimeConfig {
@@ -42,6 +46,8 @@ impl From<&SyslogConfig> for SyslogRuntimeConfig {
             app_name: config.app_name.clone(),
             tls_ca_cert_path: config.tls.ca_cert_path.clone(),
             tls_verify_hostname: config.tls.verify_hostname,
+            tls_client_cert_path: config.tls.client_cert_path.clone(),
+            tls_client_key_path: config.tls.client_key_path.clone(),
         }
     }
 }
@@ -120,7 +126,9 @@ impl SyslogForwarder {
                                 || new_config.server != runtime.server
                                 || new_config.port != runtime.port
                                 || new_config.tls_ca_cert_path != runtime.tls_ca_cert_path
-                                || new_config.tls_verify_hostname != runtime.tls_verify_hostname;
+                                || new_config.tls_verify_hostname != runtime.tls_verify_hostname
+                                || new_config.tls_client_cert_path != runtime.tls_client_cert_path
+                                || new_config.tls_client_key_path != runtime.tls_client_key_path;
                             runtime = new_config;
                             if needs_reconnect {
                                 tracing::info!(
@@ -307,20 +315,79 @@ fn build_tls_config(config: &SyslogRuntimeConfig) -> Result<rustls::ClientConfig
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     }
 
+    let client_auth = match (&config.tls_client_cert_path, &config.tls_client_key_path) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert_pem = std::fs::read(cert_path).map_err(|e| {
+                format!(
+                    "クライアント証明書ファイルの読み込みに失敗: {}: {}",
+                    cert_path, e
+                )
+            })?;
+            let mut cert_cursor = std::io::Cursor::new(cert_pem);
+            let certs = rustls_pemfile::certs(&mut cert_cursor)
+                .filter_map(|r| r.ok())
+                .collect::<Vec<_>>();
+            if certs.is_empty() {
+                return Err(format!(
+                    "クライアント証明書ファイルに有効な証明書が見つかりません: {}",
+                    cert_path
+                ));
+            }
+
+            let key_pem = std::fs::read(key_path).map_err(|e| {
+                format!(
+                    "クライアント秘密鍵ファイルの読み込みに失敗: {}: {}",
+                    key_path, e
+                )
+            })?;
+            let mut key_cursor = std::io::Cursor::new(key_pem);
+            let key = rustls_pemfile::private_key(&mut key_cursor)
+                .map_err(|e| format!("クライアント秘密鍵の読み込みに失敗: {}: {}", key_path, e))?
+                .ok_or_else(|| {
+                    format!(
+                        "クライアント秘密鍵ファイルに有効な秘密鍵が見つかりません: {}",
+                        key_path
+                    )
+                })?;
+
+            Some((certs, key))
+        }
+        (Some(_), None) => {
+            return Err(
+                "クライアント証明書が設定されていますが、秘密鍵（client_key_path）が設定されていません"
+                    .to_string(),
+            );
+        }
+        (None, Some(_)) => {
+            return Err(
+                "クライアント秘密鍵が設定されていますが、証明書（client_cert_path）が設定されていません"
+                    .to_string(),
+            );
+        }
+        (None, None) => None,
+    };
+
     if config.tls_verify_hostname {
-        rustls::ClientConfig::builder()
-            .with_root_certificates(root_store)
-            .with_no_client_auth()
-            .pipe(Ok)
+        let builder = rustls::ClientConfig::builder().with_root_certificates(root_store);
+        match client_auth {
+            Some((certs, key)) => builder
+                .with_client_auth_cert(certs, key)
+                .map_err(|e| format!("クライアント証明書の設定に失敗: {}", e)),
+            None => Ok(builder.with_no_client_auth()),
+        }
     } else {
         tracing::warn!(
             "Syslog TLS: ホスト名検証が無効です。本番環境では有効にすることを推奨します"
         );
-        let config = rustls::ClientConfig::builder()
+        let builder = rustls::ClientConfig::builder()
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoVerifier))
-            .with_no_client_auth();
-        Ok(config)
+            .with_custom_certificate_verifier(Arc::new(NoVerifier));
+        match client_auth {
+            Some((certs, key)) => builder
+                .with_client_auth_cert(certs, key)
+                .map_err(|e| format!("クライアント証明書の設定に失敗: {}", e)),
+            None => Ok(builder.with_no_client_auth()),
+        }
     }
 }
 
@@ -368,14 +435,6 @@ impl rustls::client::danger::ServerCertVerifier for NoVerifier {
     }
 }
 
-/// パイプライン演算子的なヘルパートレイト
-trait Pipe: Sized {
-    fn pipe<T>(self, f: impl FnOnce(Self) -> T) -> T {
-        f(self)
-    }
-}
-
-impl<T> Pipe for T {}
 
 /// トランスポート層（UDP / TCP / TLS）
 enum Transport {
@@ -592,6 +651,8 @@ mod tests {
             app_name: "zettai-mamorukun".to_string(),
             tls_ca_cert_path: None,
             tls_verify_hostname: true,
+            tls_client_cert_path: None,
+            tls_client_key_path: None,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -624,6 +685,8 @@ mod tests {
             app_name: "zettai-mamorukun".to_string(),
             tls_ca_cert_path: None,
             tls_verify_hostname: true,
+            tls_client_cert_path: None,
+            tls_client_key_path: None,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -645,6 +708,8 @@ mod tests {
             app_name: "app".to_string(),
             tls_ca_cert_path: None,
             tls_verify_hostname: true,
+            tls_client_cert_path: None,
+            tls_client_key_path: None,
         };
 
         let msg = format_rfc5424(&event, &config);
@@ -715,6 +780,8 @@ mod tests {
             tls: SyslogTlsConfig {
                 ca_cert_path: Some("/etc/ssl/ca.pem".to_string()),
                 verify_hostname: false,
+                client_cert_path: None,
+                client_key_path: None,
             },
         };
         let runtime = SyslogRuntimeConfig::from(&config);
@@ -897,6 +964,8 @@ mod tests {
             app_name: "zettai-reload".to_string(),
             tls_ca_cert_path: None,
             tls_verify_hostname: true,
+            tls_client_cert_path: None,
+            tls_client_key_path: None,
         };
         sender.send(new_runtime).unwrap();
 
@@ -988,6 +1057,8 @@ mod tests {
             tls: SyslogTlsConfig {
                 ca_cert_path: Some(ca_file.path().to_string_lossy().into_owned()),
                 verify_hostname: true,
+                client_cert_path: None,
+                client_key_path: None,
             },
         };
         let bus = EventBus::new(16);
@@ -1041,6 +1112,213 @@ mod tests {
             received.ends_with('\n'),
             "改行で終わっていません: {}",
             received
+        );
+    }
+
+    #[tokio::test]
+    async fn test_syslog_forwarder_receives_and_sends_tls_mtls() {
+        use rcgen::{CertificateParams, KeyPair};
+        use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
+        use tokio::net::TcpListener;
+        use tokio_rustls::TlsAcceptor;
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        // CA 証明書を生成
+        let ca_key_pair = KeyPair::generate().unwrap();
+        let mut ca_params = CertificateParams::new(vec!["Test CA".to_string()]).unwrap();
+        ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_cert = ca_params.self_signed(&ca_key_pair).unwrap();
+
+        // サーバ証明書を生成
+        let server_key_pair = KeyPair::generate().unwrap();
+        let server_params = CertificateParams::new(vec!["localhost".to_string()]).unwrap();
+        let server_cert = server_params
+            .signed_by(&server_key_pair, &ca_cert, &ca_key_pair)
+            .unwrap();
+
+        // クライアント証明書を生成
+        let client_key_pair = KeyPair::generate().unwrap();
+        let client_params =
+            CertificateParams::new(vec!["zettai-mamorukun-client".to_string()]).unwrap();
+        let client_cert = client_params
+            .signed_by(&client_key_pair, &ca_cert, &ca_key_pair)
+            .unwrap();
+
+        // CA 証明書を一時ファイルに書き出す
+        let ca_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(ca_file.path(), ca_cert.pem().as_bytes()).unwrap();
+
+        // クライアント証明書・秘密鍵を一時ファイルに書き出す
+        let client_cert_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(client_cert_file.path(), client_cert.pem().as_bytes()).unwrap();
+
+        let client_key_file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            client_key_file.path(),
+            client_key_pair.serialize_pem().as_bytes(),
+        )
+        .unwrap();
+
+        // mTLS を要求するサーバ設定
+        let ca_cert_der = CertificateDer::from(ca_cert.der().to_vec());
+        let mut client_auth_roots = rustls::RootCertStore::empty();
+        client_auth_roots.add(ca_cert_der).unwrap();
+        let client_verifier =
+            rustls::server::WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .build()
+                .unwrap();
+
+        let server_cert_der = CertificateDer::from(server_cert.der().to_vec());
+        let server_key_der =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(server_key_pair.serialize_der()));
+
+        let tls_server_config = rustls::ServerConfig::builder()
+            .with_client_cert_verifier(client_verifier)
+            .with_single_cert(vec![server_cert_der], server_key_der)
+            .unwrap();
+        let acceptor = TlsAcceptor::from(Arc::new(tls_server_config));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let server_addr = listener.local_addr().unwrap();
+
+        let accept_handle = tokio::spawn(async move {
+            let (tcp_stream, _) = listener.accept().await.unwrap();
+            let mut tls_stream = acceptor.accept(tcp_stream).await.unwrap();
+            let mut buf = [0u8; 4096];
+            let len = tokio::io::AsyncReadExt::read(&mut tls_stream, &mut buf)
+                .await
+                .unwrap();
+            String::from_utf8_lossy(&buf[..len]).to_string()
+        });
+
+        let config = SyslogConfig {
+            enabled: true,
+            protocol: "tls".to_string(),
+            server: "localhost".to_string(),
+            port: server_addr.port(),
+            facility: "local0".to_string(),
+            hostname: "mtls-test-host".to_string(),
+            app_name: "zettai-mtls-test".to_string(),
+            tls: SyslogTlsConfig {
+                ca_cert_path: Some(ca_file.path().to_string_lossy().into_owned()),
+                verify_hostname: true,
+                client_cert_path: Some(client_cert_file.path().to_string_lossy().into_owned()),
+                client_key_path: Some(client_key_file.path().to_string_lossy().into_owned()),
+            },
+        };
+        let bus = EventBus::new(16);
+        let (forwarder, _sender) = SyslogForwarder::new(&config, &bus);
+        forwarder.spawn();
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        bus.publish(SecurityEvent::new(
+            "mtls_test_event",
+            Severity::Warning,
+            "mtls_module",
+            "mTLS テストメッセージ",
+        ));
+
+        let received = tokio::time::timeout(std::time::Duration::from_secs(5), accept_handle)
+            .await
+            .expect("mTLS メッセージ受信がタイムアウトしました")
+            .expect("mTLS サーバタスクがパニックしました");
+
+        assert!(
+            received.contains("<132>1 "),
+            "PRI 値が正しくありません: {}",
+            received
+        );
+        assert!(
+            received.contains("mtls-test-host"),
+            "ホスト名が含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("zettai-mtls-test"),
+            "アプリ名が含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("eventType=\"mtls_test_event\""),
+            "イベントタイプが含まれていません: {}",
+            received
+        );
+        assert!(
+            received.contains("mTLS テストメッセージ"),
+            "メッセージが含まれていません: {}",
+            received
+        );
+    }
+
+    #[test]
+    fn test_build_tls_config_client_cert_only_error() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let config = SyslogRuntimeConfig {
+            protocol: "tls".to_string(),
+            server: "localhost".to_string(),
+            port: 6514,
+            facility: "local0".to_string(),
+            hostname: "test".to_string(),
+            app_name: "test".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
+            tls_client_cert_path: Some("/tmp/nonexistent-cert.pem".to_string()),
+            tls_client_key_path: None,
+        };
+        let result = build_tls_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("秘密鍵"));
+    }
+
+    #[test]
+    fn test_build_tls_config_client_key_only_error() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let config = SyslogRuntimeConfig {
+            protocol: "tls".to_string(),
+            server: "localhost".to_string(),
+            port: 6514,
+            facility: "local0".to_string(),
+            hostname: "test".to_string(),
+            app_name: "test".to_string(),
+            tls_ca_cert_path: None,
+            tls_verify_hostname: true,
+            tls_client_cert_path: None,
+            tls_client_key_path: Some("/tmp/nonexistent-key.pem".to_string()),
+        };
+        let result = build_tls_config(&config);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("証明書"));
+    }
+
+    #[test]
+    fn test_syslog_runtime_config_from_syslog_config_with_mtls() {
+        let config = SyslogConfig {
+            enabled: true,
+            protocol: "tls".to_string(),
+            server: "siem.example.com".to_string(),
+            port: 6514,
+            facility: "local0".to_string(),
+            hostname: "test-host".to_string(),
+            app_name: "zettai-mamorukun".to_string(),
+            tls: SyslogTlsConfig {
+                ca_cert_path: Some("/path/to/ca.pem".to_string()),
+                verify_hostname: true,
+                client_cert_path: Some("/path/to/client.pem".to_string()),
+                client_key_path: Some("/path/to/client-key.pem".to_string()),
+            },
+        };
+        let runtime = SyslogRuntimeConfig::from(&config);
+        assert_eq!(
+            runtime.tls_client_cert_path,
+            Some("/path/to/client.pem".to_string())
+        );
+        assert_eq!(
+            runtime.tls_client_key_path,
+            Some("/path/to/client-key.pem".to_string())
         );
     }
 }


### PR DESCRIPTION
## 概要

Syslog TLS 転送（v1.10.0）に相互TLS認証（mTLS）を追加し、クライアント証明書によるサーバ側でのクライアント認証を可能にする。

Closes #225

## 変更内容

- `SyslogTlsConfig` に `client_cert_path` / `client_key_path` フィールドを追加
- `SyslogRuntimeConfig` に mTLS フィールドを追加し、`From` 変換を更新
- `build_tls_config` でクライアント証明書の読み込み・設定を実装（`.with_client_auth_cert()`）
- 片方のみ設定時の明確なエラー処理
- ホットリロード再接続判定にクライアント証明書パスの変更検知を追加
- `config.example.toml` に mTLS 設定例を追加
- CLAUDE.md に mTLS 対応の記述を追記

## テスト

- 新規テスト4件追加（mTLS 接続成功、cert/key 片方のみエラー、From 変換）
- 全38テスト通過、clippy 警告なし、fmt チェック通過

## テストプラン

- [x] `cargo test` — 全テスト通過
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット OK
- [x] 既存 TLS テスト（片方向）が引き続き通過
- [x] mTLS テスト（rcgen 生成のクライアント証明書）が通過
- [x] 秘密鍵がログに出力されないことを確認
- [x] 本番コードに unwrap()/expect() がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)