### PR TITLE
feat: CLI 自動補完スクリプト生成（completions サブコマンド） (#292)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,6 +3275,7 @@ dependencies = [
  "aes-gcm",
  "base64",
  "clap",
+ "clap_complete",
  "crossterm",
  "csv",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 aes-gcm = "0.10"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 serde = { version = "1", features = ["derive"] }
 sha1 = "0.10"
 sha2 = "0.10"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::{Shell, generate};
 use std::io::{self, BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process;
@@ -196,6 +197,12 @@ enum Commands {
     },
     /// 暗号化鍵を生成する
     GenerateKey,
+    /// シェル補完スクリプトを生成する
+    Completions {
+        /// 対象シェル (bash, zsh, fish, elvish, powershell)
+        #[arg(value_enum)]
+        shell: Shell,
+    },
     /// 暗号化鍵をローテーションする（既存の暗号化値を新しい鍵で再暗号化）
     RotateKey {
         /// 旧鍵のソース（env:変数名、ファイルパス、またはBase64文字列）
@@ -1586,6 +1593,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             run_rotate_key(&cli.config, old_key, new_key, *dry_run, *backup);
             return Ok(());
         }
+        Some(Commands::Completions { shell }) => {
+            let mut cmd = Cli::command();
+            generate(*shell, &mut cmd, "zettai-mamorukun", &mut std::io::stdout());
+            return Ok(());
+        }
         Some(Commands::HashToken { token }) => {
             let token_str = match token {
                 Some(t) => t.clone(),
@@ -1779,5 +1791,47 @@ mod tests {
         let record = rdr.records().next().unwrap().unwrap();
         assert!(record[4].contains("カンマ,を含む"));
         assert!(record[5].contains("commas"));
+    }
+
+    #[test]
+    fn test_completions_bash() {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        generate(Shell::Bash, &mut cmd, "zettai-mamorukun", &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(
+            output.contains("complete"),
+            "bash completion should contain 'complete'"
+        );
+        assert!(
+            output.contains("zettai-mamorukun"),
+            "bash completion should contain binary name"
+        );
+    }
+
+    #[test]
+    fn test_completions_zsh() {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        generate(Shell::Zsh, &mut cmd, "zettai-mamorukun", &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(!output.is_empty(), "zsh completion should not be empty");
+        assert!(
+            output.contains("zettai-mamorukun"),
+            "zsh completion should contain binary name"
+        );
+    }
+
+    #[test]
+    fn test_completions_fish() {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        generate(Shell::Fish, &mut cmd, "zettai-mamorukun", &mut buf);
+        let output = String::from_utf8(buf).unwrap();
+        assert!(!output.is_empty(), "fish completion should not be empty");
+        assert!(
+            output.contains("zettai-mamorukun"),
+            "fish completion should contain binary name"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- `completions` サブコマンドを追加し、bash/zsh/fish/elvish/powershell 向けのシェル補完スクリプトを生成可能にした
- `clap_complete` クレートを使用し、clap の定義から自動的に補完スクリプトを生成
- bash/zsh/fish の補完スクリプト生成テストを追加

## 使い方

```bash
# bash
zettai-mamorukun completions bash > /etc/bash_completion.d/zettai-mamorukun

# zsh
zettai-mamorukun completions zsh > /usr/local/share/zsh/site-functions/_zettai-mamorukun

# fish
zettai-mamorukun completions fish > ~/.config/fish/completions/zettai-mamorukun.fish
```

## Test plan

- [x] `cargo test test_completions` — 3 テスト（bash/zsh/fish）全て OK
- [x] `cargo clippy -- -D warnings` — OK
- [x] `cargo fmt --check` — OK

Closes #292