### PR TITLE
feat: Prometheus エクスポーターのホットリロード対応 (#243)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.19.0"
+version = "1.20.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -791,6 +791,7 @@ socket_path = "/var/run/zettai-mamorukun/status.sock"
 # 有効にすると HTTP エンドポイントで Prometheus テキスト形式のメトリクスを公開する
 # /metrics — メトリクス取得、/health — ヘルスチェック
 # 注意: metrics.enabled = true が必要
+# SIGHUP でホットリロード可能（enabled, bind_address, port の変更が即時反映される）
 enabled = false
 # バインドアドレス
 bind_address = "127.0.0.1"

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -16,7 +16,7 @@ use crate::core::syslog::{SyslogForwarder, SyslogRuntimeConfig};
 use crate::error::AppError;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -53,6 +53,7 @@ impl Daemon {
         let mut shared_metrics: Option<Arc<StdMutex<SharedMetrics>>> = None;
         let mut status_cancel_token: Option<CancellationToken> = None;
         let mut prometheus_cancel_token: Option<CancellationToken> = None;
+        let prometheus_started_at = Instant::now();
 
         // イベントバスの初期化
         let mut action_config_sender: Option<watch::Sender<ActionEngineConfig>> = None;
@@ -379,8 +380,11 @@ impl Daemon {
         // Prometheus エクスポーターの起動
         if self.config.prometheus.enabled {
             if let Some(ref metrics) = shared_metrics {
-                let exporter =
-                    PrometheusExporter::new(&self.config.prometheus, Arc::clone(metrics));
+                let exporter = PrometheusExporter::new(
+                    &self.config.prometheus,
+                    Arc::clone(metrics),
+                    prometheus_started_at,
+                );
                 prometheus_cancel_token = Some(exporter.cancel_token());
                 match exporter.spawn() {
                     Ok(()) => {}
@@ -647,11 +651,80 @@ impl Daemon {
                                 }
                             }
 
-                            // Prometheus エクスポーターのリロード警告
+                            // Prometheus エクスポーターのホットリロード
                             if self.config.prometheus != new_config.prometheus {
-                                tracing::warn!(
-                                    "prometheus セクションの変更はホットリロードに対応していません。デーモンを再起動してください"
-                                );
+                                let was_enabled = self.config.prometheus.enabled;
+                                let now_enabled = new_config.prometheus.enabled;
+
+                                if was_enabled && !now_enabled {
+                                    // パターン A: 停止のみ
+                                    if let Some(token) = prometheus_cancel_token.take() {
+                                        token.cancel();
+                                        tracing::info!("Prometheus エクスポーターを停止しました");
+                                    }
+                                } else if !was_enabled && now_enabled {
+                                    // パターン B: 新規起動
+                                    if let Some(ref metrics) = shared_metrics {
+                                        let exporter = PrometheusExporter::new(
+                                            &new_config.prometheus,
+                                            Arc::clone(metrics),
+                                            prometheus_started_at,
+                                        );
+                                        prometheus_cancel_token = Some(exporter.cancel_token());
+                                        match exporter.spawn() {
+                                            Ok(()) => tracing::info!(
+                                                "Prometheus エクスポーターを起動しました（ホットリロード）"
+                                            ),
+                                            Err(e) => tracing::error!(
+                                                error = %e,
+                                                "Prometheus エクスポーターの起動に失敗しました"
+                                            ),
+                                        }
+                                    }
+                                } else {
+                                    // パターン C: bind_address/port 変更（停止→再起動）
+                                    if let Some(token) = prometheus_cancel_token.take() {
+                                        token.cancel();
+                                    }
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                    if let Some(ref metrics) = shared_metrics {
+                                        let exporter = PrometheusExporter::new(
+                                            &new_config.prometheus,
+                                            Arc::clone(metrics),
+                                            prometheus_started_at,
+                                        );
+                                        prometheus_cancel_token = Some(exporter.cancel_token());
+                                        match exporter.spawn() {
+                                            Ok(()) => tracing::info!(
+                                                bind_address = %new_config.prometheus.bind_address,
+                                                port = new_config.prometheus.port,
+                                                "Prometheus エクスポーターをリロードしました"
+                                            ),
+                                            Err(e) => {
+                                                tracing::error!(
+                                                    error = %e,
+                                                    "新設定での Prometheus エクスポーターの起動に失敗。旧設定で復旧を試みます"
+                                                );
+                                                let fallback = PrometheusExporter::new(
+                                                    &self.config.prometheus,
+                                                    Arc::clone(metrics),
+                                                    prometheus_started_at,
+                                                );
+                                                prometheus_cancel_token =
+                                                    Some(fallback.cancel_token());
+                                                match fallback.spawn() {
+                                                    Ok(()) => tracing::info!(
+                                                        "旧設定で Prometheus エクスポーターを復旧しました"
+                                                    ),
+                                                    Err(e2) => tracing::error!(
+                                                        error = %e2,
+                                                        "旧設定での Prometheus エクスポーターの復旧にも失敗しました"
+                                                    ),
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
 
                             self.config = new_config;

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -431,4 +431,137 @@ mod tests {
         assert_eq!(exporter.bind_address, "0.0.0.0");
         assert_eq!(exporter.port, 9200);
     }
+
+    #[test]
+    fn test_prometheus_exporter_new_with_started_at() {
+        let past = Instant::now() - std::time::Duration::from_secs(5);
+        let config = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port: 9200,
+        };
+        let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
+        let exporter = PrometheusExporter::new(&config, shared, past);
+
+        let output =
+            PrometheusExporter::format_metrics(&exporter.shared_metrics, exporter.started_at);
+        assert!(output.contains("zettai_uptime_seconds"));
+        let uptime = parse_uptime_from_metrics(&output);
+        assert!(uptime >= 5.0, "uptime should be >= 5.0, got {uptime}");
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_restart_on_different_port() {
+        let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
+
+        // 最初のエクスポーターを空きポートで起動
+        let listener1 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port1 = listener1.local_addr().unwrap().port();
+        drop(listener1);
+
+        let config1 = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port: port1,
+        };
+        let exporter1 = PrometheusExporter::new(&config1, Arc::clone(&shared), Instant::now());
+        let cancel1 = exporter1.cancel_token();
+        exporter1.spawn().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // cancel_token で停止
+        cancel1.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // 別の空きポートで新しいエクスポーターを起動
+        let listener2 = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port2 = listener2.local_addr().unwrap().port();
+        drop(listener2);
+
+        let config2 = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port: port2,
+        };
+        let exporter2 = PrometheusExporter::new(&config2, Arc::clone(&shared), Instant::now());
+        let cancel2 = exporter2.cancel_token();
+        exporter2.spawn().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // 新ポートで /metrics にアクセスできることを確認
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port2}"))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("zettai_uptime_seconds"));
+
+        cancel2.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_exporter_started_at_preserved() {
+        let past = Instant::now() - std::time::Duration::from_secs(3);
+        let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let config = PrometheusConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+        };
+        let exporter = PrometheusExporter::new(&config, Arc::clone(&shared), past);
+        let cancel = exporter.cancel_token();
+        exporter.spawn().unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // /metrics から uptime を取得
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        let uptime = parse_uptime_from_metrics(&response);
+        assert!(
+            uptime >= 3.0,
+            "uptime should be >= 3.0 (started_at preserved), got {uptime}"
+        );
+
+        cancel.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    fn parse_uptime_from_metrics(output: &str) -> f64 {
+        for line in output.lines() {
+            if line.starts_with("zettai_uptime_seconds ") {
+                return line
+                    .strip_prefix("zettai_uptime_seconds ")
+                    .unwrap()
+                    .trim()
+                    .parse::<f64>()
+                    .unwrap();
+            }
+        }
+        panic!("zettai_uptime_seconds not found in metrics output");
+    }
 }

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -22,12 +22,16 @@ pub struct PrometheusExporter {
 
 impl PrometheusExporter {
     /// 新しい PrometheusExporter を作成する
-    pub fn new(config: &PrometheusConfig, shared_metrics: Arc<StdMutex<SharedMetrics>>) -> Self {
+    pub fn new(
+        config: &PrometheusConfig,
+        shared_metrics: Arc<StdMutex<SharedMetrics>>,
+        started_at: Instant,
+    ) -> Self {
         Self {
             bind_address: config.bind_address.clone(),
             port: config.port,
             shared_metrics,
-            started_at: Instant::now(),
+            started_at,
             cancel_token: CancellationToken::new(),
         }
     }
@@ -352,7 +356,7 @@ mod tests {
             module_counts,
         }));
 
-        let exporter = PrometheusExporter::new(&config, Arc::clone(&shared));
+        let exporter = PrometheusExporter::new(&config, Arc::clone(&shared), Instant::now());
         let cancel_token = exporter.cancel_token();
         exporter.spawn().unwrap();
 
@@ -422,7 +426,7 @@ mod tests {
             port: 9200,
         };
         let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
-        let exporter = PrometheusExporter::new(&config, shared);
+        let exporter = PrometheusExporter::new(&config, shared, Instant::now());
 
         assert_eq!(exporter.bind_address, "0.0.0.0");
         assert_eq!(exporter.port, 9200);


### PR DESCRIPTION
## Summary

- SIGHUP による Prometheus エクスポーターのホットリロードに対応
- `bind_address` / `port` の変更を再起動なしで反映可能に
- `enabled` の動的切り替え（有効↔無効）をサポート
- リロード失敗時は旧設定でフォールバック再起動を試みる安全な設計

## 変更内容

- `PrometheusExporter::new()` に `started_at: Instant` パラメータを追加（uptime 維持）
- `daemon.rs` の SIGHUP ハンドラに 3 パターンのリロードロジックを実装
- 同一ポート再バインド対策として 100ms の待機を挿入
- ホットリロードテスト 3 件追加
- `config.example.toml` にホットリロード対応の説明コメントを追加
- バージョンを v1.20.0 に更新

Closes #243

## Test plan

- [x] `cargo test` — 全 38 テスト パス
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット問題なし
- [x] 新規テスト: started_at 外部注入、ポート変更での再起動、uptime 維持の検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)