### PR TITLE
feat: REST API バッチ操作エンドポイントを追加 (#259)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.27.0"
+version = "1.28.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -832,6 +832,12 @@ port = 9201
 # token_hash = "sha256:..."
 # role = "admin"
 
+# バッチ操作の最大件数
+# batch_max_size = 1000
+
+# リクエストボディの最大サイズ（バイト）
+# max_request_body_size = 1048576
+
 # WebSocket イベントストリーミング設定
 # /api/v1/events/stream で SecurityEvent をリアルタイムにストリーミングする
 # 認証: Authorization ヘッダー or ?token=xxx クエリパラメータ

--- a/src/config.rs
+++ b/src/config.rs
@@ -6158,6 +6158,14 @@ pub struct ApiConfig {
     /// 最大ページサイズ
     #[serde(default = "ApiConfig::default_max_page_size")]
     pub max_page_size: u32,
+
+    /// バッチ操作の最大件数
+    #[serde(default = "ApiConfig::default_batch_max_size")]
+    pub batch_max_size: u32,
+
+    /// リクエストボディの最大サイズ（バイト）
+    #[serde(default = "ApiConfig::default_max_request_body_size")]
+    pub max_request_body_size: usize,
 }
 
 impl ApiConfig {
@@ -6180,6 +6188,14 @@ impl ApiConfig {
     fn default_max_page_size() -> u32 {
         200
     }
+
+    fn default_batch_max_size() -> u32 {
+        1000
+    }
+
+    fn default_max_request_body_size() -> usize {
+        1_048_576
+    }
 }
 
 impl Default for ApiConfig {
@@ -6195,6 +6211,8 @@ impl Default for ApiConfig {
             openapi_enabled: Self::default_openapi_enabled(),
             default_page_size: Self::default_page_size(),
             max_page_size: Self::default_max_page_size(),
+            batch_max_size: Self::default_batch_max_size(),
+            max_request_body_size: Self::default_max_request_body_size(),
         }
     }
 }
@@ -6212,6 +6230,8 @@ impl Clone for ApiConfig {
             openapi_enabled: self.openapi_enabled,
             default_page_size: self.default_page_size,
             max_page_size: self.max_page_size,
+            batch_max_size: self.batch_max_size,
+            max_request_body_size: self.max_request_body_size,
         }
     }
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -190,6 +190,8 @@ pub struct ApiServer {
     openapi_enabled: bool,
     default_page_size: u32,
     max_page_size: u32,
+    batch_max_size: u32,
+    max_request_body_size: usize,
 }
 
 impl ApiServer {
@@ -230,6 +232,8 @@ impl ApiServer {
             openapi_enabled: config.openapi_enabled,
             default_page_size: config.default_page_size,
             max_page_size: config.max_page_size,
+            batch_max_size: config.batch_max_size,
+            max_request_body_size: config.max_request_body_size,
         }
     }
 
