### PR TITLE
feat: 設定ファイルの暗号化対応（AES-256-GCM による機密値保護）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧、設定リロード、アーカイブ操作をリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。アーカイブエンドポイント（`/api/v1/archives`）でアーカイブ一覧取得・手動アーカイブ実行・復元・ローテーション・個別削除が可能（dry_run 対応、パストラバーサル防止）。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）。ホットリロード対応
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
+- **Encryption**: 設定ファイル内の機密値（Webhook URL、認証トークン等）を AES-256-GCM で暗号化・復号する。`ENC[...]` 形式で暗号化された値を設定読み込み時に自動復号。環境変数または鍵ファイルによる鍵管理。CLI コマンド（`encrypt-value`, `decrypt-value`, `generate-key`）を提供
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 
 ## ディレクトリ構成
@@ -77,6 +78,7 @@ src/
   main.rs              # エントリポイント（デーモン起動）
   lib.rs               # クレートルート
   config.rs            # 設定ファイル読み込み
+  encryption.rs        # 設定値の暗号化・復号（AES-256-GCM）
   error.rs             # エラー型定義（thiserror）
   core/
     mod.rs             # コアモジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +282,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -387,6 +433,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -727,6 +782,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1076,6 +1141,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1493,18 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1540,7 +1632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1550,7 +1642,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2467,6 +2568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3152,6 +3263,8 @@ dependencies = [
 name = "zettai-mamorukun"
 version = "1.40.0"
 dependencies = [
+ "aes-gcm",
+ "base64",
  "clap",
  "crossterm",
  "csv",
@@ -3190,6 +3303,7 @@ dependencies = [
  "wiremock",
  "x509-parser",
  "xattr",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.40.0"
+version = "1.41.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
 
 [dependencies]
+aes-gcm = "0.10"
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 sha1 = "0.10"
@@ -41,6 +43,7 @@ tokio-tungstenite = "0.26"
 rustls-pki-types = "1"
 webpki-roots = "0.26"
 rustls-pemfile = "2"
+zeroize = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,6 +1,20 @@
 # zettai-mamorukun 設定ファイル
 # /etc/zettai-mamorukun/config.toml にコピーして使用する
 
+# [encryption]
+# 設定ファイル内の機密値を暗号化する場合に使用する
+# 暗号化された値は ENC[...] 形式で記述し、設定読み込み時に自動復号される
+#
+# 鍵の生成: zettai-mamorukun generate-key
+# 値の暗号化: zettai-mamorukun encrypt-value "秘密の値"
+# 値の復号: zettai-mamorukun decrypt-value "ENC[...]"
+#
+# 鍵は以下の優先順位で解決される:
+#   1. 環境変数 ZETTAI_ENCRYPTION_KEY（Base64 エンコードされた 32 バイト鍵）
+#   2. key_file で指定したファイル
+#
+# key_file = "/etc/zettai-mamorukun/encryption.key"
+
 [general]
 # ログレベル: trace, debug, info, warn, error
 log_level = "info"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::encryption::EncryptionConfig;
 use crate::error::AppError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -77,6 +78,10 @@ pub struct AppConfig {
     /// セキュリティスコアリング設定
     #[serde(default)]
     pub scoring: ScoringConfig,
+
+    /// 暗号化設定
+    #[serde(default)]
+    pub encryption: Option<EncryptionConfig>,
 }
 
 /// デーモン動作設定
@@ -4307,6 +4312,8 @@ impl AppConfig {
             path: path.to_path_buf(),
             source: e,
         })?;
+
+        let content = crate::encryption::decrypt_config_content(&content)?;
 
         toml::from_str(&content).map_err(|e| AppError::ConfigParse {
             path: path.to_path_buf(),

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,0 +1,470 @@
+use crate::error::AppError;
+use aes_gcm::{AeadCore, Aes256Gcm, KeyInit, Nonce, aead::Aead};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use zeroize::Zeroize;
+
+const NONCE_LEN: usize = 12;
+const TAG_LEN: usize = 16;
+const KEY_LEN: usize = 32;
+const ENC_PREFIX: &str = "ENC[";
+const ENC_SUFFIX: &str = "]";
+const ENV_KEY_NAME: &str = "ZETTAI_ENCRYPTION_KEY";
+
+/// 暗号化設定
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+pub struct EncryptionConfig {
+    /// 暗号化鍵ファイルのパス
+    pub key_file: Option<PathBuf>,
+}
+
+/// AES-256 暗号化鍵（メモリ破棄時にゼロクリア）
+pub struct EncryptionKey {
+    bytes: [u8; KEY_LEN],
+}
+
+impl Drop for EncryptionKey {
+    fn drop(&mut self) {
+        self.bytes.zeroize();
+    }
+}
+
+impl EncryptionKey {
+    fn new(bytes: [u8; KEY_LEN]) -> Self {
+        Self { bytes }
+    }
+
+    fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.bytes
+    }
+}
+
+/// 文字列が `ENC[...]` 形式かどうかを判定する
+pub fn is_encrypted(value: &str) -> bool {
+    value.starts_with(ENC_PREFIX) && value.ends_with(ENC_SUFFIX) && value.len() > 5
+}
+
+/// ランダムな暗号化鍵を生成する
+pub fn generate_key() -> EncryptionKey {
+    let mut bytes = [0u8; KEY_LEN];
+    let key = Aes256Gcm::generate_key(aes_gcm::aead::OsRng);
+    bytes.copy_from_slice(&key);
+    EncryptionKey::new(bytes)
+}
+
+/// 暗号化鍵を Base64 エンコードして返す
+pub fn key_to_base64(key: &EncryptionKey) -> String {
+    BASE64.encode(key.as_bytes())
+}
+
+/// 環境変数または鍵ファイルから暗号化鍵を解決する
+pub fn resolve_key(config: &Option<EncryptionConfig>) -> Result<Option<EncryptionKey>, AppError> {
+    if let Ok(env_val) = std::env::var(ENV_KEY_NAME) {
+        let decoded = BASE64
+            .decode(env_val.trim())
+            .map_err(|_| AppError::Encryption {
+                message: format!("{} の Base64 デコードに失敗しました", ENV_KEY_NAME),
+            })?;
+        return Ok(Some(bytes_to_key(&decoded)?));
+    }
+
+    if let Some(enc_config) = config
+        && let Some(ref key_path) = enc_config.key_file
+    {
+        return load_key_from_file(key_path).map(Some);
+    }
+
+    Ok(None)
+}
+
+fn load_key_from_file(path: &Path) -> Result<EncryptionKey, AppError> {
+    let content = std::fs::read_to_string(path).map_err(|_| AppError::Encryption {
+        message: format!(
+            "暗号化鍵ファイルの読み込みに失敗しました: {}",
+            path.display()
+        ),
+    })?;
+    let decoded = BASE64
+        .decode(content.trim())
+        .map_err(|_| AppError::Encryption {
+            message: format!(
+                "暗号化鍵ファイルの Base64 デコードに失敗しました: {}",
+                path.display()
+            ),
+        })?;
+    bytes_to_key(&decoded)
+}
+
+fn bytes_to_key(bytes: &[u8]) -> Result<EncryptionKey, AppError> {
+    if bytes.len() != KEY_LEN {
+        return Err(AppError::Encryption {
+            message: format!(
+                "暗号化鍵の長さが不正です（期待: {} バイト、実際: {} バイト）",
+                KEY_LEN,
+                bytes.len()
+            ),
+        });
+    }
+    let mut key_bytes = [0u8; KEY_LEN];
+    key_bytes.copy_from_slice(bytes);
+    Ok(EncryptionKey::new(key_bytes))
+}
+
+/// 平文を AES-256-GCM で暗号化し `ENC[...]` 形式の文字列を返す
+pub fn encrypt_value(key: &EncryptionKey, plaintext: &str) -> Result<String, AppError> {
+    let cipher = Aes256Gcm::new(key.as_bytes().into());
+    let nonce = Aes256Gcm::generate_nonce(aes_gcm::aead::OsRng);
+    let ciphertext =
+        cipher
+            .encrypt(&nonce, plaintext.as_bytes())
+            .map_err(|_| AppError::Encryption {
+                message: "暗号化に失敗しました".to_string(),
+            })?;
+
+    let mut combined = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    combined.extend_from_slice(&nonce);
+    combined.extend_from_slice(&ciphertext);
+
+    Ok(format!(
+        "{}{}{}",
+        ENC_PREFIX,
+        BASE64.encode(&combined),
+        ENC_SUFFIX
+    ))
+}
+
+/// `ENC[...]` 形式の文字列を復号し平文を返す
+pub fn decrypt_value(key: &EncryptionKey, encrypted: &str) -> Result<String, AppError> {
+    if !is_encrypted(encrypted) {
+        return Err(AppError::Encryption {
+            message: "暗号化値の形式が不正です（ENC[...] 形式を期待）".to_string(),
+        });
+    }
+
+    let b64 = &encrypted[ENC_PREFIX.len()..encrypted.len() - ENC_SUFFIX.len()];
+    let combined = BASE64.decode(b64).map_err(|_| AppError::Encryption {
+        message: "暗号化値の Base64 デコードに失敗しました".to_string(),
+    })?;
+
+    let min_len = NONCE_LEN + TAG_LEN;
+    if combined.len() < min_len {
+        return Err(AppError::Encryption {
+            message: format!(
+                "暗号化値のデータが短すぎます（最小: {} バイト = nonce {} + tag {}）",
+                min_len, NONCE_LEN, TAG_LEN
+            ),
+        });
+    }
+
+    let (nonce_bytes, ciphertext) = combined.split_at(NONCE_LEN);
+    let nonce = Nonce::from_slice(nonce_bytes);
+    let cipher = Aes256Gcm::new(key.as_bytes().into());
+
+    let plaintext = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| AppError::Encryption {
+            message: "暗号化値の復号に失敗しました（鍵が正しいか確認してください）".to_string(),
+        })?;
+
+    String::from_utf8(plaintext).map_err(|_| AppError::Encryption {
+        message: "復号結果が有効な UTF-8 文字列ではありません".to_string(),
+    })
+}
+
+/// TOML 文字列内の全 `ENC[...]` 値を復号した TOML 文字列を返す
+pub fn decrypt_config_content(content: &str) -> Result<String, AppError> {
+    if !content.contains(ENC_PREFIX) {
+        return Ok(content.to_string());
+    }
+
+    // [encryption] セクションを部分パースして鍵を解決
+    #[derive(Deserialize)]
+    struct PartialConfig {
+        encryption: Option<EncryptionConfig>,
+    }
+
+    let partial: PartialConfig =
+        toml::from_str(content).unwrap_or(PartialConfig { encryption: None });
+
+    let key = resolve_key(&partial.encryption)?.ok_or_else(|| AppError::Encryption {
+        message: "暗号化された設定値がありますが、暗号化鍵が設定されていません。環境変数 ZETTAI_ENCRYPTION_KEY を設定するか、[encryption] セクションで key_file を指定してください".to_string(),
+    })?;
+
+    let mut result = content.to_string();
+    // ENC[...] パターンを検索して復号
+    loop {
+        let Some(start) = result.find(ENC_PREFIX) else {
+            break;
+        };
+        let Some(end) = result[start..].find(ENC_SUFFIX) else {
+            break;
+        };
+        let end = start + end + ENC_SUFFIX.len();
+        let encrypted = &result[start..end];
+
+        // Base64 文字のみで構成されているか簡易チェック
+        let b64_part = &encrypted[ENC_PREFIX.len()..encrypted.len() - ENC_SUFFIX.len()];
+        if !b64_part
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+        {
+            break;
+        }
+
+        let decrypted = decrypt_value(&key, encrypted)?;
+        result = format!("{}{}{}", &result[..start], decrypted, &result[end..]);
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> EncryptionKey {
+        let mut bytes = [0u8; KEY_LEN];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = i as u8;
+        }
+        EncryptionKey::new(bytes)
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let key = test_key();
+        let plaintext = "https://hooks.slack.com/services/T00/B00/xxxx";
+        let encrypted = encrypt_value(&key, plaintext).unwrap();
+        assert!(is_encrypted(&encrypted));
+        let decrypted = decrypt_value(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_empty_string() {
+        let key = test_key();
+        let plaintext = "";
+        let encrypted = encrypt_value(&key, plaintext).unwrap();
+        let decrypted = decrypt_value(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_unicode() {
+        let key = test_key();
+        let plaintext = "日本語のテストデータ 🔒";
+        let encrypted = encrypt_value(&key, plaintext).unwrap();
+        let decrypted = decrypt_value(&key, &encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn test_is_encrypted() {
+        assert!(is_encrypted("ENC[AAAA]"));
+        assert!(is_encrypted("ENC[dGVzdA==]"));
+        assert!(!is_encrypted(""));
+        assert!(!is_encrypted("ENC["));
+        assert!(!is_encrypted("ENC[]"));
+        assert!(!is_encrypted("plain text"));
+        assert!(!is_encrypted("ENC[A")); // no closing bracket
+    }
+
+    #[test]
+    fn test_decrypt_invalid_format() {
+        let key = test_key();
+        let result = decrypt_value(&key, "not-encrypted");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_wrong_key() {
+        let key1 = test_key();
+        let mut key2_bytes = [0u8; KEY_LEN];
+        key2_bytes[0] = 0xFF;
+        let key2 = EncryptionKey::new(key2_bytes);
+
+        let encrypted = encrypt_value(&key1, "secret").unwrap();
+        let result = decrypt_value(&key2, &encrypted);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_tampered_data() {
+        let key = test_key();
+        let encrypted = encrypt_value(&key, "secret").unwrap();
+
+        // 暗号文の一部を改ざん
+        let b64 = &encrypted[ENC_PREFIX.len()..encrypted.len() - ENC_SUFFIX.len()];
+        let mut data = BASE64.decode(b64).unwrap();
+        if let Some(last) = data.last_mut() {
+            *last ^= 0xFF;
+        }
+        let tampered = format!("{}{}{}", ENC_PREFIX, BASE64.encode(&data), ENC_SUFFIX);
+
+        let result = decrypt_value(&key, &tampered);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_data_too_short() {
+        let key = test_key();
+        let short_data = vec![0u8; 10]; // 12+16 より短い
+        let encrypted = format!("{}{}{}", ENC_PREFIX, BASE64.encode(&short_data), ENC_SUFFIX);
+        let result = decrypt_value(&key, &encrypted);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_generate_key_length() {
+        let key = generate_key();
+        assert_eq!(key.as_bytes().len(), KEY_LEN);
+    }
+
+    #[test]
+    fn test_key_to_base64_roundtrip() {
+        let key = generate_key();
+        let b64 = key_to_base64(&key);
+        let decoded = BASE64.decode(&b64).unwrap();
+        assert_eq!(decoded.len(), KEY_LEN);
+        assert_eq!(decoded, key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_env_var() {
+        let key = test_key();
+        let b64 = key_to_base64(&key);
+        unsafe { std::env::set_var(ENV_KEY_NAME, &b64) };
+        let resolved = resolve_key(&None).unwrap();
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().as_bytes(), key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("test.key");
+        let key = test_key();
+        std::fs::write(&key_path, key_to_base64(&key)).unwrap();
+
+        let config = Some(EncryptionConfig {
+            key_file: Some(key_path),
+        });
+        // 環境変数がセットされている場合に備えて削除
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        let resolved = resolve_key(&config).unwrap();
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().as_bytes(), key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_env_priority_over_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("test.key");
+
+        let env_key = test_key();
+        let mut file_key_bytes = [0u8; KEY_LEN];
+        file_key_bytes[0] = 0xFF;
+        let file_key = EncryptionKey::new(file_key_bytes);
+
+        std::fs::write(&key_path, key_to_base64(&file_key)).unwrap();
+        unsafe { std::env::set_var(ENV_KEY_NAME, key_to_base64(&env_key)) };
+
+        let config = Some(EncryptionConfig {
+            key_file: Some(key_path),
+        });
+        let resolved = resolve_key(&config).unwrap();
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+
+        assert!(resolved.is_some());
+        assert_eq!(resolved.unwrap().as_bytes(), env_key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_none() {
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        let resolved = resolve_key(&None).unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_key_base64_invalid() {
+        unsafe { std::env::set_var(ENV_KEY_NAME, "not-valid-base64!!!") };
+        let result = resolve_key(&None);
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_key_wrong_length() {
+        let short_key = BASE64.encode(&[0u8; 16]);
+        unsafe { std::env::set_var(ENV_KEY_NAME, &short_key) };
+        let result = resolve_key(&None);
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_config_content_no_encrypted_values() {
+        let content = r#"
+[general]
+log_level = "info"
+"#;
+        let result = decrypt_config_content(content).unwrap();
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_decrypt_config_content_with_encrypted_values() {
+        let key = test_key();
+        let b64 = key_to_base64(&key);
+
+        let secret_url = "https://hooks.slack.com/services/T00/B00/xxxx";
+        let encrypted_url = encrypt_value(&key, secret_url).unwrap();
+
+        let secret_header = "Bearer my-secret-token";
+        let encrypted_header = encrypt_value(&key, secret_header).unwrap();
+
+        unsafe { std::env::set_var(ENV_KEY_NAME, &b64) };
+
+        let content = format!(
+            r#"
+[general]
+log_level = "info"
+
+[[actions.rules]]
+name = "webhook-alert"
+action = "webhook"
+url = "{}"
+
+[actions.rules.headers]
+Authorization = "{}"
+"#,
+            encrypted_url, encrypted_header
+        );
+
+        let result = decrypt_config_content(&content).unwrap();
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+
+        assert!(result.contains(secret_url));
+        assert!(result.contains(secret_header));
+        assert!(!result.contains("ENC["));
+    }
+
+    #[test]
+    fn test_decrypt_config_no_key_with_encrypted_values() {
+        unsafe { std::env::remove_var(ENV_KEY_NAME) };
+        let content = r#"
+[general]
+log_level = "info"
+
+[[actions.rules]]
+name = "test"
+action = "webhook"
+url = "ENC[dGVzdGRhdGFmb3JlbmNyeXB0aW9u]"
+"#;
+        let result = decrypt_config_content(content);
+        assert!(result.is_err());
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,4 +83,8 @@ pub enum AppError {
     /// アラートルールエラー
     #[error("アラートルールエラー: {0}")]
     AlertRule(String),
+
+    /// 暗号化/復号エラー
+    #[error("暗号化エラー: {message}")]
+    Encryption { message: String },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 pub mod config;
 pub mod core;
+pub mod encryption;
 pub mod error;
 pub mod modules;
 pub mod profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,20 @@ enum Commands {
         #[command(subcommand)]
         action: ArchiveAction,
     },
+    /// 設定値を暗号化する
+    EncryptValue {
+        /// 暗号化する平文
+        #[arg(value_name = "PLAINTEXT")]
+        plaintext: String,
+    },
+    /// 暗号化された設定値を復号する
+    DecryptValue {
+        /// 復号する暗号化文字列（ENC[...]形式）
+        #[arg(value_name = "ENCRYPTED")]
+        encrypted: String,
+    },
+    /// 暗号化鍵を生成する
+    GenerateKey,
 }
 
 #[derive(Subcommand)]
@@ -947,6 +961,66 @@ fn run_score_command(api_url: &str, api_token: Option<&str>, json: bool) {
     }
 }
 
+fn resolve_encryption_key(config_path: &Path) -> zettai_mamorukun::encryption::EncryptionKey {
+    use zettai_mamorukun::encryption::resolve_key;
+
+    let enc_config = AppConfig::load(config_path).ok().and_then(|c| c.encryption);
+
+    match resolve_key(&enc_config) {
+        Ok(Some(key)) => key,
+        Ok(None) => {
+            eprintln!("エラー: 暗号化鍵が設定されていません");
+            eprintln!(
+                "  環境変数 ZETTAI_ENCRYPTION_KEY を設定するか、設定ファイルの [encryption] セクションで key_file を指定してください"
+            );
+            eprintln!("  鍵の生成: zettai-mamorukun generate-key");
+            process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("エラー: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn run_encrypt_value(config_path: &Path, plaintext: &str) {
+    let key = resolve_encryption_key(config_path);
+    match zettai_mamorukun::encryption::encrypt_value(&key, plaintext) {
+        Ok(encrypted) => println!("{}", encrypted),
+        Err(e) => {
+            eprintln!("エラー: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn run_decrypt_value(config_path: &Path, encrypted: &str) {
+    let key = resolve_encryption_key(config_path);
+    match zettai_mamorukun::encryption::decrypt_value(&key, encrypted) {
+        Ok(plaintext) => println!("{}", plaintext),
+        Err(e) => {
+            eprintln!("エラー: {}", e);
+            process::exit(1);
+        }
+    }
+}
+
+fn run_generate_key() {
+    let key = zettai_mamorukun::encryption::generate_key();
+    let b64 = zettai_mamorukun::encryption::key_to_base64(&key);
+    println!("{}", b64);
+    eprintln!("# 鍵をファイルに保存する場合:");
+    eprintln!("#   zettai-mamorukun generate-key > /etc/zettai-mamorukun/encryption.key");
+    eprintln!("#   chmod 600 /etc/zettai-mamorukun/encryption.key");
+    eprintln!("#");
+    eprintln!("# 環境変数で指定する場合:");
+    eprintln!("#   export ZETTAI_ENCRYPTION_KEY=\"<上記の鍵>\"");
+    eprintln!("#");
+    eprintln!("# 設定ファイルで鍵ファイルを指定する場合:");
+    eprintln!("#   [encryption]");
+    eprintln!("#   key_file = \"/etc/zettai-mamorukun/encryption.key\"");
+}
+
 fn run_archive_command(config_path: &Path, action: &ArchiveAction) {
     let config = AppConfig::load(config_path).ok();
     let default_config = zettai_mamorukun::config::EventStoreConfig::default();
@@ -1353,6 +1427,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::Archive { action }) => {
             run_archive_command(&cli.config, action);
+            return Ok(());
+        }
+        Some(Commands::EncryptValue { plaintext }) => {
+            run_encrypt_value(&cli.config, plaintext);
+            return Ok(());
+        }
+        Some(Commands::DecryptValue { encrypted }) => {
+            run_decrypt_value(&cli.config, encrypted);
+            return Ok(());
+        }
+        Some(Commands::GenerateKey) => {
+            run_generate_key();
             return Ok(());
         }
         Some(Commands::HashToken { token }) => {


### PR DESCRIPTION
## Summary

- 設定ファイル内の機密情報（Webhook URL、認証トークン、HTTP ヘッダー値等）を AES-256-GCM で暗号化して保存し、設定読み込み時に自動復号する機能を追加
- `ENC[base64(nonce || ciphertext || tag)]` 形式で暗号化された値を TOML パース前に復号
- CLI コマンド `encrypt-value`, `decrypt-value`, `generate-key` を追加
- 環境変数 `ZETTAI_ENCRYPTION_KEY` または鍵ファイルによる鍵管理
- `zeroize` クレートによる鍵のメモリ安全な破棄

## Test plan

- [x] 暗号化→復号ラウンドトリップテスト（通常文字列、空文字列、Unicode）
- [x] 不正な形式、不正な鍵、改ざんデータでの復号エラーテスト
- [x] 鍵の生成・Base64 変換テスト
- [x] 環境変数/鍵ファイルからの鍵解決テスト（優先順位含む）
- [x] TOML 設定内の暗号化値一括復号テスト
- [x] 鍵未設定時のエラーテスト
- [x] cargo clippy / cargo fmt / cargo test 全パス

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)