### PR TITLE
feat: Prometheus メトリクスエクスポーター (#241)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
+- **Prometheus Exporter**: MetricsCollector の集計データを Prometheus テキスト形式で HTTP エンドポイント（`/metrics`）から公開する。Grafana・Alertmanager 等の外部監視基盤と連携可能。`/health` エンドポイントでヘルスチェックも提供
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
@@ -86,6 +87,7 @@ src/
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
     metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）
+    prometheus.rs      # Prometheus メトリクスエクスポーター（HTTP エンドポイント）
     scan_diff.rs       # スキャン状態差分レポート（CLI scan-diff コマンド）
     status.rs          # ステータスサーバー（Unix ソケット経由の CLI ステータス問い合わせ）
     syslog.rs          # Syslog 転送（RFC 5424 形式の SIEM 連携）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.18.0"
+version = "1.19.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.18.0"
+version = "1.19.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -786,6 +786,17 @@ enabled = false
 # Unix ソケットのパス
 socket_path = "/var/run/zettai-mamorukun/status.sock"
 
+[prometheus]
+# Prometheus メトリクスエクスポーターの有効/無効
+# 有効にすると HTTP エンドポイントで Prometheus テキスト形式のメトリクスを公開する
+# /metrics — メトリクス取得、/health — ヘルスチェック
+# 注意: metrics.enabled = true が必要
+enabled = false
+# バインドアドレス
+bind_address = "127.0.0.1"
+# リスニングポート
+port = 9100
+
 [correlation]
 # 相関分析エンジンの有効/無効
 # 複数のセキュリティイベントを時系列で相関分析し、多段階攻撃パターンを検知する

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,10 @@ pub struct AppConfig {
     /// アラートルール DSL 設定
     #[serde(default)]
     pub alert_rules: AlertRulesConfig,
+
+    /// Prometheus メトリクスエクスポーター設定
+    #[serde(default)]
+    pub prometheus: PrometheusConfig,
 }
 
 /// デーモン動作設定
@@ -4031,6 +4035,14 @@ impl AppConfig {
             }
         }
 
+        // prometheus の検証
+        if self.prometheus.enabled && self.prometheus.port == 0 {
+            errors.push("prometheus.port: 0 より大きい値を指定してください".to_string());
+        }
+        if self.prometheus.enabled && self.prometheus.bind_address.is_empty() {
+            errors.push("prometheus.bind_address: 空文字列は指定できません".to_string());
+        }
+
         if errors.is_empty() {
             Ok(())
         } else {
@@ -5921,6 +5933,42 @@ impl Default for DynamicLibraryMonitorConfig {
             ignore_pids: Vec::new(),
             ignore_libraries: Vec::new(),
             monitor_all_processes: false,
+        }
+    }
+}
+
+/// Prometheus メトリクスエクスポーター設定
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct PrometheusConfig {
+    /// Prometheus エクスポーターの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// バインドアドレス
+    #[serde(default = "PrometheusConfig::default_bind_address")]
+    pub bind_address: String,
+
+    /// リスニングポート
+    #[serde(default = "PrometheusConfig::default_port")]
+    pub port: u16,
+}
+
+impl PrometheusConfig {
+    fn default_bind_address() -> String {
+        "127.0.0.1".to_string()
+    }
+
+    fn default_port() -> u16 {
+        9100
+    }
+}
+
+impl Default for PrometheusConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            bind_address: Self::default_bind_address(),
+            port: Self::default_port(),
         }
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -9,6 +9,7 @@ use crate::core::event_stream::{EventStreamRuntimeConfig, EventStreamServer};
 use crate::core::health::HealthChecker;
 use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
+use crate::core::prometheus::PrometheusExporter;
 use crate::core::scan_state::{self, DiffKind};
 use crate::core::status::{DaemonState, StatusServer};
 use crate::core::syslog::{SyslogForwarder, SyslogRuntimeConfig};
