### PR TITLE
feat: REST API OpenAPI スキーマ生成を追加 (#255)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
 - **Prometheus Exporter**: MetricsCollector の集計データを Prometheus テキスト形式で HTTP エンドポイント（`/metrics`）から公開する。Grafana・Alertmanager 等の外部監視基盤と連携可能。`/health` エンドポイントでヘルスチェックも提供
-- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧、設定リロードをリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。ホットリロード対応
+- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧、設定リロードをリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。ホットリロード対応
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
@@ -89,6 +89,7 @@ src/
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
     metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）
+    openapi.rs         # OpenAPI 3.0.3 スキーマ生成
     prometheus.rs      # Prometheus メトリクスエクスポーター（HTTP エンドポイント）
     scan_diff.rs       # スキャン状態差分レポート（CLI scan-diff コマンド）
     status.rs          # ステータスサーバー（Unix ソケット経由の CLI ステータス問い合わせ）

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.25.0"
+version = "1.26.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.25.0"
+version = "1.26.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -805,7 +805,7 @@ port = 9100
 # REST API サーバーの有効/無効
 # 有効にすると HTTP REST API でデーモンのステータス確認、イベント検索、
 # モジュール一覧、設定リロードをリモートから操作可能にする
-# エンドポイント: /api/v1/health, /api/v1/status, /api/v1/modules, /api/v1/events, /api/v1/reload
+# エンドポイント: /api/v1/health, /api/v1/status, /api/v1/modules, /api/v1/events, /api/v1/reload, /api/v1/openapi.json
 # SIGHUP でホットリロード可能（enabled, bind_address, port, tokens の変更が即時反映される）
 enabled = false
 # バインドアドレス
@@ -859,6 +859,11 @@ max_requests_per_second = 10.0
 burst_size = 20
 # 古いクライアントエントリのクリーンアップ間隔（秒）
 cleanup_interval_secs = 60
+
+# OpenAPI スキーマエンドポイントの有効/無効
+# 有効にすると /api/v1/openapi.json で OpenAPI 3.0.3 仕様書を取得できる
+# 認証不要のエンドポイント
+openapi_enabled = true
 
 [api.cors]
 # CORS の有効/無効

--- a/src/config.rs
+++ b/src/config.rs
@@ -6146,6 +6146,10 @@ pub struct ApiConfig {
     /// CORS 設定
     #[serde(default)]
     pub cors: CorsConfig,
+
+    /// OpenAPI スキーマエンドポイントの有効/無効
+    #[serde(default = "ApiConfig::default_openapi_enabled")]
+    pub openapi_enabled: bool,
 }
 
 impl ApiConfig {
@@ -6155,6 +6159,10 @@ impl ApiConfig {
 
     fn default_port() -> u16 {
         9201
+    }
+
+    fn default_openapi_enabled() -> bool {
+        true
     }
 }
 
@@ -6168,6 +6176,7 @@ impl Default for ApiConfig {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: Self::default_openapi_enabled(),
         }
     }
 }
@@ -6182,6 +6191,7 @@ impl Clone for ApiConfig {
             rate_limit: self.rate_limit.clone(),
             websocket: self.websocket.clone(),
             cors: self.cors.clone(),
+            openapi_enabled: self.openapi_enabled,
         }
     }
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -9,6 +9,7 @@ use crate::config::{
 };
 use crate::core::event::{SecurityEvent, Severity};
 use crate::core::metrics::SharedMetrics;
