### PR TITLE
feat: REST API クライアント証明書認証（mTLS）(#274)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
 - **Prometheus Exporter**: MetricsCollector の集計データを Prometheus テキスト形式で HTTP エンドポイント（`/metrics`）から公開する。Grafana・Alertmanager 等の外部監視基盤と連携可能。`/health` エンドポイントでヘルスチェックも提供
-- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧、設定リロードをリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。ホットリロード対応
+- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧、設定リロードをリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）。ホットリロード対応
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する

--- a/config.example.toml
+++ b/config.example.toml
@@ -858,6 +858,12 @@ enabled = false
 # 秘密鍵ファイル（PEM 形式）
 # key_file = "/etc/zettai-mamorukun/certs/server.key"
 
+# mTLS（クライアント証明書認証）設定
+# [api.tls.mtls]
+# enabled = false
+# client_ca_file = "/etc/zettai-mamorukun/certs/client-ca.crt"
+# client_auth_mode = "required"  # "required" | "optional"
+
 # WebSocket イベントストリーミング設定
 # /api/v1/events/stream で SecurityEvent をリアルタイムにストリーミングする
 # 認証: Authorization ヘッダー or ?token=xxx クエリパラメータ

--- a/src/config.rs
+++ b/src/config.rs
@@ -6144,6 +6144,43 @@ impl Default for WebSocketConfig {
     }
 }
 
+/// REST API mTLS（クライアント証明書認証）設定
+///
+/// REST API の TLS 設定にネストする形で mTLS を構成する。
+/// Syslog モジュールではフラット構造（`client_ca_file` 等が直接 TLS 設定に並ぶ）だが、
+/// REST API では TLS 自体がオプショナルなサブテーブルであるため、
+/// mTLS をさらにネストすることで設定の階層構造を明確にしている。
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct ApiMtlsConfig {
+    /// mTLS の有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// クライアント CA 証明書ファイルのパス（PEM 形式）
+    #[serde(default)]
+    pub client_ca_file: String,
+
+    /// クライアント認証モード（"required" または "optional"）
+    #[serde(default = "ApiMtlsConfig::default_client_auth_mode")]
+    pub client_auth_mode: String,
+}
+
+impl ApiMtlsConfig {
+    fn default_client_auth_mode() -> String {
+        "required".to_string()
+    }
+}
+
+impl Default for ApiMtlsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            client_ca_file: String::new(),
+            client_auth_mode: Self::default_client_auth_mode(),
+        }
+    }
+}
+
 /// REST API TLS 設定
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct ApiTlsConfig {
@@ -6158,6 +6195,10 @@ pub struct ApiTlsConfig {
     /// 秘密鍵ファイルのパス（PEM 形式）
     #[serde(default)]
     pub key_file: String,
+
+    /// mTLS（クライアント証明書認証）設定
+    #[serde(default)]
+    pub mtls: ApiMtlsConfig,
 }
 
 /// REST API サーバー設定

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -249,6 +249,7 @@ pub struct ApiServer {
     shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>>,
     access_log: Arc<AtomicBool>,
     tls_acceptor: Option<Arc<tokio_rustls::TlsAcceptor>>,
+    mtls_status: String,
 }
 
 /// TLS アクセプターを構築する
@@ -273,7 +274,7 @@ fn build_tls_acceptor(
         ))
     })?;
 
-    let certs: Vec<rustls_pki_types::CertificateDer<'static>> =
+    let server_certs: Vec<rustls_pki_types::CertificateDer<'static>> =
         certs(&mut BufReader::new(cert_file))
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
@@ -292,7 +293,7 @@ fn build_tls_acceptor(
         })?
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "秘密鍵が見つかりません"))?;
 