@@ -51,6 +52,7 @@ impl Daemon {
         let shared_module_names: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
         let mut shared_metrics: Option<Arc<StdMutex<SharedMetrics>>> = None;
         let mut status_cancel_token: Option<CancellationToken> = None;
+        let mut prometheus_cancel_token: Option<CancellationToken> = None;
 
         // イベントバスの初期化
         let mut action_config_sender: Option<watch::Sender<ActionEngineConfig>> = None;
@@ -374,6 +376,25 @@ impl Daemon {
             }
         }
 
+        // Prometheus エクスポーターの起動
+        if self.config.prometheus.enabled {
+            if let Some(ref metrics) = shared_metrics {
+                let exporter =
+                    PrometheusExporter::new(&self.config.prometheus, Arc::clone(metrics));
+                prometheus_cancel_token = Some(exporter.cancel_token());
+                match exporter.spawn() {
+                    Ok(()) => {}
+                    Err(e) => {
+                        tracing::error!(error = %e, "Prometheus エクスポーターの起動に失敗しました");
+                    }
+                }
+            } else {
+                tracing::warn!(
+                    "Prometheus エクスポーターはメトリクス収集が無効のため起動できません。metrics.enabled = true を設定してください"
+                );
+            }
+        }
+
         // モジュールウォッチドッグの初期化
         let watchdog_enabled = self.config.module_watchdog.enabled;
         let watchdog_interval_duration =
@@ -626,6 +647,13 @@ impl Daemon {
                                 }
                             }
 