+use crate::core::openapi;
 use crate::core::status::{MetricsSummary, StatusResponse};
 use futures_util::{SinkExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -186,6 +187,7 @@ pub struct ApiServer {
     ws_config: WebSocketConfig,
     ws_connections: Arc<AtomicUsize>,
     cors_config: Arc<CorsConfig>,
+    openapi_enabled: bool,
 }
 
 impl ApiServer {
@@ -223,6 +225,7 @@ impl ApiServer {
             ws_config: config.websocket.clone(),
             ws_connections: Arc::new(AtomicUsize::new(0)),
             cors_config: Arc::new(config.cors.clone()),
+            openapi_enabled: config.openapi_enabled,
         }
     }
 
@@ -251,6 +254,7 @@ impl ApiServer {
         let ws_config = Arc::new(self.ws_config);
         let ws_connections = self.ws_connections;
         let cors_config = self.cors_config;
+        let openapi_enabled = self.openapi_enabled;
 
         // クリーンアップタスク
         if self.rate_limit_config.enabled {
@@ -296,11 +300,13 @@ impl ApiServer {
                                 let wsc = Arc::clone(&ws_config);
                                 let wsc_count = Arc::clone(&ws_connections);
                                 let cors = Arc::clone(&cors_config);
+                                let oa_enabled = openapi_enabled;
                                 tokio::spawn(async move {
                                     if let Err(e) = Self::handle_connection(
                                         stream, &names, &metrics, &restarts,
                                         started, &db_path, &sender, &toks,
                                         client_ip, &rl, &eb, &wsc, &wsc_count, &cors,
+                                        oa_enabled,
                                     ).await {
                                         tracing::debug!(error = %e, "API 接続の処理に失敗");
                                     }
@@ -454,6 +460,7 @@ impl ApiServer {
         ws_config: &Arc<WebSocketConfig>,
         ws_connections: &Arc<AtomicUsize>,
         cors_config: &Arc<CorsConfig>,
+        openapi_enabled: bool,
     ) -> Result<(), io::Error> {
         // 接続タイムアウト（スローロリス対策）
         let result = tokio::time::timeout(
@@ -478,8 +485,8 @@ impl ApiServer {
         let cors_headers = Self::build_cors_headers(cors_config, origin, is_preflight);
         let cors_headers_for_health = cors_headers.clone();
 
-        // レートリミットチェック（/api/v1/health はスキップ）
-        let rate_limit_check = if path != "/api/v1/health" {
+        // レートリミットチェック（/api/v1/health, /api/v1/openapi.json はスキップ）
+        let rate_limit_check = if path != "/api/v1/health" && path != "/api/v1/openapi.json" {
             // unwrap safety: Mutex が poisoned になるのはパニック時のみ
             let mut rl_guard = rate_limiter.lock().unwrap();
             (*rl_guard)
@@ -687,6 +694,30 @@ impl ApiServer {
                     .await?;
                 }
             },
+            (HttpMethod::Get, "/api/v1/openapi.json") => {
+                if openapi_enabled {
+                    let schema = openapi::generate_openapi_schema();
+                    let body = serde_json::to_string(&schema).unwrap_or_else(|_| {
+                        r#"{"error":"OpenAPI スキーマの生成に失敗しました"}"#.to_string()
+                    });
+                    let cors_only = if cors_headers_for_health.is_empty() {
+                        None
+                    } else {
+                        Some(cors_headers_for_health.as_str())
+                    };
+                    Self::send_json_response_with_headers(&mut stream, 200, "OK", &body, cors_only)
+                        .await?;
+                } else {
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        404,
+                        "Not Found",
+                        "OpenAPI スキーマが無効です",
+                        extra,
+                    )
+                    .await?;
+                }
+            }
             (HttpMethod::Get, _) | (HttpMethod::Options, _) | (HttpMethod::Other, _) => {
                 if matches!(
                     path.as_str(),
@@ -695,6 +726,7 @@ impl ApiServer {
                         | "/api/v1/modules"
                         | "/api/v1/events"
                         | "/api/v1/reload"
+                        | "/api/v1/openapi.json"
                 ) {
                     Self::send_error_with_headers(
                         &mut stream,
@@ -718,7 +750,11 @@ impl ApiServer {
             (HttpMethod::Post, _) => {
                 if matches!(
                     path.as_str(),
-                    "/api/v1/health" | "/api/v1/status" | "/api/v1/modules" | "/api/v1/events"
+                    "/api/v1/health"
+                        | "/api/v1/status"
+                        | "/api/v1/modules"
+                        | "/api/v1/events"
+                        | "/api/v1/openapi.json"
                 ) {
                     Self::send_error_with_headers(
                         &mut stream,
@@ -1453,6 +1489,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -1503,6 +1540,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let modules = Arc::new(StdMutex::new(vec!["test_module".to_string()]));
         let metrics = Arc::new(StdMutex::new(SharedMetrics {
@@ -1563,6 +1601,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let modules = Arc::new(StdMutex::new(vec![
             "mod_a".to_string(),
@@ -1622,6 +1661,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -1676,6 +1716,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -1726,6 +1767,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -1776,6 +1818,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -1914,6 +1957,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2088,6 +2132,7 @@ mod tests {
             rate_limit: ApiRateLimitConfig::default(),
             websocket: ws_config,
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2543,6 +2588,7 @@ mod tests {
             },
             websocket: WebSocketConfig::default(),
             cors: CorsConfig::default(),
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2766,6 +2812,7 @@ mod tests {
                 allowed_origins: vec!["https://dashboard.example.com".to_string()],
                 ..CorsConfig::default()
             },
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2825,6 +2872,7 @@ mod tests {
                 allowed_origins: Vec::new(),
                 ..CorsConfig::default()
             },
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2883,6 +2931,7 @@ mod tests {
                 allowed_origins: vec!["https://allowed.example.com".to_string()],
                 ..CorsConfig::default()
             },
+            openapi_enabled: true,
         };
         let server = ApiServer::new(
             &config,
@@ -2917,6 +2966,108 @@ mod tests {
         let response = String::from_utf8_lossy(&buf);
         assert!(response.contains("HTTP/1.1 200 OK"));
         assert!(!response.contains("Access-Control-Allow-Origin"));
+
+        cancel.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_api_server_openapi_endpoint() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let (reload_tx, _reload_rx) = mpsc::channel::<()>(1);
+        let config = ApiConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+            tokens: Vec::new(),
+            rate_limit: ApiRateLimitConfig::default(),
+            websocket: WebSocketConfig::default(),
+            cors: CorsConfig::default(),
+            openapi_enabled: true,
+        };
+        let server = ApiServer::new(
+            &config,
+            Arc::new(StdMutex::new(Vec::new())),
+            None,
+            Arc::new(StdMutex::new(HashMap::new())),
+            Instant::now(),
+            None,
+            reload_tx,
+            None,
+        );
+        let cancel = server.cancel_token();
+        server.spawn().unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /api/v1/openapi.json HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"openapi\":\"3.0.3\""));
+        assert!(response.contains("\"paths\""));
+        assert!(response.contains("/api/v1/health"));
+
+        cancel.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_api_server_openapi_disabled() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let (reload_tx, _reload_rx) = mpsc::channel::<()>(1);
+        let config = ApiConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+            tokens: Vec::new(),
+            rate_limit: ApiRateLimitConfig::default(),
+            websocket: WebSocketConfig::default(),
+            cors: CorsConfig::default(),
+            openapi_enabled: false,
+        };
+        let server = ApiServer::new(
+            &config,
+            Arc::new(StdMutex::new(Vec::new())),
+            None,
+            Arc::new(StdMutex::new(HashMap::new())),
+            Instant::now(),
+            None,
+            reload_tx,
+            None,
+        );
+        let cancel = server.cancel_token();
+        server.spawn().unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /api/v1/openapi.json HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 404"));
+        assert!(response.contains("OpenAPI"));
 
         cancel.cancel();
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod event_stream;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;
+pub mod openapi;
 pub mod prometheus;
 pub mod scan_diff;
 pub mod scan_state;

--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -1,0 +1,616 @@
+//! OpenAPI 3.0 スキーマ生成
+//!
+//! REST API のエンドポイント定義から OpenAPI 3.0.3 仕様書を生成する。
+
+use serde_json::{Value, json};
+
+/// OpenAPI 3.0.3 仕様書を JSON として生成する
+pub fn generate_openapi_schema() -> Value {
+    json!({
+        "openapi": "3.0.3",
+        "info": {
+            "title": "zettai-mamorukun REST API",
+            "description": "Linux セキュリティ監視デーモン zettai-mamorukun の REST API",
+            "version": env!("CARGO_PKG_VERSION"),
+            "license": {
+                "name": "MIT"
+            }
+        },
+        "servers": [
+            {
+                "url": "/api/v1",
+                "description": "API v1"
+            }
+        ],
+        "paths": {
+            "/api/v1/health": health_path(),
+            "/api/v1/status": status_path(),
+            "/api/v1/modules": modules_path(),
+            "/api/v1/events": events_path(),
+            "/api/v1/reload": reload_path(),
+            "/api/v1/events/stream": events_stream_path(),
+            "/api/v1/openapi.json": openapi_path(),
+        },
+        "components": {
+            "securitySchemes": {
+                "BearerAuth": {
+                    "type": "http",
+                    "scheme": "bearer",
+                    "description": "API トークン認証。`zettai-mamorukun hash-token <TOKEN>` でハッシュを生成し、設定ファイルに登録する"
+                }
+            },
+            "schemas": component_schemas(),
+        }
+    })
+}
+
+fn health_path() -> Value {
+    json!({
+        "get": {
+            "summary": "ヘルスチェック",
+            "description": "API サーバーの稼働状態を返す。認証不要。",
+            "operationId": "getHealth",
+            "tags": ["system"],
+            "responses": {
+                "200": {
+                    "description": "正常稼働中",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "status": {
+                                        "type": "string",
+                                        "enum": ["ok"],
+                                        "example": "ok"
+                                    }
+                                },
+                                "required": ["status"]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn status_path() -> Value {
+    json!({
+        "get": {
+            "summary": "デーモンステータス",
+            "description": "デーモンのバージョン、稼働時間、有効モジュール、メトリクスサマリーを返す。",
+            "operationId": "getStatus",
+            "tags": ["system"],
+            "security": [{"BearerAuth": []}],
+            "responses": {
+                "200": {
+                    "description": "ステータス情報",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/StatusResponse"
+                            }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" }
+            }
+        }
+    })
+}
+
+fn modules_path() -> Value {
+    json!({
+        "get": {
+            "summary": "モジュール一覧",
+            "description": "有効な監視モジュールの一覧とリスタート回数を返す。",
+            "operationId": "getModules",
+            "tags": ["modules"],
+            "security": [{"BearerAuth": []}],
+            "responses": {
+                "200": {
+                    "description": "モジュール一覧",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ModulesResponse"
+                            }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" }
+            }
+        }
+    })
+}
+
+fn events_path() -> Value {
+    json!({
+        "get": {
+            "summary": "イベント検索",
+            "description": "SQLite イベントストアからセキュリティイベントを検索する。",
+            "operationId": "getEvents",
+            "tags": ["events"],
+            "security": [{"BearerAuth": []}],
+            "parameters": [
+                {
+                    "name": "severity",
+                    "in": "query",
+                    "description": "Severity でフィルタリング（info, warning, critical）",
+                    "required": false,
+                    "schema": {
+                        "type": "string",
+                        "enum": ["info", "warning", "critical"]
+                    }
+                },
+                {
+                    "name": "module",
+                    "in": "query",
+                    "description": "ソースモジュール名でフィルタリング",
+                    "required": false,
+                    "schema": { "type": "string" }
+                },
+                {
+                    "name": "since",
+                    "in": "query",
+                    "description": "開始日時（ISO 8601 形式: YYYY-MM-DDTHH:MM:SSZ または YYYY-MM-DD）",
+                    "required": false,
+                    "schema": { "type": "string", "format": "date-time" }
+                },
+                {
+                    "name": "until",
+                    "in": "query",
+                    "description": "終了日時（ISO 8601 形式）",
+                    "required": false,
+                    "schema": { "type": "string", "format": "date-time" }
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "description": "最大取得件数（デフォルト: 100、上限: 1000）",
+                    "required": false,
+                    "schema": {
+                        "type": "integer",
+                        "default": 100,
+                        "minimum": 1,
+                        "maximum": 1000
+                    }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "イベント一覧",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EventsResponse"
+                            }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" },
+                "503": {
+                    "description": "イベントストアが無効",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn reload_path() -> Value {
+    json!({
+        "post": {
+            "summary": "設定リロード",
+            "description": "設定ファイルを再読み込みし、変更のあったモジュールを再起動する。admin ロールが必要。",
+            "operationId": "postReload",
+            "tags": ["system"],
+            "security": [{"BearerAuth": []}],
+            "responses": {
+                "200": {
+                    "description": "リロード成功",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "example": "リロードをトリガーしました"
+                                    }
+                                },
+                                "required": ["message"]
+                            }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" },
+                "500": {
+                    "description": "リロード失敗",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn events_stream_path() -> Value {
+    json!({
+        "get": {
+            "summary": "イベントストリーミング（WebSocket）",
+            "description": "WebSocket でセキュリティイベントをリアルタイムにストリーミングする。Upgrade: websocket ヘッダーが必要。認証は Authorization ヘッダーまたは token クエリパラメータで行う。",
+            "operationId": "getEventsStream",
+            "tags": ["events"],
+            "security": [{"BearerAuth": []}],
+            "parameters": [
+                {
+                    "name": "module",
+                    "in": "query",
+                    "description": "モジュール名フィルタ（カンマ区切りで複数指定可能）",
+                    "required": false,
+                    "schema": { "type": "string" }
+                },
+                {
+                    "name": "severity",
+                    "in": "query",
+                    "description": "最小 Severity フィルタ",
+                    "required": false,
+                    "schema": {
+                        "type": "string",
+                        "enum": ["info", "warning", "critical"]
+                    }
+                },
+                {
+                    "name": "token",
+                    "in": "query",
+                    "description": "Bearer トークン（Authorization ヘッダーの代替）",
+                    "required": false,
+                    "schema": { "type": "string" }
+                }
+            ],
+            "responses": {
+                "101": {
+                    "description": "WebSocket Upgrade 成功。各メッセージは SecurityEvent の JSON。",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SecurityEvent"
+                            }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "426": {
+                    "description": "WebSocket Upgrade が必要",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                },
+                "503": {
+                    "description": "WebSocket が無効または接続数上限",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn openapi_path() -> Value {
+    json!({
+        "get": {
+            "summary": "OpenAPI スキーマ",
+            "description": "この API の OpenAPI 3.0.3 仕様書を JSON 形式で返す。認証不要。",
+            "operationId": "getOpenApiSchema",
+            "tags": ["system"],
+            "responses": {
+                "200": {
+                    "description": "OpenAPI 3.0.3 仕様書",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "description": "OpenAPI 3.0.3 仕様書"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn component_schemas() -> Value {
+    json!({
+        "ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "type": "string",
+                    "description": "エラーメッセージ"
+                }
+            },
+            "required": ["error"]
+        },
+        "StatusResponse": {
+            "type": "object",
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "description": "デーモンバージョン",
+                    "example": "1.26.0"
+                },
+                "uptime_secs": {
+                    "type": "integer",
+                    "description": "稼働時間（秒）",
+                    "example": 3600
+                },
+                "modules": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "有効モジュール名の一覧"
+                },
+                "metrics": {
+                    "oneOf": [
+                        { "$ref": "#/components/schemas/MetricsSummary" },
+                        { "type": "null" }
+                    ],
+                    "description": "メトリクスサマリー（メトリクスが無効の場合は null）"
+                },
+                "module_restarts": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" },
+                    "description": "モジュールごとのリスタート回数"
+                }
+            },
+            "required": ["version", "uptime_secs", "modules", "metrics", "module_restarts"]
+        },
+        "MetricsSummary": {
+            "type": "object",
+            "properties": {
+                "total_events": {
+                    "type": "integer",
+                    "description": "イベント総数"
+                },
+                "info_count": {
+                    "type": "integer",
+                    "description": "Info イベント数"
+                },
+                "warning_count": {
+                    "type": "integer",
+                    "description": "Warning イベント数"
+                },
+                "critical_count": {
+                    "type": "integer",
+                    "description": "Critical イベント数"
+                },
+                "module_counts": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" },
+                    "description": "モジュールごとのイベント数"
+                }
+            },
+            "required": ["total_events", "info_count", "warning_count", "critical_count", "module_counts"]
+        },
+        "ModulesResponse": {
+            "type": "object",
+            "properties": {
+                "modules": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/ModuleInfo" },
+                    "description": "モジュール一覧"
+                }
+            },
+            "required": ["modules"]
+        },
+        "ModuleInfo": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "モジュール名"
+                },
+                "restarts": {
+                    "type": "integer",
+                    "description": "リスタート回数"
+                }
+            },
+            "required": ["name", "restarts"]
+        },
+        "EventsResponse": {
+            "type": "object",
+            "properties": {
+                "events": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/EventRecord" },
+                    "description": "イベント一覧"
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "返却件数"
+                }
+            },
+            "required": ["events", "count"]
+        },
+        "EventRecord": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "integer",
+                    "description": "イベント ID"
+                },
+                "timestamp": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "タイムスタンプ"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "critical"],
+                    "description": "重要度"
+                },
+                "source_module": {
+                    "type": "string",
+                    "description": "ソースモジュール名"
+                },
+                "event_type": {
+                    "type": "string",
+                    "description": "イベントタイプ"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "メッセージ"
+                },
+                "details": {
+                    "type": ["string", "null"],
+                    "description": "詳細情報"
+                }
+            },
+            "required": ["id", "timestamp", "severity", "source_module", "event_type", "message"]
+        },
+        "SecurityEvent": {
+            "type": "object",
+            "description": "WebSocket で送信されるセキュリティイベント",
+            "properties": {
+                "event_type": {
+                    "type": "string",
+                    "description": "イベントタイプ"
+                },
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "critical"],
+                    "description": "重要度"
+                },
+                "source_module": {
+                    "type": "string",
+                    "description": "ソースモジュール名"
+                },
+                "timestamp": {
+                    "type": "integer",
+                    "description": "UNIX タイムスタンプ（秒）"
+                },
+                "message": {
+                    "type": "string",
+                    "description": "メッセージ"
+                },
+                "details": {
+                    "type": ["string", "null"],
+                    "description": "詳細情報"
+                }
+            },
+            "required": ["event_type", "severity", "source_module", "timestamp", "message"]
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_openapi_schema_has_required_fields() {
+        let schema = generate_openapi_schema();
+        assert_eq!(schema["openapi"], "3.0.3");
+        assert!(schema["info"]["title"].is_string());
+        assert!(schema["info"]["version"].is_string());
+        assert!(schema["paths"].is_object());
+        assert!(schema["components"].is_object());
+    }
+
+    #[test]
+    fn test_all_endpoints_present() {
+        let schema = generate_openapi_schema();
+        let paths = schema["paths"].as_object().unwrap();
+        assert!(paths.contains_key("/api/v1/health"));
+        assert!(paths.contains_key("/api/v1/status"));
+        assert!(paths.contains_key("/api/v1/modules"));
+        assert!(paths.contains_key("/api/v1/events"));
+        assert!(paths.contains_key("/api/v1/reload"));
+        assert!(paths.contains_key("/api/v1/events/stream"));
+        assert!(paths.contains_key("/api/v1/openapi.json"));
+    }
+
+    #[test]
+    fn test_security_scheme_defined() {
+        let schema = generate_openapi_schema();
+        let schemes = &schema["components"]["securitySchemes"];
+        assert!(schemes["BearerAuth"].is_object());
+        assert_eq!(schemes["BearerAuth"]["type"], "http");
+        assert_eq!(schemes["BearerAuth"]["scheme"], "bearer");
+    }
+
+    #[test]
+    fn test_component_schemas_defined() {
+        let schema = generate_openapi_schema();
+        let schemas = &schema["components"]["schemas"];
+        assert!(schemas["StatusResponse"].is_object());
+        assert!(schemas["MetricsSummary"].is_object());
+        assert!(schemas["ModulesResponse"].is_object());
+        assert!(schemas["EventsResponse"].is_object());
+        assert!(schemas["EventRecord"].is_object());
+        assert!(schemas["SecurityEvent"].is_object());
+        assert!(schemas["ErrorResponse"].is_object());
+    }
+
+    #[test]
+    fn test_health_endpoint_no_auth() {
+        let schema = generate_openapi_schema();
+        let health = &schema["paths"]["/api/v1/health"]["get"];
+        assert!(health["security"].is_null());
+    }
+
+    #[test]
+    fn test_status_endpoint_requires_auth() {
+        let schema = generate_openapi_schema();
+        let status = &schema["paths"]["/api/v1/status"]["get"];
+        assert!(status["security"].is_array());
+    }
+
+    #[test]
+    fn test_events_query_parameters() {
+        let schema = generate_openapi_schema();
+        let events = &schema["paths"]["/api/v1/events"]["get"];
+        let params = events["parameters"].as_array().unwrap();
+        assert_eq!(params.len(), 5);
+        let param_names: Vec<&str> = params.iter().map(|p| p["name"].as_str().unwrap()).collect();
+        assert!(param_names.contains(&"severity"));
+        assert!(param_names.contains(&"module"));
+        assert!(param_names.contains(&"since"));
+        assert!(param_names.contains(&"until"));
+        assert!(param_names.contains(&"limit"));
+    }
+
+    #[test]
+    fn test_reload_is_post() {
+        let schema = generate_openapi_schema();
+        assert!(schema["paths"]["/api/v1/reload"]["post"].is_object());
+        assert!(schema["paths"]["/api/v1/reload"]["get"].is_null());
+    }
+
+    #[test]
+    fn test_openapi_schema_is_valid_json() {
+        let schema = generate_openapi_schema();
+        let json_str = serde_json::to_string(&schema).unwrap();
+        assert!(!json_str.is_empty());
+        let reparsed: Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(schema, reparsed);
+    }
+}


### PR DESCRIPTION
## 概要

REST API のエンドポイント定義から OpenAPI 3.0.3 仕様書を自動生成し、`/api/v1/openapi.json` エンドポイントで提供する。

## 変更内容

- **`src/core/openapi.rs`（新規）** — `serde_json::json!` マクロで OpenAPI 3.0.3 スキーマを構築する `generate_openapi_schema()` 関数を実装
- **`src/core/api.rs`** — `/api/v1/openapi.json` エンドポイントを追加（認証不要、レートリミット対象外）
- **`src/config.rs`** — `ApiConfig` に `openapi_enabled: bool` フィールドを追加（デフォルト: `true`）
- **`config.example.toml`** — `openapi_enabled` 設定項目を追加
- **`CLAUDE.md`** — REST API Server の説明に OpenAPI スキーマ対応を追記、ディレクトリ構成に `openapi.rs` を追加

## スキーマ内容

- 全7エンドポイント（health, status, modules, events, reload, events/stream, openapi.json）の paths 定義
- リクエスト/レスポンスの JSON Schema（StatusResponse, MetricsSummary, ModulesResponse, EventsResponse, EventRecord, SecurityEvent, ErrorResponse）
- BearerAuth セキュリティスキーマ
- WebSocket エンドポイントは description で詳細を記述（OpenAPI 3.0 にネイティブサポートがないため）

## テスト

- `src/core/openapi.rs` に 9 件の単体テスト追加
- `src/core/api.rs` に 2 件の統合テスト追加（有効時・無効時）
- 全 2039 テスト通過
- `cargo clippy -- -D warnings` 通過
- `cargo fmt --check` 通過

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)