-    let config =
+    let builder =
         ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
             .with_safe_default_protocol_versions()
             .map_err(|e| {
@@ -300,15 +301,91 @@ fn build_tls_acceptor(
                     io::ErrorKind::InvalidData,
                     format!("TLS プロトコルバージョンの設定に失敗: {}", e),
                 )
+            })?;
+
+    let config = if tls_config.mtls.enabled {
+        use rustls::server::WebPkiClientVerifier;
+
+        let ca_file = File::open(&tls_config.mtls.client_ca_file).map_err(|e| {
+            io::Error::other(format!(
+                "クライアント CA 証明書ファイルを開けません: {}: {}",
+                tls_config.mtls.client_ca_file, e
+            ))
+        })?;
+        let ca_certs: Vec<rustls_pki_types::CertificateDer<'static>> =
+            certs(&mut BufReader::new(ca_file))
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("クライアント CA 証明書の読み込みに失敗: {}", e),
+                    )
+                })?;
+
+        let mut client_root_store = rustls::RootCertStore::empty();
+        for cert in ca_certs {
+            client_root_store.add(cert).map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("クライアント CA 証明書の追加に失敗: {}", e),
+                )
+            })?;
+        }
+
+        let provider = Arc::new(rustls::crypto::ring::default_provider());
+        let verifier = if tls_config.mtls.client_auth_mode == "optional" {
+            WebPkiClientVerifier::builder_with_provider(
+                Arc::new(client_root_store),
+                provider.clone(),
+            )
+            .allow_unauthenticated()
+            .build()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("mTLS クライアント検証の構築に失敗: {}", e),
+                )
             })?
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
+        } else {
+            WebPkiClientVerifier::builder_with_provider(
+                Arc::new(client_root_store),
+                provider.clone(),
+            )
+            .build()
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("mTLS クライアント検証の構築に失敗: {}", e),
+                )
+            })?
+        };
+
+        tracing::info!(
+            client_ca_file = %tls_config.mtls.client_ca_file,
+            client_auth_mode = %tls_config.mtls.client_auth_mode,
+            "REST API mTLS: 有効"
+        );
+
+        builder
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(server_certs, key)
             .map_err(|e| {
                 io::Error::new(
                     io::ErrorKind::InvalidData,
                     format!("TLS 設定の構築に失敗: {}", e),
                 )
-            })?;
+            })?
+    } else {
+        builder
+            .with_no_client_auth()
+            .with_single_cert(server_certs, key)
+            .map_err(|e| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("TLS 設定の構築に失敗: {}", e),
+                )
+            })?
+    };
 
     Ok(tokio_rustls::TlsAcceptor::from(Arc::new(config)))
 }
@@ -340,6 +417,12 @@ impl ApiServer {
         } else {
             None
         };