+                            // Prometheus エクスポーターのリロード警告
+                            if self.config.prometheus != new_config.prometheus {
+                                tracing::warn!(
+                                    "prometheus セクションの変更はホットリロードに対応していません。デーモンを再起動してください"
+                                );
+                            }
+
                             self.config = new_config;
                         }
                         Err(e) => {
@@ -695,6 +723,11 @@ impl Daemon {
 
         // ステータスサーバーの停止
         if let Some(token) = status_cancel_token {
+            token.cancel();
+        }
+
+        // Prometheus エクスポーターの停止
+        if let Some(token) = prometheus_cancel_token {
             token.cancel();
         }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,7 @@ pub mod event_stream;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;
+pub mod prometheus;
 pub mod scan_diff;
 pub mod scan_state;
 pub mod status;

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -1,0 +1,430 @@
+//! Prometheus メトリクスエクスポーター
+//!
+//! Prometheus テキスト形式でメトリクスを HTTP エンドポイントから公開する。
+//! `/metrics` エンドポイントでメトリクスを、`/health` エンドポイントでヘルスチェックを提供する。
+
+use crate::config::PrometheusConfig;
+use crate::core::metrics::SharedMetrics;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Instant;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+/// Prometheus メトリクスエクスポーター
+pub struct PrometheusExporter {
+    bind_address: String,
+    port: u16,
+    shared_metrics: Arc<StdMutex<SharedMetrics>>,
+    started_at: Instant,
+    cancel_token: CancellationToken,
+}
+
+impl PrometheusExporter {
+    /// 新しい PrometheusExporter を作成する
+    pub fn new(config: &PrometheusConfig, shared_metrics: Arc<StdMutex<SharedMetrics>>) -> Self {
+        Self {
+            bind_address: config.bind_address.clone(),
+            port: config.port,
+            shared_metrics,
+            started_at: Instant::now(),
+            cancel_token: CancellationToken::new(),
+        }
+    }
+
+    /// キャンセルトークンを取得する
+    pub fn cancel_token(&self) -> CancellationToken {
+        self.cancel_token.clone()
+    }
+
+    /// Prometheus エクスポーターを非同期タスクとして起動する
+    pub fn spawn(self) -> Result<(), std::io::Error> {
+        let addr = format!("{}:{}", self.bind_address, self.port);
+        let listener = std::net::TcpListener::bind(&addr)?;
+        listener.set_nonblocking(true)?;
+        let listener = TcpListener::from_std(listener)?;
+
+        let shared_metrics = self.shared_metrics;
+        let started_at = self.started_at;
+        let cancel_token = self.cancel_token;
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    result = listener.accept() => {
+                        match result {
+                            Ok((stream, _)) => {
+                                let metrics = Arc::clone(&shared_metrics);
+                                let started = started_at;
+                                tokio::spawn(async move {
+                                    if let Err(e) = Self::handle_connection(stream, &metrics, started).await {
+                                        tracing::debug!(error = %e, "Prometheus 接続の処理に失敗");
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::debug!(error = %e, "Prometheus リスナーの accept に失敗");
+                            }
+                        }
+                    }
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("Prometheus エクスポーターを停止します");
+                        break;
+                    }
+                }
+            }
+        });
+
+        tracing::info!(
+            bind_address = %addr,
+            "Prometheus エクスポーターを起動しました"
+        );
+        Ok(())
+    }
+
+    async fn handle_connection(
+        mut stream: tokio::net::TcpStream,
+        shared_metrics: &Arc<StdMutex<SharedMetrics>>,
+        started_at: Instant,
+    ) -> Result<(), std::io::Error> {
+        // 接続タイムアウト（スローロリス対策）
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            Self::read_request(&mut stream),
+        )
+        .await;
+
+        let request_line = match result {
+            Ok(Ok(line)) => line,
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "接続タイムアウト",
+                ));
+            }
+        };
+
+        let path = Self::parse_request_path(&request_line);
+
+        match path {
+            "/metrics" => {
+                let body = Self::format_metrics(shared_metrics, started_at);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).await?;
+            }
+            "/health" => {
+                let body = "ok";
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).await?;
+            }
+            _ => {
+                let body = "Not Found";
+                let response = format!(
+                    "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).await?;
+            }
+        }
+
+        stream.shutdown().await?;
+        Ok(())
+    }
+
+    async fn read_request(stream: &mut tokio::net::TcpStream) -> Result<String, std::io::Error> {
+        let mut buf = [0u8; 1024];
+        let n = stream.read(&mut buf).await?;
+        if n == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "空のリクエスト",
+            ));
+        }
+        Ok(String::from_utf8_lossy(&buf[..n]).to_string())
+    }
+
+    fn parse_request_path(request: &str) -> &str {
+        // "GET /metrics HTTP/1.1\r\n..." からパスを抽出
+        let first_line = request.lines().next().unwrap_or("");
+        let parts: Vec<&str> = first_line.split_whitespace().collect();
+        if parts.len() >= 2 { parts[1] } else { "/" }
+    }
+
+    fn format_metrics(
+        shared_metrics: &Arc<StdMutex<SharedMetrics>>,
+        started_at: Instant,
+    ) -> String {
+        let mut output = String::new();
+
+        // uptime
+        let uptime = started_at.elapsed().as_secs_f64();
+        output.push_str("# HELP zettai_uptime_seconds デーモンの稼働時間（秒）\n");
+        output.push_str("# TYPE zettai_uptime_seconds gauge\n");
+        output.push_str(&format!("zettai_uptime_seconds {uptime:.1}\n"));
+        output.push('\n');
+
+        // メトリクスデータを取得
+        let metrics = match shared_metrics.lock() {
+            Ok(m) => m.clone(),
+            Err(_) => {
+                // Mutex が poisoned の場合はデフォルト値を返す
+                SharedMetrics::default()
+            }
+        };
+
+        // total events counter
+        output.push_str("# HELP zettai_events_total セキュリティイベントの総数\n");
+        output.push_str("# TYPE zettai_events_total counter\n");
+        output.push_str(&format!("zettai_events_total {}\n", metrics.total_events));
+        output.push('\n');
+
+        // events by severity
+        output.push_str("# HELP zettai_events_by_severity_total Severity 別のイベント数\n");
+        output.push_str("# TYPE zettai_events_by_severity_total counter\n");
+        output.push_str(&format!(
+            "zettai_events_by_severity_total{{severity=\"info\"}} {}\n",
+            metrics.info_count
+        ));
+        output.push_str(&format!(
+            "zettai_events_by_severity_total{{severity=\"warning\"}} {}\n",
+            metrics.warning_count
+        ));
+        output.push_str(&format!(
+            "zettai_events_by_severity_total{{severity=\"critical\"}} {}\n",
+            metrics.critical_count
+        ));
+        output.push('\n');
+
+        // events by module
+        if !metrics.module_counts.is_empty() {
+            output.push_str("# HELP zettai_events_by_module_total モジュール別のイベント数\n");
+            output.push_str("# TYPE zettai_events_by_module_total counter\n");
+            let mut modules: Vec<_> = metrics.module_counts.iter().collect();
+            modules.sort_by_key(|(k, _)| (*k).clone());
+            for (module, count) in modules {
+                output.push_str(&format!(
+                    "zettai_events_by_module_total{{module=\"{}\"}} {}\n",
+                    module, count
+                ));
+            }
+            output.push('\n');
+        }
+
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_parse_request_path_metrics() {
+        assert_eq!(
+            PrometheusExporter::parse_request_path("GET /metrics HTTP/1.1\r\n"),
+            "/metrics"
+        );
+    }
+
+    #[test]
+    fn test_parse_request_path_health() {
+        assert_eq!(
+            PrometheusExporter::parse_request_path("GET /health HTTP/1.1\r\n"),
+            "/health"
+        );
+    }
+
+    #[test]
+    fn test_parse_request_path_root() {
+        assert_eq!(
+            PrometheusExporter::parse_request_path("GET / HTTP/1.1\r\n"),
+            "/"
+        );
+    }
+
+    #[test]
+    fn test_parse_request_path_empty() {
+        assert_eq!(PrometheusExporter::parse_request_path(""), "/");
+    }
+
+    #[test]
+    fn test_format_metrics_default() {
+        let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
+        let started_at = Instant::now();
+        let output = PrometheusExporter::format_metrics(&shared, started_at);
+
+        assert!(output.contains("# HELP zettai_uptime_seconds"));
+        assert!(output.contains("# TYPE zettai_uptime_seconds gauge"));
+        assert!(output.contains("# HELP zettai_events_total"));
+        assert!(output.contains("# TYPE zettai_events_total counter"));
+        assert!(output.contains("zettai_events_total 0"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"info\"} 0"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"warning\"} 0"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"critical\"} 0"));
+        // module_counts が空の場合は by_module セクションは出力されない
+        assert!(!output.contains("zettai_events_by_module_total"));
+    }
+
+    #[test]
+    fn test_format_metrics_with_data() {
+        let mut module_counts = HashMap::new();
+        module_counts.insert("file_integrity".to_string(), 15);
+        module_counts.insert("process_monitor".to_string(), 8);
+
+        let shared = Arc::new(StdMutex::new(SharedMetrics {
+            total_events: 23,
+            info_count: 10,
+            warning_count: 8,
+            critical_count: 5,
+            module_counts,
+        }));
+        let started_at = Instant::now();
+        let output = PrometheusExporter::format_metrics(&shared, started_at);
+
+        assert!(output.contains("zettai_events_total 23"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"info\"} 10"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"warning\"} 8"));
+        assert!(output.contains("zettai_events_by_severity_total{severity=\"critical\"} 5"));
+        assert!(output.contains("zettai_events_by_module_total{module=\"file_integrity\"} 15"));
+        assert!(output.contains("zettai_events_by_module_total{module=\"process_monitor\"} 8"));
+    }
+
+    #[test]
+    fn test_format_metrics_module_sorted() {
+        let mut module_counts = HashMap::new();
+        module_counts.insert("z_module".to_string(), 1);
+        module_counts.insert("a_module".to_string(), 2);
+
+        let shared = Arc::new(StdMutex::new(SharedMetrics {
+            total_events: 3,
+            info_count: 3,
+            warning_count: 0,
+            critical_count: 0,
+            module_counts,
+        }));
+        let started_at = Instant::now();
+        let output = PrometheusExporter::format_metrics(&shared, started_at);
+
+        // a_module が z_module より前に出力される
+        let a_pos = output.find("a_module").unwrap();
+        let z_pos = output.find("z_module").unwrap();
+        assert!(a_pos < z_pos);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_spawn_and_metrics() {
+        let config = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port: 0, // OS が空きポートを割り当てる — ここではテスト用に直接指定
+        };
+
+        // ポート 0 だと実際のポート取得が難しいため、動的に空きポートを取得
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let config = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+        };
+
+        let mut module_counts = HashMap::new();
+        module_counts.insert("test_module".to_string(), 42);
+
+        let shared = Arc::new(StdMutex::new(SharedMetrics {
+            total_events: 42,
+            info_count: 30,
+            warning_count: 10,
+            critical_count: 2,
+            module_counts,
+        }));
+
+        let exporter = PrometheusExporter::new(&config, Arc::clone(&shared));
+        let cancel_token = exporter.cancel_token();
+        exporter.spawn().unwrap();
+
+        // サーバーが起動する時間を与える
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // /metrics エンドポイントをテスト
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("text/plain; version=0.0.4"));
+        assert!(response.contains("zettai_events_total 42"));
+        assert!(response.contains("zettai_events_by_severity_total{severity=\"info\"} 30"));
+        assert!(response.contains("zettai_events_by_module_total{module=\"test_module\"} 42"));
+
+        // /health エンドポイントをテスト
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("ok"));
+
+        // 404 テスト
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /unknown HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+
+        assert!(response.contains("HTTP/1.1 404 Not Found"));
+
+        // サーバー停止
+        cancel_token.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[test]
+    fn test_prometheus_exporter_new() {
+        let config = PrometheusConfig {
+            enabled: true,
+            bind_address: "0.0.0.0".to_string(),
+            port: 9200,
+        };
+        let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
+        let exporter = PrometheusExporter::new(&config, shared);
+
+        assert_eq!(exporter.bind_address, "0.0.0.0");
+        assert_eq!(exporter.port, 9200);
+    }
+}