@@ -261,6 +265,8 @@ impl ApiServer {
         let openapi_enabled = self.openapi_enabled;
         let default_page_size = self.default_page_size;
         let max_page_size = self.max_page_size;
+        let batch_max_size = self.batch_max_size;
+        let max_request_body_size = self.max_request_body_size;
 
         // クリーンアップタスク
         if self.rate_limit_config.enabled {
@@ -309,12 +315,14 @@ impl ApiServer {
                                 let oa_enabled = openapi_enabled;
                                 let dps = default_page_size;
                                 let mps = max_page_size;
+                                let bms = batch_max_size;
+                                let mrbs = max_request_body_size;
                                 tokio::spawn(async move {
                                     if let Err(e) = Self::handle_connection(
                                         stream, &names, &metrics, &restarts,
                                         started, &db_path, &sender, &toks,
                                         client_ip, &rl, &eb, &wsc, &wsc_count, &cors,
-                                        oa_enabled, dps, mps,
+                                        oa_enabled, dps, mps, bms, mrbs,
                                     ).await {
                                         tracing::debug!(error = %e, "API 接続の処理に失敗");
                                     }
@@ -392,6 +400,9 @@ impl ApiServer {
             | (HttpMethod::Get, "/api/v1/events")
             | (HttpMethod::Get, "/api/v1/events/stream") => Some(ApiRole::ReadOnly),
             (HttpMethod::Post, "/api/v1/reload") => Some(ApiRole::Admin),
+            (HttpMethod::Post, "/api/v1/events/batch/delete") => Some(ApiRole::Admin),
+            (HttpMethod::Post, "/api/v1/events/batch/export") => Some(ApiRole::ReadOnly),
+            (HttpMethod::Post, "/api/v1/events/batch/acknowledge") => Some(ApiRole::Admin),
             _ => None,
         }
     }
@@ -471,6 +482,8 @@ impl ApiServer {
         openapi_enabled: bool,
         default_page_size: u32,
         max_page_size: u32,
+        batch_max_size: u32,
+        max_request_body_size: usize,
     ) -> Result<(), io::Error> {
         // 接続タイムアウト（スローロリス対策）
         let result = tokio::time::timeout(
@@ -709,6 +722,231 @@ impl ApiServer {
                     .await?;
                 }
             },
+            (HttpMethod::Post, "/api/v1/events/batch/delete") => match event_store_db_path {
+                Some(db_path) => {
+                    let body_result = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        Self::read_request_with_body(&mut stream, max_request_body_size),
+                    )
+                    .await;
+                    let full = match body_result {
+                        Ok(Ok(s)) => s,
+                        Ok(Err(e)) => {
+                            let msg = format!("リクエストの読み取りに失敗: {}", e);
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                400,
+                                "Bad Request",
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                408,
+                                "Request Timeout",
+                                "リクエストタイムアウト",
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                    };
+                    let body = full.split("\r\n\r\n").nth(1).unwrap_or("");
+                    match Self::handle_batch_delete(db_path, body, batch_max_size) {
+                        Ok(resp) => {
+                            Self::send_json_response_with_headers(
+                                &mut stream,
+                                200,
+                                "OK",
+                                &resp,
+                                extra,
+                            )
+                            .await?;
+                        }
+                        Err((status, msg)) => {
+                            let status_text = match status {
+                                400 => "Bad Request",
+                                500 => "Internal Server Error",
+                                _ => "Error",
+                            };
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                status,
+                                status_text,
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                        }
+                    }
+                }
+                None => {
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        "イベントストアが無効です",
+                        extra,
+                    )
+                    .await?;
+                }
+            },
+            (HttpMethod::Post, "/api/v1/events/batch/export") => match event_store_db_path {
+                Some(db_path) => {
+                    let body_result = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        Self::read_request_with_body(&mut stream, max_request_body_size),
+                    )
+                    .await;
+                    let full = match body_result {
+                        Ok(Ok(s)) => s,
+                        Ok(Err(e)) => {
+                            let msg = format!("リクエストの読み取りに失敗: {}", e);
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                400,
+                                "Bad Request",
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                408,
+                                "Request Timeout",
+                                "リクエストタイムアウト",
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                    };
+                    let body = full.split("\r\n\r\n").nth(1).unwrap_or("");
+                    match Self::handle_batch_export(db_path, body, batch_max_size) {
+                        Ok(resp) => {
+                            Self::send_json_response_with_headers(
+                                &mut stream,
+                                200,
+                                "OK",
+                                &resp,
+                                extra,
+                            )
+                            .await?;
+                        }
+                        Err((status, msg)) => {
+                            let status_text = match status {
+                                400 => "Bad Request",
+                                500 => "Internal Server Error",
+                                _ => "Error",
+                            };
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                status,
+                                status_text,
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                        }
+                    }
+                }
+                None => {
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        "イベントストアが無効です",
+                        extra,
+                    )
+                    .await?;
+                }
+            },
+            (HttpMethod::Post, "/api/v1/events/batch/acknowledge") => match event_store_db_path {
+                Some(db_path) => {
+                    let body_result = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        Self::read_request_with_body(&mut stream, max_request_body_size),
+                    )
+                    .await;
+                    let full = match body_result {
+                        Ok(Ok(s)) => s,
+                        Ok(Err(e)) => {
+                            let msg = format!("リクエストの読み取りに失敗: {}", e);
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                400,
+                                "Bad Request",
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                408,
+                                "Request Timeout",
+                                "リクエストタイムアウト",
+                                extra,
+                            )
+                            .await?;
+                            stream.shutdown().await?;
+                            return Ok(());
+                        }
+                    };
+                    let body = full.split("\r\n\r\n").nth(1).unwrap_or("");
+                    match Self::handle_batch_acknowledge(db_path, body, batch_max_size) {
+                        Ok(resp) => {
+                            Self::send_json_response_with_headers(
+                                &mut stream,
+                                200,
+                                "OK",
+                                &resp,
+                                extra,
+                            )
+                            .await?;
+                        }
+                        Err((status, msg)) => {
+                            let status_text = match status {
+                                400 => "Bad Request",
+                                500 => "Internal Server Error",
+                                _ => "Error",
+                            };
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                status,
+                                status_text,
+                                &msg,
+                                extra,
+                            )
+                            .await?;
+                        }
+                    }
+                }
+                None => {
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        "イベントストアが無効です",
+                        extra,
+                    )
+                    .await?;
+                }
+            },
             (HttpMethod::Get, "/api/v1/openapi.json") => {
                 if openapi_enabled {
                     let schema = openapi::generate_openapi_schema();
@@ -742,6 +980,9 @@ impl ApiServer {
                         | "/api/v1/events"
                         | "/api/v1/reload"
                         | "/api/v1/openapi.json"
+                        | "/api/v1/events/batch/delete"
+                        | "/api/v1/events/batch/export"
+                        | "/api/v1/events/batch/acknowledge"
                 ) {
                     Self::send_error_with_headers(
                         &mut stream,
@@ -1117,6 +1358,69 @@ impl ApiServer {
         Ok(String::from_utf8_lossy(&buf[..n]).to_string())
     }
 
+    async fn read_request_with_body(
+        stream: &mut tokio::net::TcpStream,
+        max_body_size: usize,
+    ) -> Result<String, io::Error> {
+        let mut buf = Vec::with_capacity(4096);
+        let mut tmp = [0u8; 4096];
+        let header_end;
+
+        loop {
+            let n = stream.read(&mut tmp).await?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "空のリクエスト",
+                ));
+            }
+            buf.extend_from_slice(&tmp[..n]);
+
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                header_end = pos + 4;
+                break;
+            }
+
+            if buf.len() > 16384 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "ヘッダーが大きすぎます",
+                ));
+            }
+        }
+
+        let header_str = String::from_utf8_lossy(&buf[..header_end]);
+        let content_length: usize = header_str
+            .lines()
+            .find_map(|line| {
+                let lower = line.to_ascii_lowercase();
+                if lower.starts_with("content-length:") {
+                    line["content-length:".len()..].trim().parse().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        if content_length > max_body_size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "リクエストボディが大きすぎます",
+            ));
+        }
+
+        let total_needed = header_end + content_length;
+        while buf.len() < total_needed {
+            let n = stream.read(&mut tmp).await?;
+            if n == 0 {
+                break;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+
+        Ok(String::from_utf8_lossy(&buf[..buf.len().min(total_needed)]).to_string())
+    }
+
     fn parse_request(raw: &str) -> (HttpMethod, String, HashMap<String, String>) {
         let first_line = raw.lines().next().unwrap_or("");
         let parts: Vec<&str> = first_line.split_whitespace().collect();
@@ -1429,6 +1733,202 @@ impl ApiServer {
         result
     }
 
+    fn parse_iso8601_to_timestamp(s: &str) -> Option<i64> {
+        let s = s.trim().trim_matches('"');
+        if s.len() == 20 && s.ends_with('Z') {
+            let inner = &s[..19];
+            let parts: Vec<&str> = inner.split('T').collect();
+            if parts.len() == 2 {
+                let datetime_str = format!("{} {}", parts[0], parts[1]);
+                return crate::core::event_store::parse_datetime(&datetime_str).ok();
+            }
+        }
+        if s.len() == 10 {
+            let datetime_str = format!("{} 00:00:00", s);
+            return crate::core::event_store::parse_datetime(&datetime_str).ok();
+        }
+        None
+    }
+
+    fn handle_batch_delete(
+        db_path: &str,
+        body: &str,
+        batch_max_size: u32,
+    ) -> Result<String, (u16, String)> {
+        let json: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| (400u16, format!("JSON パースに失敗: {}", e)))?;
+
+        let has_ids = json.get("ids").is_some();
+        let has_filter = json.get("filter").is_some();
+
+        if has_ids && has_filter {
+            return Err((400, "ids と filter は同時に指定できません".to_string()));
+        }
+        if !has_ids && !has_filter {
+            return Err((400, "ids または filter を指定してください".to_string()));
+        }
+
+        let conn = rusqlite::Connection::open(db_path)
+            .map_err(|e| (500u16, format!("データベースのオープンに失敗: {}", e)))?;
+
+        if has_ids {
+            let ids = json["ids"]
+                .as_array()
+                .ok_or_else(|| (400u16, "ids は配列で指定してください".to_string()))?;
+            if ids.len() > batch_max_size as usize {
+                return Err((
+                    400,
+                    format!("ids の件数が上限 {} を超えています", batch_max_size),
+                ));
+            }
+            let id_values: Vec<i64> = ids.iter().filter_map(|v| v.as_i64()).collect();
+            if id_values.len() != ids.len() {
+                return Err((400, "ids に不正な値が含まれています".to_string()));
+            }
+            let deleted = crate::core::event_store::batch_delete_by_ids(&conn, &id_values)
+                .map_err(|e| (500u16, format!("{}", e)))?;
+            Ok(format!(r#"{{"deleted":{}}}"#, deleted))
+        } else {
+            let filter_obj = &json["filter"];
+            let filter = crate::core::event_store::BatchDeleteFilter {
+                severity: filter_obj
+                    .get("severity")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                source_module: filter_obj
+                    .get("module")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string()),
+                since: filter_obj
+                    .get("since")
+                    .and_then(|v| v.as_str())
+                    .and_then(Self::parse_iso8601_to_timestamp),
+                until: filter_obj
+                    .get("until")
+                    .and_then(|v| v.as_str())
+                    .and_then(Self::parse_iso8601_to_timestamp),
+            };
+            let deleted = crate::core::event_store::batch_delete_by_filter(&conn, &filter)
+                .map_err(|e| (500u16, format!("{}", e)))?;
+            Ok(format!(r#"{{"deleted":{}}}"#, deleted))
+        }
+    }
+
+    fn handle_batch_export(
+        db_path: &str,
+        body: &str,
+        batch_max_size: u32,
+    ) -> Result<String, (u16, String)> {
+        let json: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| (400u16, format!("JSON パースに失敗: {}", e)))?;
+
+        let filter = json.get("filter");
+        let limit = json
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u32)
+            .unwrap_or(batch_max_size)
+            .min(batch_max_size);
+
+        let query = crate::core::event_store::EventQuery {
+            module: filter
+                .and_then(|f| f.get("module"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            severity: filter
+                .and_then(|f| f.get("severity"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            since: filter
+                .and_then(|f| f.get("since"))
+                .and_then(|v| v.as_str())
+                .and_then(Self::parse_iso8601_to_timestamp),
+            until: filter
+                .and_then(|f| f.get("until"))
+                .and_then(|v| v.as_str())
+                .and_then(Self::parse_iso8601_to_timestamp),
+            event_type: filter
+                .and_then(|f| f.get("event_type"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string()),
+            limit,
+            cursor: None,
+        };
+
+        let conn = rusqlite::Connection::open_with_flags(
+            db_path,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY,
+        )
+        .map_err(|e| (500u16, format!("データベースのオープンに失敗: {}", e)))?;
+
+        let records =
+            crate::core::event_store::query_events_for_export(&conn, &query, batch_max_size)
+                .map_err(|e| (500u16, format!("{}", e)))?;
+
+        let count = records.len();
+        let items: Vec<String> = records
+            .iter()
+            .map(|r| {
+                let details_part = match &r.details {
+                    Some(d) => format!(r#","details":"{}""#, Self::escape_json_string(d)),
+                    None => String::new(),
+                };
+                let ts = crate::core::event_store::format_timestamp_iso(r.timestamp);
+                format!(
+                    r#"{{"id":{},"timestamp":"{}","severity":"{}","source_module":"{}","event_type":"{}","message":"{}","acknowledged":{}{}}}"#,
+                    r.id,
+                    Self::escape_json_string(&ts),
+                    Self::escape_json_string(&r.severity),
+                    Self::escape_json_string(&r.source_module),
+                    Self::escape_json_string(&r.event_type),
+                    Self::escape_json_string(&r.message),
+                    r.acknowledged,
+                    details_part,
+                )
+            })
+            .collect();
+
+        Ok(format!(
+            r#"{{"items":[{}],"count":{}}}"#,
+            items.join(","),
+            count
+        ))
+    }
+
+    fn handle_batch_acknowledge(
+        db_path: &str,
+        body: &str,
+        batch_max_size: u32,
+    ) -> Result<String, (u16, String)> {
+        let json: serde_json::Value = serde_json::from_str(body)
+            .map_err(|e| (400u16, format!("JSON パースに失敗: {}", e)))?;
+
+        let ids = json
+            .get("ids")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| (400u16, "ids を配列で指定してください".to_string()))?;
+
+        if ids.len() > batch_max_size as usize {
+            return Err((
+                400,
+                format!("ids の件数が上限 {} を超えています", batch_max_size),
+            ));
+        }
+
+        let id_values: Vec<i64> = ids.iter().filter_map(|v| v.as_i64()).collect();
+        if id_values.len() != ids.len() {
+            return Err((400, "ids に不正な値が含まれています".to_string()));
+        }
+
+        let conn = rusqlite::Connection::open(db_path)
+            .map_err(|e| (500u16, format!("データベースのオープンに失敗: {}", e)))?;
+
+        let acknowledged = crate::core::event_store::batch_acknowledge(&conn, &id_values)
+            .map_err(|e| (500u16, format!("{}", e)))?;
+
+        Ok(format!(r#"{{"acknowledged":{}}}"#, acknowledged))
+    }
+
     async fn send_json_response_with_headers(
         stream: &mut tokio::net::TcpStream,
         status: u16,
@@ -1535,6 +2035,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -1588,6 +2090,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let modules = Arc::new(StdMutex::new(vec!["test_module".to_string()]));
         let metrics = Arc::new(StdMutex::new(SharedMetrics {
@@ -1651,6 +2155,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let modules = Arc::new(StdMutex::new(vec![
             "mod_a".to_string(),
@@ -1713,6 +2219,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -1770,6 +2278,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -1823,6 +2333,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -1876,6 +2388,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -2017,6 +2531,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -2194,6 +2710,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -2652,6 +3170,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -2878,6 +3398,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -2940,6 +3462,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -3001,6 +3525,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -3058,6 +3584,8 @@ mod tests {
             openapi_enabled: true,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -3112,6 +3640,8 @@ mod tests {
             openapi_enabled: false,
             default_page_size: 50,
             max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
         };
         let server = ApiServer::new(
             &config,
@@ -3242,5 +3772,21 @@ mod tests {
         assert!(parsed2["has_more"].as_bool().unwrap());
         assert_eq!(parsed2["count"].as_i64().unwrap(), 4);
         assert!(parsed2["next_cursor"].is_number());
+    }
+
+    #[test]
+    fn test_required_role_batch_endpoints() {
+        assert_eq!(
+            ApiServer::required_role(&HttpMethod::Post, "/api/v1/events/batch/delete"),
+            Some(ApiRole::Admin)
+        );
+        assert_eq!(
+            ApiServer::required_role(&HttpMethod::Post, "/api/v1/events/batch/export"),
+            Some(ApiRole::ReadOnly)
+        );
+        assert_eq!(
+            ApiServer::required_role(&HttpMethod::Post, "/api/v1/events/batch/acknowledge"),
+            Some(ApiRole::Admin)
+        );
     }
 }

--- a/src/core/event_store.rs
+++ b/src/core/event_store.rs
@@ -80,6 +80,31 @@ fn init_database(conn: &Connection) -> Result<(), AppError> {
         message: format!("テーブル作成に失敗: {}", e),
     })?;
 
+    let has_acknowledged = {
+        let mut stmt = conn
+            .prepare("PRAGMA table_info(security_events)")
+            .map_err(|e| AppError::EventStore {
+                message: format!("PRAGMA table_info に失敗: {}", e),
+            })?;
+        let columns: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|e| AppError::EventStore {
+                message: format!("カラム情報の取得に失敗: {}", e),
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+        columns.iter().any(|c| c == "acknowledged")
+    };
+
+    if !has_acknowledged {
+        conn.execute_batch(
+            "ALTER TABLE security_events ADD COLUMN acknowledged INTEGER NOT NULL DEFAULT 0;",
+        )
+        .map_err(|e| AppError::EventStore {
+            message: format!("acknowledged カラムの追加に失敗: {}", e),
+        })?;
+    }
+
     Ok(())
 }
 
@@ -509,6 +534,8 @@ pub struct EventRecord {
     pub message: String,
     /// 追加情報
     pub details: Option<String>,
+    /// 確認済みフラグ
+    pub acknowledged: bool,
 }
 
 /// イベント統計結果
@@ -737,7 +764,7 @@ pub fn open_readonly(db_path: &str) -> Result<Connection, AppError> {
 /// 指定された条件でイベントを検索する
 pub fn query_events(conn: &Connection, query: &EventQuery) -> Result<Vec<EventRecord>, AppError> {
     let mut sql = String::from(
-        "SELECT id, timestamp, severity, source_module, event_type, message, details \
+        "SELECT id, timestamp, severity, source_module, event_type, message, details, acknowledged \
          FROM security_events WHERE 1=1",
     );
     let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
@@ -794,6 +821,7 @@ pub fn query_events(conn: &Connection, query: &EventQuery) -> Result<Vec<EventRe
                 event_type: row.get(4)?,
                 message: row.get(5)?,
                 details: row.get(6)?,
+                acknowledged: row.get::<_, i64>(7).map(|v| v != 0).unwrap_or(false),
             })
         })
         .map_err(|e| AppError::EventStore {
@@ -963,6 +991,208 @@ pub fn parse_datetime(s: &str) -> Result<i64, String> {
     let timestamp = total_days * 86400 + (hour as i64) * 3600 + (min as i64) * 60 + (sec as i64);
 
     Ok(timestamp)
+}
+
+/// バッチ削除フィルタ
+pub struct BatchDeleteFilter {
+    /// 重要度フィルタ
+    pub severity: Option<String>,
+    /// ソースモジュール名フィルタ
+    pub source_module: Option<String>,
+    /// 開始タイムスタンプ（UNIX 秒、以上）
+    pub since: Option<i64>,
+    /// 終了タイムスタンプ（UNIX 秒、以下）
+    pub until: Option<i64>,
+}
+
+/// ID 指定でイベントを一括削除する
+pub fn batch_delete_by_ids(conn: &Connection, ids: &[i64]) -> Result<u64, AppError> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::EventStore {
+            message: format!("トランザクション開始に失敗: {}", e),
+        })?;
+    let mut total = 0u64;
+    for chunk in ids.chunks(999) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("DELETE FROM security_events WHERE id IN ({})", placeholders);
+        let params: Vec<&dyn rusqlite::types::ToSql> = chunk
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+        let deleted = tx
+            .execute(&sql, params.as_slice())
+            .map_err(|e| AppError::EventStore {
+                message: format!("バッチ削除に失敗: {}", e),
+            })?;
+        total += deleted as u64;
+    }
+    tx.commit().map_err(|e| AppError::EventStore {
+        message: format!("コミットに失敗: {}", e),
+    })?;
+    Ok(total)
+}
+
+/// フィルタ条件でイベントを一括削除する
+pub fn batch_delete_by_filter(
+    conn: &Connection,
+    filter: &BatchDeleteFilter,
+) -> Result<u64, AppError> {
+    let mut sql = String::from("DELETE FROM security_events WHERE 1=1");
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+
+    if let Some(severity) = &filter.severity {
+        sql.push_str(&format!(" AND severity = ?{}", idx));
+        param_values.push(Box::new(severity.to_uppercase()));
+        idx += 1;
+    }
+    if let Some(module) = &filter.source_module {
+        sql.push_str(&format!(" AND source_module = ?{}", idx));
+        param_values.push(Box::new(module.clone()));
+        idx += 1;
+    }
+    if let Some(since) = filter.since {
+        sql.push_str(&format!(" AND timestamp >= ?{}", idx));
+        param_values.push(Box::new(since));
+        idx += 1;
+    }
+    if let Some(until) = filter.until {
+        sql.push_str(&format!(" AND timestamp <= ?{}", idx));
+        param_values.push(Box::new(until));
+        let _ = idx;
+    }
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        param_values.iter().map(|p| p.as_ref()).collect();
+
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::EventStore {
+            message: format!("トランザクション開始に失敗: {}", e),
+        })?;
+    let deleted = tx
+        .execute(&sql, param_refs.as_slice())
+        .map_err(|e| AppError::EventStore {
+            message: format!("フィルタ削除に失敗: {}", e),
+        })?;
+    tx.commit().map_err(|e| AppError::EventStore {
+        message: format!("コミットに失敗: {}", e),
+    })?;
+    Ok(deleted as u64)
+}
+
+/// ID 指定でイベントを一括確認済みにする
+pub fn batch_acknowledge(conn: &Connection, ids: &[i64]) -> Result<u64, AppError> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|e| AppError::EventStore {
+            message: format!("トランザクション開始に失敗: {}", e),
+        })?;
+    let mut total = 0u64;
+    for chunk in ids.chunks(999) {
+        let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!(
+            "UPDATE security_events SET acknowledged = 1 WHERE id IN ({})",
+            placeholders
+        );
+        let params: Vec<&dyn rusqlite::types::ToSql> = chunk
+            .iter()
+            .map(|id| id as &dyn rusqlite::types::ToSql)
+            .collect();
+        let updated = tx
+            .execute(&sql, params.as_slice())
+            .map_err(|e| AppError::EventStore {
+                message: format!("バッチ確認に失敗: {}", e),
+            })?;
+        total += updated as u64;
+    }
+    tx.commit().map_err(|e| AppError::EventStore {
+        message: format!("コミットに失敗: {}", e),
+    })?;
+    Ok(total)
+}
+
+/// エクスポート用クエリ（acknowledged フィールド含む、件数上限あり）
+pub fn query_events_for_export(
+    conn: &Connection,
+    query: &EventQuery,
+    max_size: u32,
+) -> Result<Vec<EventRecord>, AppError> {
+    let mut sql = String::from(
+        "SELECT id, timestamp, severity, source_module, event_type, message, details, acknowledged \
+         FROM security_events WHERE 1=1",
+    );
+    let mut param_values: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+    let mut idx = 1;
+
+    if let Some(cursor) = query.cursor {
+        sql.push_str(&format!(" AND id < ?{}", idx));
+        param_values.push(Box::new(cursor));
+        idx += 1;
+    }
+    if let Some(module) = &query.module {
+        sql.push_str(&format!(" AND source_module = ?{}", idx));
+        param_values.push(Box::new(module.clone()));
+        idx += 1;
+    }
+    if let Some(severity) = &query.severity {
+        sql.push_str(&format!(" AND severity = ?{}", idx));
+        param_values.push(Box::new(severity.to_uppercase()));
+        idx += 1;
+    }
+    if let Some(since) = query.since {
+        sql.push_str(&format!(" AND timestamp >= ?{}", idx));
+        param_values.push(Box::new(since));
+        idx += 1;
+    }
+    if let Some(until) = query.until {
+        sql.push_str(&format!(" AND timestamp <= ?{}", idx));
+        param_values.push(Box::new(until));
+        idx += 1;
+    }
+    if let Some(event_type) = &query.event_type {
+        sql.push_str(&format!(" AND event_type = ?{}", idx));
+        param_values.push(Box::new(event_type.clone()));
+        idx += 1;
+    }
+
+    let effective_limit = query.limit.min(max_size);
+    sql.push_str(&format!(" ORDER BY timestamp DESC LIMIT ?{}", idx));
+    param_values.push(Box::new(effective_limit));
+
+    let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+        param_values.iter().map(|p| p.as_ref()).collect();
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| AppError::EventStore {
+        message: format!("クエリの準備に失敗: {}", e),
+    })?;
+
+    let rows = stmt
+        .query_map(param_refs.as_slice(), |row| {
+            Ok(EventRecord {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                severity: row.get(2)?,
+                source_module: row.get(3)?,
+                event_type: row.get(4)?,
+                message: row.get(5)?,
+                details: row.get(6)?,
+                acknowledged: row.get::<_, i64>(7).map(|v| v != 0).unwrap_or(false),
+            })
+        })
+        .map_err(|e| AppError::EventStore {
+            message: format!("クエリの実行に失敗: {}", e),
+        })?;
+
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.map_err(|e| AppError::EventStore {
+            message: format!("行の読み取りに失敗: {}", e),
+        })?);
+    }
+
+    Ok(records)
 }
 
 #[cfg(test)]
@@ -1739,5 +1969,159 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn insert_test_events(conn: &Connection, count: usize) {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        for i in 0..count {
+            conn.execute(
+                "INSERT INTO security_events (timestamp, severity, source_module, event_type, message) VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![now - (i as i64), "INFO", "test_module", "test_event", format!("テスト {}", i)],
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn test_batch_delete_by_ids() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+        insert_test_events(&conn, 5);
+
+        let ids: Vec<i64> = conn
+            .prepare("SELECT id FROM security_events")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let deleted = batch_delete_by_ids(&conn, &ids[..3]).unwrap();
+        assert_eq!(deleted, 3);
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 2);
+    }
+
+    #[test]
+    fn test_batch_delete_by_filter() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        conn.execute(
+            "INSERT INTO security_events (timestamp, severity, source_module, event_type, message) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![now, "WARNING", "file_integrity", "test", "warning event"],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO security_events (timestamp, severity, source_module, event_type, message) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![now, "INFO", "file_integrity", "test", "info event"],
+        ).unwrap();
+        conn.execute(
+            "INSERT INTO security_events (timestamp, severity, source_module, event_type, message) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![now, "INFO", "network_monitor", "test", "other event"],
+        ).unwrap();
+
+        let filter = BatchDeleteFilter {
+            severity: Some("INFO".to_string()),
+            source_module: Some("file_integrity".to_string()),
+            since: None,
+            until: None,
+        };
+        let deleted = batch_delete_by_filter(&conn, &filter).unwrap();
+        assert_eq!(deleted, 1);
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 2);
+    }
+
+    #[test]
+    fn test_batch_acknowledge() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+        insert_test_events(&conn, 5);
+
+        let ids: Vec<i64> = conn
+            .prepare("SELECT id FROM security_events LIMIT 3")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+
+        let updated = batch_acknowledge(&conn, &ids).unwrap();
+        assert_eq!(updated, 3);
+
+        let acked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM security_events WHERE acknowledged = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(acked, 3);
+
+        let not_acked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM security_events WHERE acknowledged = 0",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(not_acked, 2);
+    }
+
+    #[test]
+    fn test_batch_delete_chunks() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+        insert_test_events(&conn, 1500);
+
+        let ids: Vec<i64> = conn
+            .prepare("SELECT id FROM security_events")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert_eq!(ids.len(), 1500);
+
+        let deleted = batch_delete_by_ids(&conn, &ids).unwrap();
+        assert_eq!(deleted, 1500);
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM security_events", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn test_acknowledged_column_migration() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_database(&conn).unwrap();
+
+        let has_col = {
+            let mut stmt = conn.prepare("PRAGMA table_info(security_events)").unwrap();
+            let columns: Vec<String> = stmt
+                .query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .filter_map(|r| r.ok())
+                .collect();
+            columns.iter().any(|c| c == "acknowledged")
+        };
+        assert!(has_col);
+
+        // Running init_database again should be idempotent
+        init_database(&conn).unwrap();
     }
 }

--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -30,6 +30,9 @@ pub fn generate_openapi_schema() -> Value {
             "/api/v1/reload": reload_path(),
             "/api/v1/events/stream": events_stream_path(),
             "/api/v1/openapi.json": openapi_path(),
+            "/api/v1/events/batch/delete": batch_delete_path(),
+            "/api/v1/events/batch/export": batch_export_path(),
+            "/api/v1/events/batch/acknowledge": batch_acknowledge_path(),
         },
         "components": {
             "securitySchemes": {
@@ -348,6 +351,129 @@ fn openapi_path() -> Value {
     })
 }
 
+fn batch_delete_path() -> Value {
+    json!({
+        "post": {
+            "summary": "イベント一括削除",
+            "description": "ID 指定またはフィルタ条件でイベントを一括削除する。admin ロールが必要。",
+            "operationId": "postBatchDelete",
+            "tags": ["events"],
+            "security": [{"BearerAuth": []}],
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/BatchDeleteRequest" }
+                    }
+                }
+            },
+            "responses": {
+                "200": {
+                    "description": "削除成功",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/BatchDeleteResponse" }
+                        }
+                    }
+                },
+                "400": { "$ref": "#/components/schemas/ErrorResponse" },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" },
+                "503": {
+                    "description": "イベントストアが無効",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn batch_export_path() -> Value {
+    json!({
+        "post": {
+            "summary": "イベント一括エクスポート",
+            "description": "フィルタ条件でイベントを一括エクスポートする。read_only ロール以上が必要。",
+            "operationId": "postBatchExport",
+            "tags": ["events"],
+            "security": [{"BearerAuth": []}],
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/BatchExportRequest" }
+                    }
+                }
+            },
+            "responses": {
+                "200": {
+                    "description": "エクスポート成功",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/BatchExportResponse" }
+                        }
+                    }
+                },
+                "400": { "$ref": "#/components/schemas/ErrorResponse" },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" },
+                "503": {
+                    "description": "イベントストアが無効",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn batch_acknowledge_path() -> Value {
+    json!({
+        "post": {
+            "summary": "イベント一括確認済みマーク",
+            "description": "ID 指定でイベントを一括確認済みにする。admin ロールが必要。",
+            "operationId": "postBatchAcknowledge",
+            "tags": ["events"],
+            "security": [{"BearerAuth": []}],
+            "requestBody": {
+                "required": true,
+                "content": {
+                    "application/json": {
+                        "schema": { "$ref": "#/components/schemas/BatchAcknowledgeRequest" }
+                    }
+                }
+            },
+            "responses": {
+                "200": {
+                    "description": "確認済みマーク成功",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/BatchAcknowledgeResponse" }
+                        }
+                    }
+                },
+                "400": { "$ref": "#/components/schemas/ErrorResponse" },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "403": { "$ref": "#/components/schemas/ErrorResponse" },
+                "503": {
+                    "description": "イベントストアが無効",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
 fn component_schemas() -> Value {
     json!({
         "ErrorResponse": {
@@ -500,6 +626,10 @@ fn component_schemas() -> Value {
                 "details": {
                     "type": ["string", "null"],
                     "description": "詳細情報"
+                },
+                "acknowledged": {
+                    "type": "boolean",
+                    "description": "確認済みフラグ"
                 }
             },
             "required": ["id", "timestamp", "severity", "source_module", "event_type", "message"]
@@ -535,6 +665,101 @@ fn component_schemas() -> Value {
                 }
             },
             "required": ["event_type", "severity", "source_module", "timestamp", "message"]
+        },
+        "BatchDeleteRequest": {
+            "type": "object",
+            "description": "バッチ削除リクエスト。ids または filter のいずれかを指定する",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": { "type": "integer", "format": "int64" },
+                    "description": "削除対象のイベント ID 一覧"
+                },
+                "filter": { "$ref": "#/components/schemas/BatchDeleteFilter" }
+            }
+        },
+        "BatchDeleteFilter": {
+            "type": "object",
+            "description": "バッチ削除フィルタ条件",
+            "properties": {
+                "severity": {
+                    "type": "string",
+                    "enum": ["info", "warning", "critical"],
+                    "description": "Severity でフィルタリング"
+                },
+                "module": {
+                    "type": "string",
+                    "description": "ソースモジュール名でフィルタリング"
+                },
+                "since": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "開始日時（ISO 8601 形式）"
+                },
+                "until": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "終了日時（ISO 8601 形式）"
+                }
+            }
+        },
+        "BatchDeleteResponse": {
+            "type": "object",
+            "properties": {
+                "deleted": {
+                    "type": "integer",
+                    "description": "削除された件数"
+                }
+            },
+            "required": ["deleted"]
+        },
+        "BatchExportRequest": {
+            "type": "object",
+            "description": "バッチエクスポートリクエスト",
+            "properties": {
+                "filter": { "$ref": "#/components/schemas/BatchDeleteFilter" },
+                "limit": {
+                    "type": "integer",
+                    "description": "最大取得件数（デフォルト: batch_max_size）",
+                    "minimum": 1
+                }
+            }
+        },
+        "BatchExportResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": { "$ref": "#/components/schemas/EventRecord" },
+                    "description": "エクスポートされたイベント一覧"
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "エクスポートされた件数"
+                }
+            },
+            "required": ["items", "count"]
+        },
+        "BatchAcknowledgeRequest": {
+            "type": "object",
+            "properties": {
+                "ids": {
+                    "type": "array",
+                    "items": { "type": "integer", "format": "int64" },
+                    "description": "確認済みにするイベント ID 一覧"
+                }
+            },
+            "required": ["ids"]
+        },
+        "BatchAcknowledgeResponse": {
+            "type": "object",
+            "properties": {
+                "acknowledged": {
+                    "type": "integer",
+                    "description": "確認済みにした件数"
+                }
+            },
+            "required": ["acknowledged"]
         }
     })
 }
@@ -642,6 +867,28 @@ mod tests {
         assert!(required_names.contains(&"next_cursor"));
         assert!(required_names.contains(&"has_more"));
         assert!(required_names.contains(&"count"));
+    }
+
+    #[test]
+    fn test_batch_endpoints_present() {
+        let schema = generate_openapi_schema();
+        let paths = schema["paths"].as_object().unwrap();
+        assert!(paths.contains_key("/api/v1/events/batch/delete"));
+        assert!(paths.contains_key("/api/v1/events/batch/export"));
+        assert!(paths.contains_key("/api/v1/events/batch/acknowledge"));
+    }
+
+    #[test]
+    fn test_batch_schemas_defined() {
+        let schema = generate_openapi_schema();
+        let schemas = &schema["components"]["schemas"];
+        assert!(schemas["BatchDeleteRequest"].is_object());
+        assert!(schemas["BatchDeleteFilter"].is_object());
+        assert!(schemas["BatchDeleteResponse"].is_object());
+        assert!(schemas["BatchExportRequest"].is_object());
+        assert!(schemas["BatchExportResponse"].is_object());
+        assert!(schemas["BatchAcknowledgeRequest"].is_object());
+        assert!(schemas["BatchAcknowledgeResponse"].is_object());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1104,6 +1104,7 @@ mod tests {
                 event_type: "file_modified".to_string(),
                 message: "ファイルが変更されました".to_string(),
                 details: Some("/etc/passwd".to_string()),
+                acknowledged: false,
             },
             event_store::EventRecord {
                 id: 2,
@@ -1113,6 +1114,7 @@ mod tests {
                 event_type: "brute_force_detected".to_string(),
                 message: "SSH ブルートフォース攻撃を検知".to_string(),
                 details: None,
+                acknowledged: false,
             },
         ]
     }
@@ -1224,6 +1226,7 @@ mod tests {
             event_type: "test".to_string(),
             message: "カンマ,を含む\"メッセージ\"\n改行も".to_string(),
             details: Some("details with, commas".to_string()),
+            acknowledged: false,
         }];
         let mut buf = Vec::new();
         export_csv(&records, &mut buf).unwrap();