+
+        if config.tls.mtls.enabled && !config.tls.enabled {
+            tracing::warn!(
+                "mTLS が有効ですが TLS が無効です。mTLS を機能させるには tls.enabled = true が必要です"
+            );
+        }
 
         let tls_acceptor = if config.tls.enabled {
             match build_tls_acceptor(&config.tls) {
@@ -386,6 +469,11 @@ impl ApiServer {
             shared_scoring,
             access_log: Arc::new(AtomicBool::new(config.access_log)),
             tls_acceptor,
+            mtls_status: if config.tls.enabled && config.tls.mtls.enabled {
+                config.tls.mtls.client_auth_mode.clone()
+            } else {
+                "無効".to_string()
+            },
         }
     }
 
@@ -428,6 +516,7 @@ impl ApiServer {
         let shared_scoring = self.shared_scoring;
         let access_log = self.access_log;
         let tls_acceptor = self.tls_acceptor;
+        let mtls_status = self.mtls_status;
 
         // クリーンアップタスク
         if self.rate_limit_config.enabled {
@@ -522,6 +611,7 @@ impl ApiServer {
         tracing::info!(
             bind_address = %addr,
             tls = tls_enabled,
+            mtls = %mtls_status,
             "REST API サーバーを起動しました"
         );
         Ok(())
@@ -4544,6 +4634,9 @@ mod tests {
         assert!(!config.enabled);
         assert!(config.cert_file.is_empty());
         assert!(config.key_file.is_empty());
+        assert!(!config.mtls.enabled);
+        assert!(config.mtls.client_ca_file.is_empty());
+        assert_eq!(config.mtls.client_auth_mode, "required");
     }
 
     #[test]
@@ -4606,6 +4699,7 @@ mod tests {
             enabled: true,
             cert_file: "/nonexistent/cert.pem".to_string(),
             key_file: "/nonexistent/key.pem".to_string(),
+            mtls: Default::default(),
         };
         let result = build_tls_acceptor(&tls_config);
         assert!(result.is_err());
@@ -4628,6 +4722,7 @@ mod tests {
             enabled: true,
             cert_file: cert_path.to_string_lossy().to_string(),
             key_file: "/nonexistent/key.pem".to_string(),
+            mtls: Default::default(),
         };
         let result = build_tls_acceptor(&tls_config);
         assert!(result.is_err());
@@ -4652,6 +4747,7 @@ mod tests {
             enabled: true,
             cert_file: cert_path.to_string_lossy().to_string(),
             key_file: key_path.to_string_lossy().to_string(),
+            mtls: Default::default(),
         };
         let result = build_tls_acceptor(&tls_config);
         assert!(
@@ -4673,8 +4769,162 @@ mod tests {
             enabled: true,
             cert_file: cert_path.to_string_lossy().to_string(),
             key_file: key_path.to_string_lossy().to_string(),
+            mtls: Default::default(),
         };
         let result = build_tls_acceptor(&tls_config);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mtls_config_default() {
+        let config = crate::config::ApiMtlsConfig::default();
+        assert!(!config.enabled);
+        assert!(config.client_ca_file.is_empty());
+        assert_eq!(config.client_auth_mode, "required");
+    }
+
+    #[test]
+    fn test_mtls_config_deserialize() {
+        let toml_str = r#"
+            enabled = true
+            client_ca_file = "/etc/certs/client-ca.crt"
+            client_auth_mode = "optional"
+        "#;
+        let config: crate::config::ApiMtlsConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.client_ca_file, "/etc/certs/client-ca.crt");
+        assert_eq!(config.client_auth_mode, "optional");
+    }
+
+    #[test]
+    fn test_mtls_config_deserialize_default_mode() {
+        let toml_str = r#"
+            enabled = true
+            client_ca_file = "/etc/certs/client-ca.crt"
+        "#;
+        let config: crate::config::ApiMtlsConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.client_auth_mode, "required");
+    }
+
+    #[test]
+    fn test_tls_config_with_mtls_deserialize() {
+        let toml_str = r#"
+            enabled = true
+            cert_file = "/path/to/cert.pem"
+            key_file = "/path/to/key.pem"
+            [mtls]
+            enabled = true
+            client_ca_file = "/path/to/client-ca.crt"
+            client_auth_mode = "required"
+        "#;
+        let config: crate::config::ApiTlsConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.enabled);
+        assert!(config.mtls.enabled);
+        assert_eq!(config.mtls.client_ca_file, "/path/to/client-ca.crt");
+        assert_eq!(config.mtls.client_auth_mode, "required");
+    }
+
+    #[test]
+    fn test_tls_config_without_mtls_section() {
+        let toml_str = r#"
+            enabled = true
+            cert_file = "/path/to/cert.pem"
+            key_file = "/path/to/key.pem"
+        "#;
+        let config: crate::config::ApiTlsConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.mtls.enabled);
+    }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_invalid_ca_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+
+        let cert = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, cert.cert.pem()).unwrap();
+        std::fs::write(&key_path, cert.key_pair.serialize_pem()).unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: true,
+                client_ca_file: "/nonexistent/client-ca.crt".to_string(),
+                client_auth_mode: "required".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(result.is_err());
+        assert!(
+            result
+                .err()
+                .unwrap()
+                .to_string()
+                .contains("クライアント CA 証明書ファイルを開けません")
+        );
+    }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_required() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        let ca_path = dir.path().join("client-ca.crt");
+
+        let ca = rcgen::generate_simple_self_signed(vec!["CA".to_string()]).unwrap();
+        let server = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, server.cert.pem()).unwrap();
+        std::fs::write(&key_path, server.key_pair.serialize_pem()).unwrap();
+        std::fs::write(&ca_path, ca.cert.pem()).unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: true,
+                client_ca_file: ca_path.to_string_lossy().to_string(),
+                client_auth_mode: "required".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(
+            result.is_ok(),
+            "mTLS (required) の構築に失敗: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_optional() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        let ca_path = dir.path().join("client-ca.crt");
+
+        let ca = rcgen::generate_simple_self_signed(vec!["CA".to_string()]).unwrap();
+        let server = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, server.cert.pem()).unwrap();
+        std::fs::write(&key_path, server.key_pair.serialize_pem()).unwrap();
+        std::fs::write(&ca_path, ca.cert.pem()).unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: true,
+                client_ca_file: ca_path.to_string_lossy().to_string(),
+                client_auth_mode: "optional".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(
+            result.is_ok(),
+            "mTLS (optional) の構築に失敗: {:?}",
+            result.err()
+        );
     }
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -4927,4 +4927,89 @@ mod tests {
             result.err()
         );
     }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_invalid_mode_falls_back_to_required() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        let ca_path = dir.path().join("client-ca.crt");
