### PR TITLE
feat: 暗号化鍵のローテーション機能 (#290)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧・制御、設定リロード、アーカイブ操作をリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。モジュール制御エンドポイント（`/api/v1/modules/{name}/start|stop|restart`）で個別モジュールの起動・停止・再起動が可能（admin ロール必須、dry_run 対応）。アーカイブエンドポイント（`/api/v1/archives`）でアーカイブ一覧取得・手動アーカイブ実行・復元・ローテーション・個別削除が可能（dry_run 対応、パストラバーサル防止）。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）。ホットリロード対応
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
-- **Encryption**: 設定ファイル内の機密値（Webhook URL、認証トークン等）を AES-256-GCM で暗号化・復号する。`ENC[...]` 形式で暗号化された値を設定読み込み時に自動復号。環境変数または鍵ファイルによる鍵管理。CLI コマンド（`encrypt-value`, `decrypt-value`, `generate-key`）を提供
+- **Encryption**: 設定ファイル内の機密値（Webhook URL、認証トークン等）を AES-256-GCM で暗号化・復号する。`ENC[...]` 形式で暗号化された値を設定読み込み時に自動復号。環境変数または鍵ファイルによる鍵管理。CLI コマンド（`encrypt-value`, `decrypt-value`, `generate-key`, `rotate-key`）を提供
 - **Module Manager**: モジュールの一括起動・停止・リロードを管理。設定変更の差分検出により、変更のあったモジュールのみ再起動する
 
 ## ディレクトリ構成

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,6 +8,7 @@
 # 鍵の生成: zettai-mamorukun generate-key
 # 値の暗号化: zettai-mamorukun encrypt-value "秘密の値"
 # 値の復号: zettai-mamorukun decrypt-value "ENC[...]"
+# 鍵のローテーション: zettai-mamorukun rotate-key --old-key <旧鍵> --new-key <新鍵>
 #
 # 鍵は以下の優先順位で解決される:
 #   1. 環境変数 ZETTAI_ENCRYPTION_KEY（Base64 エンコードされた 32 バイト鍵）

--- a/src/core/module_manager.rs
+++ b/src/core/module_manager.rs
@@ -1081,7 +1081,9 @@ mod tests {
 
     #[test]
     fn test_is_known_module() {
-        assert!(ModuleManager::is_known_module("DNS設定改ざん検知モジュール"));
+        assert!(ModuleManager::is_known_module(
+            "DNS設定改ざん検知モジュール"
+        ));
         assert!(ModuleManager::is_known_module(
             "ファイル整合性監視モジュール"
         ));

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -172,6 +172,112 @@ pub fn decrypt_value(key: &EncryptionKey, encrypted: &str) -> Result<String, App
     })
 }
 
