### PR TITLE
feat: セキュリティスコアリング機能を追加 (#261)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.27.0"
+version = "1.29.0"
 dependencies = [
  "clap",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.28.0"
+version = "1.29.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1397,6 +1397,19 @@ enabled = false
 # field = "source_module"
 # pattern = "file_integrity"
 
+[scoring]
+# セキュリティスコアリングの有効/無効
+# 有効にするとイベントの Severity を基にシステム全体のセキュリティ状態を
+# 0〜100 のスコアで評価し、カテゴリ別（network, filesystem, process, auth, kernel, system）に
+# グレード（A〜F）を付与する。REST API の /api/v1/score で取得可能
+enabled = false
+# スコア更新インターバル（秒）
+interval_secs = 300
+# カテゴリ別重み付け（デフォルト: 1.0）
+# [scoring.category_weights]
+# network = 1.5
+# auth = 2.0
+
 [modules.dynamic_library_monitor]
 # 動的ライブラリインジェクション検知モジュール — /proc/[pid]/maps のベースライン差分で不審な .so ロードを検知
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,6 +73,10 @@ pub struct AppConfig {
     /// REST API サーバー設定
     #[serde(default)]
     pub api: ApiConfig,
+
+    /// セキュリティスコアリング設定
+    #[serde(default)]
+    pub scoring: ScoringConfig,
 }
 
 /// デーモン動作設定
@@ -6232,6 +6236,38 @@ impl Clone for ApiConfig {
             max_page_size: self.max_page_size,
             batch_max_size: self.batch_max_size,
             max_request_body_size: self.max_request_body_size,
+        }
+    }
+}
+
+/// セキュリティスコアリング設定
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ScoringConfig {
+    /// スコアリングの有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// スコア更新インターバル（秒）
+    #[serde(default = "ScoringConfig::default_interval_secs")]
+    pub interval_secs: u64,
+
+    /// カテゴリ別の重み付け（デフォルト: 各1.0）
+    #[serde(default)]
+    pub category_weights: HashMap<String, f64>,
+}
+
+impl ScoringConfig {
+    fn default_interval_secs() -> u64 {
+        300
+    }
+}
+
+impl Default for ScoringConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interval_secs: Self::default_interval_secs(),
+            category_weights: HashMap::new(),
         }
     }
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -10,6 +10,7 @@ use crate::config::{
 use crate::core::event::{SecurityEvent, Severity};
 use crate::core::metrics::SharedMetrics;
 use crate::core::openapi;
+use crate::core::scoring::SharedSecurityScore;
 use crate::core::status::{MetricsSummary, StatusResponse};
 use futures_util::{SinkExt, StreamExt};
 use sha2::{Digest, Sha256};
@@ -192,6 +193,7 @@ pub struct ApiServer {
     max_page_size: u32,
     batch_max_size: u32,
     max_request_body_size: usize,
+    shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>>,
 }
 
 impl ApiServer {
@@ -206,6 +208,7 @@ impl ApiServer {
         event_store_db_path: Option<String>,
         reload_sender: mpsc::Sender<()>,
         event_bus: Option<broadcast::Sender<SecurityEvent>>,
+        shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>>,
     ) -> Self {
         let rate_limiter = if config.rate_limit.enabled {
             Some(RateLimiter::new(&config.rate_limit))
@@ -234,6 +237,7 @@ impl ApiServer {
             max_page_size: config.max_page_size,
             batch_max_size: config.batch_max_size,
             max_request_body_size: config.max_request_body_size,
+            shared_scoring,
         }
     }
 
@@ -267,6 +271,7 @@ impl ApiServer {
         let max_page_size = self.max_page_size;
         let batch_max_size = self.batch_max_size;
         let max_request_body_size = self.max_request_body_size;
+        let shared_scoring = self.shared_scoring;
 
         // クリーンアップタスク
         if self.rate_limit_config.enabled {
@@ -317,12 +322,13 @@ impl ApiServer {
                                 let mps = max_page_size;
                                 let bms = batch_max_size;
                                 let mrbs = max_request_body_size;
+                                let scoring = shared_scoring.clone();
                                 tokio::spawn(async move {
                                     if let Err(e) = Self::handle_connection(
                                         stream, &names, &metrics, &restarts,
                                         started, &db_path, &sender, &toks,
                                         client_ip, &rl, &eb, &wsc, &wsc_count, &cors,
-                                        oa_enabled, dps, mps, bms, mrbs,
+                                        oa_enabled, dps, mps, bms, mrbs, &scoring,
                                     ).await {
                                         tracing::debug!(error = %e, "API 接続の処理に失敗");
                                     }
@@ -398,7 +404,8 @@ impl ApiServer {
             (HttpMethod::Get, "/api/v1/status")
             | (HttpMethod::Get, "/api/v1/modules")
             | (HttpMethod::Get, "/api/v1/events")
-            | (HttpMethod::Get, "/api/v1/events/stream") => Some(ApiRole::ReadOnly),
+            | (HttpMethod::Get, "/api/v1/events/stream")
+            | (HttpMethod::Get, "/api/v1/score") => Some(ApiRole::ReadOnly),
             (HttpMethod::Post, "/api/v1/reload") => Some(ApiRole::Admin),
             (HttpMethod::Post, "/api/v1/events/batch/delete") => Some(ApiRole::Admin),
             (HttpMethod::Post, "/api/v1/events/batch/export") => Some(ApiRole::ReadOnly),
@@ -484,6 +491,7 @@ impl ApiServer {
         max_page_size: u32,
         batch_max_size: u32,
         max_request_body_size: usize,
+        shared_scoring: &Option<Arc<StdMutex<SharedSecurityScore>>>,
     ) -> Result<(), io::Error> {
         // 接続タイムアウト（スローロリス対策）
         let result = tokio::time::timeout(
@@ -694,6 +702,28 @@ impl ApiServer {
                         503,
                         "Service Unavailable",
                         "イベントストアが無効です",
+                        extra,
+                    )
+                    .await?;
+                }
+            },
+            (HttpMethod::Get, "/api/v1/score") => match shared_scoring {
+                Some(scoring) => {
+                    let body = if let Ok(s) = scoring.lock() {
+                        serde_json::to_string(&*s)
+                            .unwrap_or_else(|_| r#"{"error":"serialize failed"}"#.to_string())
+                    } else {
+                        r#"{"error":"lock failed"}"#.to_string()
+                    };
+                    Self::send_json_response_with_headers(&mut stream, 200, "OK", &body, extra)
+                        .await?;
+                }
+                None => {
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        "スコアリングが無効です",
                         extra,
                     )
                     .await?;
@@ -2047,6 +2077,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -2109,6 +2140,7 @@ mod tests {
             Instant::now(),
             None,
             reload_tx,
+            None,
             None,
         );
         let cancel = server.cancel_token();
@@ -2173,6 +2205,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -2230,6 +2263,7 @@ mod tests {
             Instant::now(),
             None,
             reload_tx,
+            None,
             None,
         );
         let cancel = server.cancel_token();
@@ -2290,6 +2324,7 @@ mod tests {
             None, // event_store_db_path is None
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -2345,6 +2380,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -2399,6 +2435,7 @@ mod tests {
             Instant::now(),
             None,
             reload_tx,
+            None,
             None,
         );
         let cancel = server.cancel_token();
@@ -2542,6 +2579,7 @@ mod tests {
             Instant::now(),
             None,
             reload_tx,
+            None,
             None,
         );
         let cancel = server.cancel_token();
@@ -2722,6 +2760,7 @@ mod tests {
             None,
             reload_tx,
             Some(event_tx.clone()),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -3182,6 +3221,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -3410,6 +3450,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -3474,6 +3515,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -3537,6 +3579,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -3596,6 +3639,7 @@ mod tests {
             None,
             reload_tx,
             None,
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -3651,6 +3695,7 @@ mod tests {
             Instant::now(),
             None,
             reload_tx,
+            None,
             None,
         );
         let cancel = server.cancel_token();

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -12,6 +12,7 @@ use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
 use crate::core::prometheus::PrometheusExporter;
 use crate::core::scan_state::{self, DiffKind};
+use crate::core::scoring::{ScoringRuntimeConfig, SecurityScorer, SharedSecurityScore};
 use crate::core::status::{DaemonState, StatusServer};
 use crate::core::syslog::{SyslogForwarder, SyslogRuntimeConfig};
 use crate::error::AppError;
@@ -52,6 +53,8 @@ impl Daemon {
         // ステータスサーバー用の共有状態
         let shared_module_names: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
         let mut shared_metrics: Option<Arc<StdMutex<SharedMetrics>>> = None;
+        let mut shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>> = None;
+        let mut scoring_config_sender: Option<watch::Sender<ScoringRuntimeConfig>> = None;
         let mut status_cancel_token: Option<CancellationToken> = None;
         let mut prometheus_cancel_token: Option<CancellationToken> = None;
         let mut api_cancel_token: Option<CancellationToken> = None;
@@ -105,6 +108,15 @@ impl Daemon {
                     interval_secs = self.config.metrics.interval_secs,
                     "メトリクスコレクターを起動しました"
                 );
+            }
+
+            // セキュリティスコアラーの起動
+            if self.config.scoring.enabled {
+                let (scorer, sender, shared) = SecurityScorer::new(&self.config.scoring, &bus);
+                scoring_config_sender = Some(sender);
+                shared_scoring = Some(shared);
+                scorer.spawn();
+                tracing::info!("セキュリティスコアラーを起動しました");
             }
 
             // ダイジェストコレクターの起動
@@ -389,7 +401,8 @@ impl Daemon {
                     &self.config.prometheus,
                     Arc::clone(metrics),
                     prometheus_started_at,
-                );
+                )
+                .with_scoring(shared_scoring.clone());
                 prometheus_cancel_token = Some(exporter.cancel_token());
                 match exporter.spawn() {
                     Ok(()) => {}
@@ -420,6 +433,7 @@ impl Daemon {
                 event_store_db_path,
                 reload_sender.clone(),
                 event_bus.as_ref().map(|b| b.sender()),
+                shared_scoring.clone(),
             );
             api_cancel_token = Some(api_server.cancel_token());
             match api_server.spawn() {
@@ -553,6 +567,23 @@ impl Daemon {
                                 } else {
                                     tracing::warn!(
                                         "メトリクスのインターバルリロードに失敗しました（受信側が閉じています）"
+                                    );
+                                }
+                            }
+
+                            // スコアラーのリロード
+                            if let Some(ref sender) = scoring_config_sender {
+                                let new_runtime = ScoringRuntimeConfig {
+                                    interval_secs: new_config.scoring.interval_secs,
+                                    category_weights: new_config.scoring.category_weights.clone(),
+                                };
+                                if sender.send(new_runtime).is_ok() {
+                                    tracing::info!(
+                                        "スコアラーの設定をリロードしました"
+                                    );
+                                } else {
+                                    tracing::warn!(
+                                        "スコアラーの設定リロードに失敗しました（受信側が閉じています）"
                                     );
                                 }
                             }
@@ -700,7 +731,8 @@ impl Daemon {
                                             &new_config.prometheus,
                                             Arc::clone(metrics),
                                             prometheus_started_at,
-                                        );
+                                        )
+                                        .with_scoring(shared_scoring.clone());
                                         prometheus_cancel_token = Some(exporter.cancel_token());
                                         match exporter.spawn() {
                                             Ok(()) => tracing::info!(
@@ -723,7 +755,8 @@ impl Daemon {
                                             &new_config.prometheus,
                                             Arc::clone(metrics),
                                             prometheus_started_at,
-                                        );
+                                        )
+                                        .with_scoring(shared_scoring.clone());
                                         prometheus_cancel_token = Some(exporter.cancel_token());
                                         match exporter.spawn() {
                                             Ok(()) => tracing::info!(
@@ -740,7 +773,8 @@ impl Daemon {
                                                     &self.config.prometheus,
                                                     Arc::clone(metrics),
                                                     prometheus_started_at,
-                                                );
+                                                )
+                                                .with_scoring(shared_scoring.clone());
                                                 prometheus_cancel_token =
                                                     Some(fallback.cancel_token());
                                                 match fallback.spawn() {
@@ -785,6 +819,7 @@ impl Daemon {
                                         event_store_db_path,
                                         reload_sender.clone(),
                                         event_bus.as_ref().map(|b| b.sender()),
+                                        shared_scoring.clone(),
                                     );
                                     api_cancel_token = Some(api_server.cancel_token());
                                     match api_server.spawn() {
@@ -816,6 +851,7 @@ impl Daemon {
                                         event_store_db_path,
                                         reload_sender.clone(),
                                         event_bus.as_ref().map(|b| b.sender()),
+                                        shared_scoring.clone(),
                                     );
                                     api_cancel_token = Some(api_server.cancel_token());
                                     match api_server.spawn() {
@@ -843,6 +879,7 @@ impl Daemon {
                                                 fallback_db_path,
                                                 reload_sender.clone(),
                                                 event_bus.as_ref().map(|b| b.sender()),
+                                                shared_scoring.clone(),
                                             );
                                             api_cancel_token =
                                                 Some(fallback.cancel_token());

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -15,5 +15,6 @@ pub mod openapi;
 pub mod prometheus;
 pub mod scan_diff;
 pub mod scan_state;
+pub mod scoring;
 pub mod status;
 pub mod syslog;

--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -33,6 +33,7 @@ pub fn generate_openapi_schema() -> Value {
             "/api/v1/events/batch/delete": batch_delete_path(),
             "/api/v1/events/batch/export": batch_export_path(),
             "/api/v1/events/batch/acknowledge": batch_acknowledge_path(),
+            "/api/v1/score": score_path(),
         },
         "components": {
             "securitySchemes": {
@@ -474,6 +475,37 @@ fn batch_acknowledge_path() -> Value {
     })
 }
 
+fn score_path() -> Value {
+    json!({
+        "get": {
+            "summary": "セキュリティスコア取得",
+            "description": "システム全体のセキュリティスコアとカテゴリ別評価を返す。",
+            "operationId": "getScore",
+            "tags": ["security"],
+            "security": [{"BearerAuth": []}],
+            "responses": {
+                "200": {
+                    "description": "スコア取得成功",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/SecurityScore" }
+                        }
+                    }
+                },
+                "401": { "$ref": "#/components/schemas/ErrorResponse" },
+                "503": {
+                    "description": "スコアリングが無効",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
 fn component_schemas() -> Value {
     json!({
         "ErrorResponse": {
@@ -760,6 +792,66 @@ fn component_schemas() -> Value {
                 }
             },
             "required": ["acknowledged"]
+        },
+        "SecurityScore": {
+            "type": "object",
+            "properties": {
+                "overall_score": {
+                    "type": "integer",
+                    "description": "総合セキュリティスコア（0〜100）",
+                    "minimum": 0,
+                    "maximum": 100
+                },
+                "grade": {
+                    "type": "string",
+                    "description": "グレード（A〜F）",
+                    "enum": ["A", "B", "C", "D", "F"]
+                },
+                "categories": {
+                    "type": "object",
+                    "description": "カテゴリ別スコア",
+                    "additionalProperties": { "$ref": "#/components/schemas/CategoryScore" }
+                },
+                "summary": { "$ref": "#/components/schemas/ScoreSummary" },
+                "evaluated_at": {
+                    "type": "string",
+                    "format": "date-time",
+                    "description": "評価日時（ISO 8601）"
+                }
+            },
+            "required": ["overall_score", "grade", "categories", "summary", "evaluated_at"]
+        },
+        "CategoryScore": {
+            "type": "object",
+            "properties": {
+                "score": {
+                    "type": "integer",
+                    "description": "カテゴリスコア（0〜100）",
+                    "minimum": 0,
+                    "maximum": 100
+                },
+                "grade": {
+                    "type": "string",
+                    "description": "グレード（A〜F）"
+                },
+                "issues": {
+                    "type": "integer",
+                    "description": "検知された問題数"
+                }
+            },
+            "required": ["score", "grade", "issues"]
+        },
+        "ScoreSummary": {
+            "type": "object",
+            "properties": {
+                "total_events": { "type": "integer", "description": "総イベント数" },
+                "critical": { "type": "integer", "description": "CRITICAL イベント数" },
+                "high": { "type": "integer", "description": "HIGH（WARNING）イベント数" },
+                "medium": { "type": "integer", "description": "MEDIUM イベント数（0固定）" },
+                "low": { "type": "integer", "description": "LOW イベント数（0固定）" },
+                "info": { "type": "integer", "description": "INFO イベント数" }
+            },
+            "required": ["total_events", "critical", "high", "medium", "low", "info"]
         }
     })
 }

--- a/src/core/prometheus.rs
+++ b/src/core/prometheus.rs
@@ -5,6 +5,7 @@
 
 use crate::config::PrometheusConfig;
 use crate::core::metrics::SharedMetrics;
+use crate::core::scoring::SharedSecurityScore;
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -16,6 +17,7 @@ pub struct PrometheusExporter {
     bind_address: String,
     port: u16,
     shared_metrics: Arc<StdMutex<SharedMetrics>>,
+    shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>>,
     started_at: Instant,
     cancel_token: CancellationToken,
 }
@@ -31,9 +33,16 @@ impl PrometheusExporter {
             bind_address: config.bind_address.clone(),
             port: config.port,
             shared_metrics,
+            shared_scoring: None,
             started_at,
             cancel_token: CancellationToken::new(),
         }
+    }
+
+    /// セキュリティスコアリングデータを設定する
+    pub fn with_scoring(mut self, scoring: Option<Arc<StdMutex<SharedSecurityScore>>>) -> Self {
+        self.shared_scoring = scoring;
+        self
     }
 
     /// キャンセルトークンを取得する
@@ -49,6 +58,7 @@ impl PrometheusExporter {
         let listener = TcpListener::from_std(listener)?;
 
         let shared_metrics = self.shared_metrics;
+        let shared_scoring = self.shared_scoring;
         let started_at = self.started_at;
         let cancel_token = self.cancel_token;
 
@@ -59,9 +69,10 @@ impl PrometheusExporter {
                         match result {
                             Ok((stream, _)) => {
                                 let metrics = Arc::clone(&shared_metrics);
+                                let scoring = shared_scoring.clone();
                                 let started = started_at;
                                 tokio::spawn(async move {
-                                    if let Err(e) = Self::handle_connection(stream, &metrics, started).await {
+                                    if let Err(e) = Self::handle_connection(stream, &metrics, &scoring, started).await {
                                         tracing::debug!(error = %e, "Prometheus 接続の処理に失敗");
                                     }
                                 });
@@ -89,6 +100,7 @@ impl PrometheusExporter {
     async fn handle_connection(
         mut stream: tokio::net::TcpStream,
         shared_metrics: &Arc<StdMutex<SharedMetrics>>,
+        shared_scoring: &Option<Arc<StdMutex<SharedSecurityScore>>>,
         started_at: Instant,
     ) -> Result<(), std::io::Error> {
         // 接続タイムアウト（スローロリス対策）
@@ -113,7 +125,7 @@ impl PrometheusExporter {
 
         match path {
             "/metrics" => {
-                let body = Self::format_metrics(shared_metrics, started_at);
+                let body = Self::format_metrics(shared_metrics, shared_scoring, started_at);
                 let response = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                     body.len(),
@@ -166,6 +178,7 @@ impl PrometheusExporter {
 
     fn format_metrics(
         shared_metrics: &Arc<StdMutex<SharedMetrics>>,
+        shared_scoring: &Option<Arc<StdMutex<SharedSecurityScore>>>,
         started_at: Instant,
     ) -> String {
         let mut output = String::new();
@@ -224,6 +237,39 @@ impl PrometheusExporter {
             output.push('\n');
         }
 
+        // security score
+        if let Some(scoring) = shared_scoring {
+            let score_data = match scoring.lock() {
+                Ok(s) => Some(s.clone()),
+                Err(_) => None,
+            };
+            if let Some(data) = score_data {
+                output.push_str(
+                    "# HELP zettai_security_score_overall Overall security score (0-100)\n",
+                );
+                output.push_str("# TYPE zettai_security_score_overall gauge\n");
+                output.push_str(&format!(
+                    "zettai_security_score_overall {}\n",
+                    data.overall_score
+                ));
+                output.push('\n');
+
+                if !data.categories.is_empty() {
+                    output.push_str("# HELP zettai_security_score_category Security score by category (0-100)\n");
+                    output.push_str("# TYPE zettai_security_score_category gauge\n");
+                    let mut cats: Vec<_> = data.categories.iter().collect();
+                    cats.sort_by_key(|(k, _)| (*k).clone());
+                    for (category, cat_score) in cats {
+                        output.push_str(&format!(
+                            "zettai_security_score_category{{category=\"{}\"}} {}\n",
+                            category, cat_score.score
+                        ));
+                    }
+                    output.push('\n');
+                }
+            }
+        }
+
         output
     }
 }
@@ -266,7 +312,7 @@ mod tests {
     fn test_format_metrics_default() {
         let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
         let started_at = Instant::now();
-        let output = PrometheusExporter::format_metrics(&shared, started_at);
+        let output = PrometheusExporter::format_metrics(&shared, &None, started_at);
 
         assert!(output.contains("# HELP zettai_uptime_seconds"));
         assert!(output.contains("# TYPE zettai_uptime_seconds gauge"));
@@ -294,7 +340,7 @@ mod tests {
             module_counts,
         }));
         let started_at = Instant::now();
-        let output = PrometheusExporter::format_metrics(&shared, started_at);
+        let output = PrometheusExporter::format_metrics(&shared, &None, started_at);
 
         assert!(output.contains("zettai_events_total 23"));
         assert!(output.contains("zettai_events_by_severity_total{severity=\"info\"} 10"));
@@ -318,7 +364,7 @@ mod tests {
             module_counts,
         }));
         let started_at = Instant::now();
-        let output = PrometheusExporter::format_metrics(&shared, started_at);
+        let output = PrometheusExporter::format_metrics(&shared, &None, started_at);
 
         // a_module が z_module より前に出力される
         let a_pos = output.find("a_module").unwrap();
@@ -443,8 +489,11 @@ mod tests {
         let shared = Arc::new(StdMutex::new(SharedMetrics::default()));
         let exporter = PrometheusExporter::new(&config, shared, past);
 
-        let output =
-            PrometheusExporter::format_metrics(&exporter.shared_metrics, exporter.started_at);
+        let output = PrometheusExporter::format_metrics(
+            &exporter.shared_metrics,
+            &None,
+            exporter.started_at,
+        );
         assert!(output.contains("zettai_uptime_seconds"));
         let uptime = parse_uptime_from_metrics(&output);
         assert!(uptime >= 5.0, "uptime should be >= 5.0, got {uptime}");

--- a/src/core/scoring.rs
+++ b/src/core/scoring.rs
@@ -1,0 +1,546 @@
+//! セキュリティスコアリング
+
+use crate::config::ScoringConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+use tokio::sync::{broadcast, watch};
+
+/// 外部から参照可能なセキュリティスコアデータ
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SharedSecurityScore {
+    /// 総合スコア（0〜100）
+    pub overall_score: u32,
+    /// グレード（A〜F）
+    pub grade: String,
+    /// カテゴリ別スコア
+    pub categories: HashMap<String, CategoryScore>,
+    /// サマリー
+    pub summary: ScoreSummary,
+    /// 評価日時（ISO 8601）
+    pub evaluated_at: String,
+}
+
+/// カテゴリ別スコア
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct CategoryScore {
+    /// スコア（0〜100）
+    pub score: u32,
+    /// グレード（A〜F）
+    pub grade: String,
+    /// 検知された問題数
+    pub issues: u32,
+}
+
+/// スコアサマリー
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ScoreSummary {
+    /// 総イベント数
+    pub total_events: u64,
+    /// CRITICAL イベント数
+    pub critical: u64,
+    /// WARNING イベント数（high として扱う）
+    pub high: u64,
+    /// 未使用（API 互換のため 0 固定）
+    pub medium: u64,
+    /// 未使用（0 固定）
+    pub low: u64,
+    /// INFO イベント数
+    pub info: u64,
+}
+
+/// スコアリングランタイム設定（ホットリロード用）
+#[derive(Debug, Clone)]
+pub struct ScoringRuntimeConfig {
+    /// スコア更新インターバル（秒）
+    pub interval_secs: u64,
+    /// カテゴリ別重み付け
+    pub category_weights: HashMap<String, f64>,
+}
+
+/// セキュリティスコアラー
+pub struct SecurityScorer {
+    receiver: broadcast::Receiver<SecurityEvent>,
+    interval: Duration,
+    config_receiver: watch::Receiver<ScoringRuntimeConfig>,
+    shared_score: Arc<StdMutex<SharedSecurityScore>>,
+    category_weights: HashMap<String, f64>,
+}
+
+impl SecurityScorer {
+    /// 設定とイベントバスから SecurityScorer を構築する
+    pub fn new(
+        config: &ScoringConfig,
+        event_bus: &EventBus,
+    ) -> (
+        Self,
+        watch::Sender<ScoringRuntimeConfig>,
+        Arc<StdMutex<SharedSecurityScore>>,
+    ) {
+        let interval_secs = config.interval_secs;
+        let runtime_config = ScoringRuntimeConfig {
+            interval_secs,
+            category_weights: config.category_weights.clone(),
+        };
+        let (config_sender, config_receiver) = watch::channel(runtime_config);
+        let shared_score = Arc::new(StdMutex::new(SharedSecurityScore::default()));
+        (
+            Self {
+                receiver: event_bus.subscribe(),
+                interval: Duration::from_secs(interval_secs),
+                config_receiver,
+                shared_score: Arc::clone(&shared_score),
+                category_weights: config.category_weights.clone(),
+            },
+            config_sender,
+            shared_score,
+        )
+    }
+
+    /// 非同期タスクとしてスコアラーを起動する
+    pub fn spawn(self) {
+        let shared_score = self.shared_score;
+        let category_weights = self.category_weights;
+        tokio::spawn(async move {
+            Self::run_loop(
+                self.receiver,
+                self.interval,
+                self.config_receiver,
+                shared_score,
+                category_weights,
+            )
+            .await;
+        });
+    }
+
+    async fn run_loop(
+        mut receiver: broadcast::Receiver<SecurityEvent>,
+        interval: Duration,
+        mut config_receiver: watch::Receiver<ScoringRuntimeConfig>,
+        shared_score: Arc<StdMutex<SharedSecurityScore>>,
+        mut category_weights: HashMap<String, f64>,
+    ) {
+        let mut category_critical: HashMap<String, u64> = HashMap::new();
+        let mut category_warning: HashMap<String, u64> = HashMap::new();
+        let mut total_events: u64 = 0;
+        let mut critical_count: u64 = 0;
+        let mut warning_count: u64 = 0;
+        let mut info_count: u64 = 0;
+
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await;
+
+        loop {
+            tokio::select! {
+                result = receiver.recv() => {
+                    match result {
+                        Ok(event) => {
+                            total_events += 1;
+                            let category = categorize_module(&event.source_module).to_string();
+                            match event.severity {
+                                Severity::Critical => {
+                                    critical_count += 1;
+                                    *category_critical.entry(category).or_insert(0) += 1;
+                                }
+                                Severity::Warning => {
+                                    warning_count += 1;
+                                    *category_warning.entry(category).or_insert(0) += 1;
+                                }
+                                Severity::Info => {
+                                    info_count += 1;
+                                }
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            tracing::warn!(
+                                skipped = n,
+                                "スコアラー: {} 件のイベントをスキップ（遅延）",
+                                n
+                            );
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::info!("イベントバスが閉じられました。スコアラーを終了します");
+                            break;
+                        }
+                    }
+                }
+                _ = ticker.tick() => {
+                    update_shared_score(
+                        &shared_score,
+                        &category_critical,
+                        &category_warning,
+                        &category_weights,
+                        total_events,
+                        critical_count,
+                        warning_count,
+                        info_count,
+                    );
+                }
+                result = config_receiver.changed() => {
+                    match result {
+                        Ok(()) => {
+                            let new_config = config_receiver.borrow_and_update().clone();
+                            let new_interval = Duration::from_secs(new_config.interval_secs);
+                            tracing::info!(
+                                old_interval_secs = interval.as_secs(),
+                                new_interval_secs = new_config.interval_secs,
+                                "スコアラー: 設定をリロードしました"
+                            );
+                            category_weights = new_config.category_weights;
+                            ticker = tokio::time::interval(new_interval);
+                            ticker.tick().await;
+                        }
+                        Err(_) => {
+                            tracing::info!("設定チャネルが閉じられました。スコアラーを終了します");
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn update_shared_score(
+    shared_score: &Arc<StdMutex<SharedSecurityScore>>,
+    category_critical: &HashMap<String, u64>,
+    category_warning: &HashMap<String, u64>,
+    category_weights: &HashMap<String, f64>,
+    total_events: u64,
+    critical_count: u64,
+    warning_count: u64,
+    info_count: u64,
+) {
+    let all_categories = [
+        "network",
+        "filesystem",
+        "process",
+        "auth",
+        "kernel",
+        "system",
+    ];
+
+    let mut categories = HashMap::new();
+    let mut weighted_sum: f64 = 0.0;
+    let mut weight_total: f64 = 0.0;
+
+    for &cat in &all_categories {
+        let cat_critical = category_critical.get(cat).copied().unwrap_or(0);
+        let cat_warning = category_warning.get(cat).copied().unwrap_or(0);
+        let score = calculate_score(cat_critical, cat_warning);
+        let grade = grade_from_score(score).to_string();
+        let issues = (cat_critical + cat_warning) as u32;
+
+        let weight = category_weights.get(cat).copied().unwrap_or(1.0);
+        weighted_sum += score as f64 * weight;
+        weight_total += weight;
+
+        categories.insert(
+            cat.to_string(),
+            CategoryScore {
+                score,
+                grade,
+                issues,
+            },
+        );
+    }
+
+    let overall_score = if weight_total > 0.0 {
+        (weighted_sum / weight_total).round() as u32
+    } else {
+        100
+    };
+    let overall_score = overall_score.min(100);
+    let grade = grade_from_score(overall_score).to_string();
+
+    let now = chrono_now_iso8601();
+
+    if let Ok(mut s) = shared_score.lock() {
+        s.overall_score = overall_score;
+        s.grade = grade;
+        s.categories = categories;
+        s.summary = ScoreSummary {
+            total_events,
+            critical: critical_count,
+            high: warning_count,
+            medium: 0,
+            low: 0,
+            info: info_count,
+        };
+        s.evaluated_at = now;
+    }
+}
+
+fn calculate_score(critical_count: u64, warning_count: u64) -> u32 {
+    let penalty = (critical_count.min(2) * 20 + warning_count.min(3) * 10) as u32;
+    100u32.saturating_sub(penalty)
+}
+
+fn grade_from_score(score: u32) -> &'static str {
+    match score {
+        90..=100 => "A",
+        75..=89 => "B",
+        60..=74 => "C",
+        40..=59 => "D",
+        _ => "F",
+    }
+}
+
+fn categorize_module(module_name: &str) -> &'static str {
+    match module_name {
+        "network_monitor"
+        | "network_interface_monitor"
+        | "network_traffic_monitor"
+        | "listening_port_monitor"
+        | "dns_monitor"
+        | "dns_query_monitor"
+        | "ssh_brute_force"
+        | "firewall_monitor"
+        | "proc_net_monitor"
+        | "backdoor_detector"
+        | "unix_socket_monitor"
+        | "abstract_socket_monitor" => "network",
+
+        "file_integrity" | "inotify_monitor" | "log_tamper" | "xattr_monitor" | "mount_monitor"
+        | "tmp_exec_monitor" | "shm_monitor" | "suid_sgid_monitor" | "honeypot_monitor" => {
+            "filesystem"
+        }
+
+        "process_monitor"
+        | "process_tree_monitor"
+        | "process_exec_monitor"
+        | "process_cgroup_monitor"
+        | "process_cmdline_monitor"
+        | "hidden_process_monitor"
+        | "privilege_escalation_monitor"
+        | "ptrace_monitor"
+        | "proc_maps_monitor"
+        | "proc_environ_monitor"
+        | "fd_monitor"
+        | "fileless_exec_monitor"
+        | "dynamic_library_monitor" => "process",
+
+        "user_account"
+        | "group_monitor"
+        | "login_session_monitor"
+        | "ssh_key_monitor"
+        | "sshd_config_monitor"
+        | "sudoers_monitor"
+        | "pam_monitor"
+        | "security_files_monitor" => "auth",
+
+        "kernel_module"
+        | "kernel_params"
+        | "kernel_cmdline_monitor"
+        | "kallsyms_monitor"
+        | "ebpf_monitor"
+        | "livepatch_monitor"
+        | "seccomp_monitor"
+        | "capabilities_monitor"
+        | "mac_monitor"
+        | "initramfs_monitor"
+        | "bootloader_monitor"
+        | "cgroup_monitor" => "kernel",
+
+        _ => "system",
+    }
+}
+
+fn chrono_now_iso8601() -> String {
+    let now = std::time::SystemTime::now();
+    let duration = now
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    let days = secs / 86400;
+    let day_secs = secs % 86400;
+    let hours = day_secs / 3600;
+    let minutes = (day_secs % 3600) / 60;
+    let seconds = day_secs % 60;
+
+    // Simple date calculation from epoch days
+    let mut y = 1970i64;
+    let mut remaining_days = days as i64;
+
+    loop {
+        let year_days = if is_leap_year(y) { 366 } else { 365 };
+        if remaining_days < year_days {
+            break;
+        }
+        remaining_days -= year_days;
+        y += 1;
+    }
+
+    let month_days: [i64; 12] = if is_leap_year(y) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+
+    let mut m = 0;
+    for (i, &md) in month_days.iter().enumerate() {
+        if remaining_days < md {
+            m = i;
+            break;
+        }
+        remaining_days -= md;
+    }
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m + 1,
+        remaining_days + 1,
+        hours,
+        minutes,
+        seconds
+    )
+}
+
+fn is_leap_year(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_score() {
+        assert_eq!(calculate_score(0, 0), 100);
+        assert_eq!(calculate_score(1, 0), 80);
+        assert_eq!(calculate_score(2, 0), 60);
+        assert_eq!(calculate_score(0, 1), 90);
+        assert_eq!(calculate_score(0, 3), 70);
+        assert_eq!(calculate_score(2, 3), 30);
+        // Capped at min(2) and min(3)
+        assert_eq!(calculate_score(5, 5), 30);
+        assert_eq!(calculate_score(10, 10), 30);
+    }
+
+    #[test]
+    fn test_grade_from_score() {
+        assert_eq!(grade_from_score(100), "A");
+        assert_eq!(grade_from_score(95), "A");
+        assert_eq!(grade_from_score(90), "A");
+        assert_eq!(grade_from_score(89), "B");
+        assert_eq!(grade_from_score(75), "B");
+        assert_eq!(grade_from_score(74), "C");
+        assert_eq!(grade_from_score(60), "C");
+        assert_eq!(grade_from_score(59), "D");
+        assert_eq!(grade_from_score(40), "D");
+        assert_eq!(grade_from_score(39), "F");
+        assert_eq!(grade_from_score(0), "F");
+    }
+
+    #[test]
+    fn test_categorize_module() {
+        assert_eq!(categorize_module("network_monitor"), "network");
+        assert_eq!(categorize_module("ssh_brute_force"), "network");
+        assert_eq!(categorize_module("file_integrity"), "filesystem");
+        assert_eq!(categorize_module("inotify_monitor"), "filesystem");
+        assert_eq!(categorize_module("process_monitor"), "process");
+        assert_eq!(categorize_module("ptrace_monitor"), "process");
+        assert_eq!(categorize_module("user_account"), "auth");
+        assert_eq!(categorize_module("pam_monitor"), "auth");
+        assert_eq!(categorize_module("kernel_module"), "kernel");
+        assert_eq!(categorize_module("ebpf_monitor"), "kernel");
+        assert_eq!(categorize_module("systemd_service"), "system");
+        assert_eq!(categorize_module("cron_monitor"), "system");
+        assert_eq!(categorize_module("unknown_module"), "system");
+    }
+
+    #[test]
+    fn test_security_scorer_new() {
+        let config = ScoringConfig::default();
+        let bus = EventBus::new(16);
+        let (scorer, _sender, _shared) = SecurityScorer::new(&config, &bus);
+        assert_eq!(scorer.interval, Duration::from_secs(300));
+    }
+
+    #[tokio::test]
+    async fn test_security_scorer_receives_events() {
+        let bus = EventBus::new(16);
+        let config = ScoringConfig {
+            enabled: true,
+            interval_secs: 1,
+            category_weights: HashMap::new(),
+        };
+        let (scorer, _sender, shared) = SecurityScorer::new(&config, &bus);
+        scorer.spawn();
+
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Critical,
+            "network_monitor",
+            "テストイベント",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Warning,
+            "file_integrity",
+            "テストイベント",
+        ));
+        bus.publish(SecurityEvent::new(
+            "test_event",
+            Severity::Info,
+            "process_monitor",
+            "テストイベント",
+        ));
+
+        // イベント処理とスコア更新を待つ
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        // ticker が発火するまで待つ
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let s = shared.lock().unwrap();
+        assert!(s.overall_score <= 100);
+        assert!(!s.grade.is_empty());
+        assert_eq!(s.summary.critical, 1);
+        assert_eq!(s.summary.high, 1);
+        assert_eq!(s.summary.info, 1);
+        assert_eq!(s.summary.total_events, 3);
+    }
+
+    #[test]
+    fn test_shared_security_score_default() {
+        let score = SharedSecurityScore::default();
+        assert_eq!(score.overall_score, 0);
+        assert_eq!(score.grade, "");
+        assert!(score.categories.is_empty());
+        assert_eq!(score.summary.total_events, 0);
+        assert_eq!(score.summary.critical, 0);
+        assert_eq!(score.summary.high, 0);
+        assert_eq!(score.summary.medium, 0);
+        assert_eq!(score.summary.low, 0);
+        assert_eq!(score.summary.info, 0);
+        assert_eq!(score.evaluated_at, "");
+    }
+
+    #[test]
+    fn test_shared_security_score_serialize() {
+        let mut score = SharedSecurityScore::default();
+        score.overall_score = 85;
+        score.grade = "B".to_string();
+        score.summary.total_events = 10;
+        score.summary.critical = 1;
+        score.summary.high = 2;
+
+        let json = serde_json::to_string(&score).unwrap();
+        assert!(json.contains("\"overall_score\":85"));
+        assert!(json.contains("\"grade\":\"B\""));
+        assert!(json.contains("\"total_events\":10"));
+    }
+
+    #[test]
+    fn test_chrono_now_iso8601_format() {
+        let ts = chrono_now_iso8601();
+        // ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
+        assert!(ts.ends_with('Z'));
+        assert!(ts.contains('T'));
+        assert_eq!(ts.len(), 20);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,18 @@ enum Commands {
         #[arg(long, value_name = "PATH")]
         db: Option<String>,
     },
+    /// セキュリティスコアを表示する
+    Score {
+        /// API サーバーの URL
+        #[arg(long, default_value = "http://127.0.0.1:9200")]
+        api_url: String,
+        /// API トークン
+        #[arg(long)]
+        api_token: Option<String>,
+        /// JSON 形式で出力
+        #[arg(long)]
+        json: bool,
+    },
     /// API トークンの SHA-256 ハッシュを生成する
     HashToken {
         /// ハッシュ化するトークン文字列（省略時は標準入力から読み取る）
@@ -773,6 +785,117 @@ fn format_number(n: u64) -> String {
 }
 
 /// イベント統計を実行する
+/// セキュリティスコアを REST API 経由で取得・表示する
+fn run_score_command(api_url: &str, api_token: Option<&str>, json: bool) {
+    use std::io::Read as _;
+    use std::net::TcpStream;
+
+    let url = api_url.trim_end_matches('/');
+    let stripped = url.strip_prefix("http://").unwrap_or_else(|| {
+        eprintln!("エラー: http:// で始まる URL を指定してください");
+        process::exit(1);
+    });
+
+    let (host_port, _) = stripped.split_once('/').unwrap_or((stripped, ""));
+
+    let mut stream = match TcpStream::connect(host_port) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!(
+                "エラー: API サーバーに接続できません ({}): {}",
+                host_port, e
+            );
+            process::exit(1);
+        }
+    };
+
+    let mut request = format!(
+        "GET /api/v1/score HTTP/1.1\r\nHost: {}\r\nConnection: close\r\n",
+        host_port
+    );
+    if let Some(token) = api_token {
+        request.push_str(&format!("Authorization: Bearer {}\r\n", token));
+    }
+    request.push_str("\r\n");
+
+    if let Err(e) = std::io::Write::write_all(&mut stream, request.as_bytes()) {
+        eprintln!("エラー: リクエストの送信に失敗しました: {}", e);
+        process::exit(1);
+    }
+
+    let mut response = String::new();
+    if let Err(e) = stream.read_to_string(&mut response) {
+        eprintln!("エラー: レスポンスの読み取りに失敗しました: {}", e);
+        process::exit(1);
+    }
+
+    let body = response
+        .split_once("\r\n\r\n")
+        .map(|(_, b)| b)
+        .unwrap_or(&response);
+
+    let first_line = response.lines().next().unwrap_or("");
+    if !first_line.contains("200") {
+        eprintln!("エラー: API エラー: {}", first_line);
+        if !body.is_empty() {
+            eprintln!("{}", body);
+        }
+        process::exit(1);
+    }
+
+    if json {
+        println!("{}", body);
+    } else {
+        match serde_json::from_str::<serde_json::Value>(body) {
+            Ok(v) => {
+                eprintln!(
+                    "セキュリティスコア: {} (グレード: {})",
+                    v.get("overall_score").and_then(|s| s.as_u64()).unwrap_or(0),
+                    v.get("grade").and_then(|s| s.as_str()).unwrap_or("?"),
+                );
+                if let Some(cats) = v.get("categories").and_then(|c| c.as_object()) {
+                    eprintln!("\nカテゴリ別:");
+                    let mut sorted: Vec<_> = cats.iter().collect();
+                    sorted.sort_by_key(|(k, _)| k.to_string());
+                    for (cat, data) in sorted {
+                        let score = data.get("score").and_then(|s| s.as_u64()).unwrap_or(0);
+                        let grade = data.get("grade").and_then(|s| s.as_str()).unwrap_or("?");
+                        let issues = data.get("issues").and_then(|s| s.as_u64()).unwrap_or(0);
+                        eprintln!(
+                            "  {:<12} スコア: {:>3} ({}) 問題: {}",
+                            cat, score, grade, issues
+                        );
+                    }
+                }
+                if let Some(summary) = v.get("summary") {
+                    eprintln!("\nサマリー:");
+                    eprintln!(
+                        "  総イベント: {}  CRITICAL: {}  HIGH: {}  INFO: {}",
+                        summary
+                            .get("total_events")
+                            .and_then(|s| s.as_u64())
+                            .unwrap_or(0),
+                        summary
+                            .get("critical")
+                            .and_then(|s| s.as_u64())
+                            .unwrap_or(0),
+                        summary.get("high").and_then(|s| s.as_u64()).unwrap_or(0),
+                        summary.get("info").and_then(|s| s.as_u64()).unwrap_or(0),
+                    );
+                }
+                if let Some(ts) = v.get("evaluated_at").and_then(|s| s.as_str()) {
+                    eprintln!("\n評価日時: {}", ts);
+                }
+            }
+            Err(e) => {
+                eprintln!("エラー: レスポンスの解析に失敗しました: {}", e);
+                println!("{}", body);
+                process::exit(1);
+            }
+        }
+    }
+}
+
 fn run_event_stats(config_path: &Path, db: &Option<String>, days: u32, json: bool) {
     if days < 1 {
         eprintln!("エラー: --days は 1 以上を指定してください");
@@ -1042,6 +1165,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
         }) => {
             run_init(profile.as_deref(), *list_profiles, output, *force);
+            return Ok(());
+        }
+        Some(Commands::Score {
+            api_url,
+            api_token,
+            json,
+        }) => {
+            run_score_command(api_url, api_token.as_deref(), *json);
             return Ok(());
         }
         Some(Commands::HashToken { token }) => {


### PR DESCRIPTION
## 概要

Closes #261

システム全体のセキュリティ状態を 0〜100 のスコアで定量評価するセキュリティスコアリング機能を追加。

## 変更内容

- **`src/core/scoring.rs`（新規）** — `SecurityScorer` をイベントバスのサブスクライバーとして実装。カテゴリ別（network, filesystem, process, auth, kernel, system）のスコア算出、グレード判定（A〜F）、設定ホットリロード対応
- **`src/core/api.rs`** — `GET /api/v1/score` エンドポイントを追加。総合スコア・カテゴリ別スコア・サマリーを JSON で返却
- **`src/core/prometheus.rs`** — `zettai_security_score_overall` / `zettai_security_score_category` ゲージメトリクスを追加
- **`src/core/openapi.rs`** — `/api/v1/score` の OpenAPI スキーマを追加
- **`src/core/daemon.rs`** — SecurityScorer の起動・ホットリロード統合
- **`src/config.rs`** — `ScoringConfig` 設定構造体を追加
- **`src/main.rs`** — `score` CLI サブコマンドを追加（REST API 経由でスコア取得）
- **`config.example.toml`** — スコアリング設定セクションを追加

## スコア算出ロジック

- 基本スコア 100 から減点方式
- Critical イベント: -20点/件（最大-40）
- Warning イベント: -10点/件（最大-30）
- Info イベント: 減点なし
- カテゴリ別の重み付けカスタマイズ対応

## テスト計画

- [x] `cargo test` — 全テスト合格（2060 + 7 + 38 = 2105 テスト）
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt --check` — フォーマット済み
- [x] スコア算出ロジックのユニットテスト
- [x] グレード判定のユニットテスト
- [x] カテゴリ分類のユニットテスト
- [x] SecurityScorer のイベント受信テスト
- [x] SharedSecurityScore のシリアライズテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)