+
+        let ca = rcgen::generate_simple_self_signed(vec!["CA".to_string()]).unwrap();
+        let server = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, server.cert.pem()).unwrap();
+        std::fs::write(&key_path, server.key_pair.serialize_pem()).unwrap();
+        std::fs::write(&ca_path, ca.cert.pem()).unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: true,
+                client_ca_file: ca_path.to_string_lossy().to_string(),
+                client_auth_mode: "invalid_mode".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(
+            result.is_ok(),
+            "不正な client_auth_mode は required にフォールバックすべき: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_invalid_ca_cert_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        let ca_path = dir.path().join("client-ca.crt");
+
+        let server = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, server.cert.pem()).unwrap();
+        std::fs::write(&key_path, server.key_pair.serialize_pem()).unwrap();
+        std::fs::write(&ca_path, "not a valid certificate").unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: true,
+                client_ca_file: ca_path.to_string_lossy().to_string(),
+                client_auth_mode: "required".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_build_tls_acceptor_mtls_disabled_ignores_mtls_settings() {
+        let dir = tempfile::tempdir().unwrap();
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+
+        let server = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        std::fs::write(&cert_path, server.cert.pem()).unwrap();
+        std::fs::write(&key_path, server.key_pair.serialize_pem()).unwrap();
+
+        let tls_config = crate::config::ApiTlsConfig {
+            enabled: true,
+            cert_file: cert_path.to_string_lossy().to_string(),
+            key_file: key_path.to_string_lossy().to_string(),
+            mtls: crate::config::ApiMtlsConfig {
+                enabled: false,
+                client_ca_file: "/nonexistent/path.crt".to_string(),
+                client_auth_mode: "required".to_string(),
+            },
+        };
+        let result = build_tls_acceptor(&tls_config);
+        assert!(
+            result.is_ok(),
+            "mTLS 無効時は CA パスが不正でもエラーにならないべき: {:?}",
+            result.err()
+        );
+    }
 }


### PR DESCRIPTION
## 概要

REST API サーバーにクライアント証明書による相互 TLS 認証（mTLS）を追加し、API アクセスのセキュリティを強化する。

Closes #274

## 変更内容

### 設定（`src/config.rs`）
- `ApiMtlsConfig` 構造体を新設（`[api.tls.mtls]` セクション）
  - `enabled`: mTLS の有効/無効
  - `client_ca_file`: クライアント CA 証明書ファイルパス（PEM 形式）
  - `client_auth_mode`: `"required"` | `"optional"`（デフォルト: `"required"`）
- `ApiTlsConfig` に `mtls` フィールドを追加

### 実装（`src/core/api.rs`）
- `build_tls_acceptor` を拡張し、mTLS 有効時に `WebPkiClientVerifier` でクライアント証明書検証を構築
- `client_auth_mode` に応じて required/optional モードを切り替え
- `mtls.enabled = true` かつ `tls.enabled = false` の場合の警告ログ出力
- 起動ログに mTLS ステータスを追加

### ドキュメント
- `CLAUDE.md` に mTLS 対応の記述を追加
- `config.example.toml` に `[api.tls.mtls]` セクションの設定例を追加

### テスト（11件）
- デフォルト値・デシリアライズ・CA パス不正・required/optional モード構築
- 不正 client_auth_mode のフォールバック・不正 CA 証明書データ・mtls 無効時のスキップ

## テスト結果
- `cargo build --release`: 成功
- `cargo test`: 全テスト通過（新規 11 テスト含む）
- `cargo clippy -- -D warnings`: 警告なし
- `cargo fmt --check`: 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)