### PR DESCRIPTION
## 概要

Prometheus テキスト形式でメトリクスを HTTP エンドポイントから公開する機能を追加。

Closes #241

## 変更内容

- **`src/core/prometheus.rs`（新規）** — `PrometheusExporter` 構造体。`tokio::net::TcpListener` ベースのミニマル HTTP サーバー
  - `/metrics` — Prometheus テキスト形式（`text/plain; version=0.0.4`）でメトリクスを返却
  - `/health` — ヘルスチェック（`200 OK`）
  - 5秒接続タイムアウト（スローロリス対策）
- **`src/config.rs`** — `PrometheusConfig` 構造体（`enabled`, `bind_address`, `port`）を追加
- **`src/core/daemon.rs`** — デーモン起動時に Prometheus エクスポーターを初期化・起動。シャットダウン時に停止。SIGHUP リロード時に変更警告
- **`config.example.toml`** — `[prometheus]` セクションを追加
- **`CLAUDE.md`** — ディレクトリ構成・アーキテクチャ概要を更新

## エクスポートするメトリクス

| メトリクス | 型 | 説明 |
|---|---|---|
| `zettai_uptime_seconds` | Gauge | デーモン稼働時間 |
| `zettai_events_total` | Counter | イベント総数 |
| `zettai_events_by_severity_total{severity}` | Counter | Severity別イベント数 |
| `zettai_events_by_module_total{module}` | Counter | モジュール別イベント数 |

## 設定例

```toml
[prometheus]
enabled = true
bind_address = "127.0.0.1"
port = 9100
```

> 注意: `metrics.enabled = true` が前提条件

## テスト計画

- [x] `cargo fmt --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [x] `cargo test` 全38テスト合格
- [x] HTTP エンドポイント（/metrics, /health, 404）の統合テスト
- [x] メトリクスフォーマットの単体テスト
- [x] リクエストパス解析の単体テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)