+/// 鍵ローテーション結果
+pub struct RotateResult {
+    /// ローテーション後の設定ファイル内容
+    pub new_content: String,
+    /// 再暗号化に成功した値の数
+    pub rotated_count: usize,
+    /// スキップした値の数
+    pub skipped_count: usize,
+    /// 各エラーの詳細メッセージ
+    pub errors: Vec<String>,
+}
+
+/// 鍵ソース文字列から暗号化鍵を解決する
+///
+/// サポートする形式:
+/// - `env:VARIABLE_NAME` — 環境変数から読み込み
+/// - ファイルパス — ファイルから読み込み
+/// - Base64 文字列 — 直接デコード
+pub fn resolve_key_from_source(source: &str) -> Result<EncryptionKey, AppError> {
+    if let Some(var_name) = source.strip_prefix("env:") {
+        let env_val = std::env::var(var_name).map_err(|_| AppError::Encryption {
+            message: format!("環境変数 {} が設定されていません", var_name),
+        })?;
+        let decoded = BASE64
+            .decode(env_val.trim())
+            .map_err(|_| AppError::Encryption {
+                message: format!("環境変数 {} の Base64 デコードに失敗しました", var_name),
+            })?;
+        return bytes_to_key(&decoded);
+    }
+
+    let path = Path::new(source);
+    if path.exists() {
+        return load_key_from_file(path);
+    }
+
+    let decoded = BASE64
+        .decode(source.trim())
+        .map_err(|_| AppError::Encryption {
+            message: "鍵ソースの Base64 デコードに失敗しました（env:変数名、ファイルパス、または Base64 文字列を指定してください）".to_string(),
+        })?;
+    bytes_to_key(&decoded)
+}
+
+/// TOML 文字列内の全 `ENC[...]` 値を旧鍵で復号し、新鍵で再暗号化する
+pub fn rotate_config_keys(
+    content: &str,
+    old_key: &EncryptionKey,
+    new_key: &EncryptionKey,
+) -> RotateResult {
+    let mut result = content.to_string();
+    let mut rotated_count = 0;
+    let mut skipped_count = 0;
+    let mut errors = Vec::new();
+
+    let mut search_start = 0;
+    loop {
+        let Some(start) = result[search_start..].find(ENC_PREFIX) else {
+            break;
+        };
+        let start = search_start + start;
+
+        let Some(end_offset) = result[start..].find(ENC_SUFFIX) else {
+            break;
+        };
+        let end = start + end_offset + ENC_SUFFIX.len();
+        let encrypted = result[start..end].to_string();
+
+        let b64_part = &encrypted[ENC_PREFIX.len()..encrypted.len() - ENC_SUFFIX.len()];
+        if !b64_part
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=')
+        {
+            search_start = end;
+            continue;
+        }
+
+        match decrypt_value(old_key, &encrypted) {
+            Ok(plaintext) => match encrypt_value(new_key, &plaintext) {
+                Ok(new_encrypted) => {
+                    result = format!("{}{}{}", &result[..start], new_encrypted, &result[end..]);
+                    search_start = start + new_encrypted.len();
+                    rotated_count += 1;
+                }
+                Err(e) => {
+                    errors.push(format!("再暗号化に失敗: {}", e));
+                    skipped_count += 1;
+                    search_start = end;
+                }
+            },
+            Err(e) => {
+                errors.push(format!("復号に失敗（旧鍵が正しくない可能性）: {}", e));
+                skipped_count += 1;
+                search_start = end;
+            }
+        }
+    }
+
+    RotateResult {
+        new_content: result,
+        rotated_count,
+        skipped_count,
+        errors,
+    }
+}
+
 /// TOML 文字列内の全 `ENC[...]` 値を復号した TOML 文字列を返す
 pub fn decrypt_config_content(content: &str) -> Result<String, AppError> {
     if !content.contains(ENC_PREFIX) {
@@ -465,6 +571,176 @@ action = "webhook"
 url = "ENC[dGVzdGRhdGFmb3JlbmNyeXB0aW9u]"
 "#;
         let result = decrypt_config_content(content);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_env() {
+        let key = test_key();
+        let b64 = key_to_base64(&key);
+        let var_name = "ZETTAI_TEST_ROTATE_KEY_ENV";
+        unsafe { std::env::set_var(var_name, &b64) };
+        let resolved = resolve_key_from_source(&format!("env:{}", var_name)).unwrap();
+        unsafe { std::env::remove_var(var_name) };
+        assert_eq!(resolved.as_bytes(), key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_env_missing() {
+        let result = resolve_key_from_source("env:ZETTAI_NONEXISTENT_VAR_12345");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_path = dir.path().join("rotate_test.key");
+        let key = test_key();
+        std::fs::write(&key_path, key_to_base64(&key)).unwrap();
+        let resolved = resolve_key_from_source(key_path.to_str().unwrap()).unwrap();
+        assert_eq!(resolved.as_bytes(), key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_base64() {
+        let key = test_key();
+        let b64 = key_to_base64(&key);
+        let resolved = resolve_key_from_source(&b64).unwrap();
+        assert_eq!(resolved.as_bytes(), key.as_bytes());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_invalid() {
+        let result = resolve_key_from_source("not-valid-base64!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rotate_config_keys_basic() {
+        let old_key = test_key();
+        let mut new_key_bytes = [0u8; KEY_LEN];
+        new_key_bytes[0] = 0xFF;
+        let new_key = EncryptionKey::new(new_key_bytes);
+
+        let secret = "my-secret-value";
+        let encrypted = encrypt_value(&old_key, secret).unwrap();
+
+        let content = format!(
+            r#"[section]
+value = "{}"
+plain = "hello"
+"#,
+            encrypted
+        );
+
+        let result = rotate_config_keys(&content, &old_key, &new_key);
+        assert_eq!(result.rotated_count, 1);
+        assert_eq!(result.skipped_count, 0);
+        assert!(result.errors.is_empty());
+        assert!(!result.new_content.contains(&encrypted));
+        assert!(result.new_content.contains("ENC["));
+
+        let new_enc_start = result.new_content.find("ENC[").unwrap();
+        let new_enc_end =
+            result.new_content[new_enc_start..].find(']').unwrap() + new_enc_start + 1;
+        let new_encrypted = &result.new_content[new_enc_start..new_enc_end];
+        let decrypted = decrypt_value(&new_key, new_encrypted).unwrap();
+        assert_eq!(decrypted, secret);
+    }
+
+    #[test]
+    fn test_rotate_config_keys_multiple() {
+        let old_key = test_key();
+        let mut new_key_bytes = [0u8; KEY_LEN];
+        new_key_bytes[0] = 0xFF;
+        let new_key = EncryptionKey::new(new_key_bytes);
+
+        let secret1 = "secret-one";
+        let secret2 = "secret-two";
+        let enc1 = encrypt_value(&old_key, secret1).unwrap();
+        let enc2 = encrypt_value(&old_key, secret2).unwrap();
+
+        let content = format!("a = \"{}\"\nb = \"{}\"\n", enc1, enc2);
+        let result = rotate_config_keys(&content, &old_key, &new_key);
+        assert_eq!(result.rotated_count, 2);
+        assert_eq!(result.skipped_count, 0);
+    }
+
+    #[test]
+    fn test_rotate_config_keys_wrong_old_key() {
+        let old_key = test_key();
+        let mut wrong_key_bytes = [0u8; KEY_LEN];
+        wrong_key_bytes[0] = 0xAA;
+        let wrong_key = EncryptionKey::new(wrong_key_bytes);
+        let mut new_key_bytes = [0u8; KEY_LEN];
+        new_key_bytes[0] = 0xFF;
+        let new_key = EncryptionKey::new(new_key_bytes);
+
+        let encrypted = encrypt_value(&old_key, "secret").unwrap();
+        let content = format!("val = \"{}\"\n", encrypted);
+
+        let result = rotate_config_keys(&content, &wrong_key, &new_key);
+        assert_eq!(result.rotated_count, 0);
+        assert_eq!(result.skipped_count, 1);
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.new_content.contains(&encrypted));
+    }
+
+    #[test]
+    fn test_rotate_config_keys_no_encrypted_values() {
+        let old_key = test_key();
+        let new_key = test_key();
+        let content = "[section]\nplain = \"hello\"\n";
+        let result = rotate_config_keys(content, &old_key, &new_key);
+        assert_eq!(result.rotated_count, 0);
+        assert_eq!(result.skipped_count, 0);
+        assert_eq!(result.new_content, content);
+    }
+
+    #[test]
+    fn test_rotate_config_keys_empty_content() {
+        let old_key = test_key();
+        let new_key = test_key();
+        let result = rotate_config_keys("", &old_key, &new_key);
+        assert_eq!(result.rotated_count, 0);
+        assert_eq!(result.skipped_count, 0);
+        assert!(result.errors.is_empty());
+        assert_eq!(result.new_content, "");
+    }
+
+    #[test]
+    fn test_rotate_config_keys_mixed_keys() {
+        let old_key = test_key();
+        let mut other_key_bytes = [0u8; KEY_LEN];
+        other_key_bytes[0] = 0xAA;
+        let other_key = EncryptionKey::new(other_key_bytes);
+        let mut new_key_bytes = [0u8; KEY_LEN];
+        new_key_bytes[0] = 0xFF;
+        let new_key = EncryptionKey::new(new_key_bytes);
+
+        let enc_old = encrypt_value(&old_key, "secret-old").unwrap();
+        let enc_other = encrypt_value(&other_key, "secret-other").unwrap();
+
+        let content = format!("a = \"{}\"\nb = \"{}\"\n", enc_old, enc_other);
+        let result = rotate_config_keys(&content, &old_key, &new_key);
+        assert_eq!(result.rotated_count, 1);
+        assert_eq!(result.skipped_count, 1);
+        assert_eq!(result.errors.len(), 1);
+
+        assert!(result.new_content.contains(&enc_other));
+        assert!(!result.new_content.contains(&enc_old));
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_env_empty_var_name() {
+        let result = resolve_key_from_source("env:");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_key_from_source_base64_wrong_length() {
+        let short = BASE64.encode(&[0u8; 16]);
+        let result = resolve_key_from_source(&short);
         assert!(result.is_err());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,6 +196,21 @@ enum Commands {
     },
     /// 暗号化鍵を生成する
     GenerateKey,
+    /// 暗号化鍵をローテーションする（既存の暗号化値を新しい鍵で再暗号化）
+    RotateKey {
+        /// 旧鍵のソース（env:変数名、ファイルパス、またはBase64文字列）
+        #[arg(long, value_name = "SOURCE")]
+        old_key: String,
+        /// 新鍵のソース（env:変数名、ファイルパス、またはBase64文字列）
+        #[arg(long, value_name = "SOURCE")]
+        new_key: String,
+        /// 実際の書き換えを行わずプレビューのみ表示
+        #[arg(long)]
+        dry_run: bool,
+        /// 書き換え前にバックアップファイルを作成する
+        #[arg(long)]
+        backup: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1021,6 +1036,127 @@ fn run_generate_key() {
     eprintln!("#   key_file = \"/etc/zettai-mamorukun/encryption.key\"");
 }
 
+fn run_rotate_key(
+    config_path: &Path,
+    old_key_src: &str,
+    new_key_src: &str,
+    dry_run: bool,
+    backup: bool,
+) {
+    use zettai_mamorukun::encryption::{resolve_key_from_source, rotate_config_keys};
+
+    let old_key = match resolve_key_from_source(old_key_src) {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("エラー: 旧鍵の読み込みに失敗しました: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let new_key = match resolve_key_from_source(new_key_src) {
+        Ok(k) => k,
+        Err(e) => {
+            eprintln!("エラー: 新鍵の読み込みに失敗しました: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let content = match std::fs::read_to_string(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "エラー: 設定ファイルの読み込みに失敗しました ({}): {}",
+                config_path.display(),
+                e
+            );
+            process::exit(1);
+        }
+    };
+
+    let result = rotate_config_keys(&content, &old_key, &new_key);
+
+    if result.rotated_count == 0 && result.skipped_count == 0 {
+        eprintln!("暗号化された値が見つかりませんでした。");
+        return;
+    }
+
+    if dry_run {
+        eprintln!("--- ドライラン（実際の書き込みは行いません） ---");
+        eprintln!(
+            "ローテーション対象: {} 件、スキップ: {} 件",
+            result.rotated_count, result.skipped_count
+        );
+        for err in &result.errors {
+            eprintln!("  警告: {}", err);
+        }
+        eprintln!("--- プレビュー ---");
+        print!("{}", result.new_content);
+        return;
+    }
+
+    if backup {
+        let timestamp = {
+            let dur = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default();
+            dur.as_secs()
+        };
+        let backup_path = format!("{}.bak.{}", config_path.display(), timestamp);
+        if let Err(e) = std::fs::copy(config_path, &backup_path) {
+            eprintln!("エラー: バックアップの作成に失敗しました: {}", e);
+            process::exit(1);
+        }
+        eprintln!("バックアップを作成しました: {}", backup_path);
+    }
+
+    let dir = config_path.parent();
+    let tmp_path = match dir {
+        Some(d) => d.join(".config.toml.rotate.tmp"),
+        None => PathBuf::from(".config.toml.rotate.tmp"),
+    };
+
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = match OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&tmp_path)
+        {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("エラー: 一時ファイルの書き込みに失敗しました: {}", e);
+                process::exit(1);
+            }
+        };
+        if let Err(e) = f.write_all(result.new_content.as_bytes()) {
+            eprintln!("エラー: 一時ファイルの書き込みに失敗しました: {}", e);
+            let _ = std::fs::remove_file(&tmp_path);
+            process::exit(1);
+        }
+    }
+
+    if let Err(e) = std::fs::rename(&tmp_path, config_path) {
+        eprintln!("エラー: 設定ファイルの置き換えに失敗しました: {}", e);
+        let _ = std::fs::remove_file(&tmp_path);
+        process::exit(1);
+    }
+
+    eprintln!("鍵ローテーションが完了しました。");
+    eprintln!(
+        "  成功: {} 件、スキップ: {} 件、エラー: {} 件",
+        result.rotated_count,
+        result.skipped_count,
+        result.errors.len()
+    );
+    for err in &result.errors {
+        eprintln!("  警告: {}", err);
+    }
+}
+
 fn run_archive_command(config_path: &Path, action: &ArchiveAction) {
     let config = AppConfig::load(config_path).ok();
     let default_config = zettai_mamorukun::config::EventStoreConfig::default();
@@ -1439,6 +1575,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Some(Commands::GenerateKey) => {
             run_generate_key();
+            return Ok(());
+        }
+        Some(Commands::RotateKey {
+            old_key,
+            new_key,
+            dry_run,
+            backup,
+        }) => {
+            run_rotate_key(&cli.config, old_key, new_key, *dry_run, *backup);
             return Ok(());
         }
         Some(Commands::HashToken { token }) => {


### PR DESCRIPTION
## Summary

Closes #290

- 設定ファイル内の全 `ENC[...]` 暗号化値を旧鍵で復号し、新鍵で再暗号化する `rotate-key` CLI コマンドを追加
- `--old-key` / `--new-key` オプションで鍵ソースを指定（`env:変数名`、ファイルパス、Base64 直接指定の3形式に対応）
- `--dry-run` で実際の書き換えなしにプレビュー表示
- `--backup` で書き換え前にバックアップファイル（`.bak.{timestamp}`）を自動作成
- 一時ファイル → `rename` によるアトミック書き換え（パーミッション 0600）
- 復号失敗した値はスキップして続行し、サマリーで成功数・スキップ数・エラー数を表示

## 変更ファイル

- `src/encryption.rs` — `resolve_key_from_source`, `RotateResult`, `rotate_config_keys` を追加、テスト11件追加
- `src/main.rs` — `Commands::RotateKey` バリアント、`run_rotate_key` 関数を追加
- `CLAUDE.md` — Encryption コンポーネント説明に `rotate-key` を追記
- `config.example.toml` — 鍵ローテーションの使用例コメントを追加

## Test plan

- [x] `cargo test -- --test-threads=1` 全テスト通過
- [x] `cargo clippy -- -D warnings` 警告なし
- [x] `cargo fmt --check` フォーマット済み
- [x] `cargo test --test integration_test` 統合テスト通過
- [x] セキュリティレビュー済み（一時ファイルパーミッション 0600、メモリゼロクリア確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)