### PR DESCRIPTION
## 概要

REST API にバッチ操作用のエンドポイントを追加する。複数イベントの一括削除・一括エクスポート・一括確認済みマークを効率的に行えるようにする。

Closes #259

## 変更内容

- **POST /api/v1/events/batch/delete** — ID リストまたはフィルタ条件による一括削除（Admin ロール）
- **POST /api/v1/events/batch/export** — フィルタ条件による一括エクスポート（ReadOnly ロール以上）
- **POST /api/v1/events/batch/acknowledge** — ID リストによる一括確認済みマーク（Admin ロール）
- `security_events` テーブルに `acknowledged` カラムを追加（自動マイグレーション）
- `ApiConfig` に `batch_max_size`（デフォルト 1000）、`max_request_body_size`（デフォルト 1MB）を追加
- OpenAPI スキーマに 3 エンドポイント + 7 スキーマ定義を追加
- SQLite パラメータ上限（999）を考慮したチャンク処理
- トランザクションによる all-or-nothing 保証

## テスト

- [x] `cargo test` — 全 38 テスト合格
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット問題なし
- [x] `cargo build --release` — ビルド成功
- [x] EventStore バッチ操作のユニットテスト（5 件追加）
- [x] OpenAPI スキーマのユニットテスト（2 件追加）
- [x] API required_role のユニットテスト（1 件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)