### PR TITLE
feat: モジュール実行統計機能の実装 (#298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,9 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 - **Event Bus**: `SecurityEvent` を `tokio::sync::broadcast` で各モジュールからサブスクライバーへ伝達。ログサブスクライバーが全イベントを構造化ログに記録
 - **Action Engine**: 検知イベントに対するアクション（ログ・コマンド実行・Webhook 送信）を設定ベースで実行。イベントバスのサブスクライバーとして動作し、Severity やモジュール名に基づくルールマッチングでアクションを選択する
 - **Metrics Collector**: SecurityEvent の発生件数・種別・Severity を集計し、定期的にサマリーをログ出力する。イベントバスのサブスクライバーとして動作。`tokio::sync::watch` チャネルによるインターバルのホットリロードに対応
+- **Module Stats Collector**: モジュール単位で検知イベント数（Severity 別）と起動時スキャン結果（実行時間・スキャンアイテム数・検知問題数・サマリー）を集計する。MetricsCollector が全体統計を扱うのに対し、こちらはモジュール粒度でパフォーマンスボトルネックや不調モジュールの可視化を支援する。REST API（`/api/v1/stats/modules`、`/api/v1/stats/modules/{name}`）で取得可能。定期サマリーログ出力にも対応
 - **Prometheus Exporter**: MetricsCollector の集計データを Prometheus テキスト形式で HTTP エンドポイント（`/metrics`）から公開する。Grafana・Alertmanager 等の外部監視基盤と連携可能。`/health` エンドポイントでヘルスチェックも提供。TLS（HTTPS）対応により暗号化通信をサポート。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）
-- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧・制御、設定リロード、アーカイブ操作をリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。モジュール制御エンドポイント（`/api/v1/modules/{name}/start|stop|restart`）で個別モジュールの起動・停止・再起動が可能（admin ロール必須、dry_run 対応）。アーカイブエンドポイント（`/api/v1/archives`）でアーカイブ一覧取得・手動アーカイブ実行・復元・ローテーション・個別削除が可能（dry_run 対応、パストラバーサル防止）。イベント集約・サマリーエンドポイント（`/api/v1/events/summary/*`）で時間帯別・モジュール別・Severity別の集計データを提供。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）。ホットリロード対応
+- **REST API Server**: HTTP REST API でデーモンのステータス確認、イベント検索、モジュール一覧・制御、設定リロード、アーカイブ操作をリモートから操作可能にする。JSON レスポンス形式で `/api/v1/` プレフィックスのエンドポイントを提供。モジュール制御エンドポイント（`/api/v1/modules/{name}/start|stop|restart`）で個別モジュールの起動・停止・再起動が可能（admin ロール必須、dry_run 対応）。アーカイブエンドポイント（`/api/v1/archives`）でアーカイブ一覧取得・手動アーカイブ実行・復元・ローテーション・個別削除が可能（dry_run 対応、パストラバーサル防止）。イベント集約・サマリーエンドポイント（`/api/v1/events/summary/*`）で時間帯別・モジュール別・Severity別の集計データを提供。モジュール統計エンドポイント（`/api/v1/stats/modules`、`/api/v1/stats/modules/{name}`）でモジュール単位の検知数・起動時スキャン結果を取得可能。WebSocket によるリアルタイムイベントストリーミング（`/api/v1/events/stream`）に対応し、モジュール名・Severity でのフィルタリングが可能。OpenAPI 3.0.3 スキーマ（`/api/v1/openapi.json`）による API ドキュメント提供。TLS（HTTPS）対応により暗号化通信をサポート（rustls ベース、TLS 1.2 以上）。mTLS（相互TLS認証）によるクライアント証明書認証に対応（required/optional モード選択可能）。ホットリロード対応
 - **Syslog Forwarder**: SecurityEvent を RFC 5424 形式で外部 Syslog サーバ（SIEM 等）に転送する。UDP/TCP/TLS（RFC 5425）プロトコル対応。TLS 接続時はカスタム CA 証明書またはシステムルート証明書を使用。mTLS（相互TLS認証）によるクライアント証明書認証に対応。イベントバスのサブスクライバーとして動作し、設定ホットリロードに対応
 - **Event Store**: SecurityEvent を SQLite データベースに永続保存する。イベントバスのサブスクライバーとして動作し、バッチ挿入・自動クリーンアップ・設定ホットリロードに対応
 - **Encryption**: 設定ファイル内の機密値（Webhook URL、認証トークン等）を AES-256-GCM で暗号化・復号する。`ENC[...]` 形式で暗号化された値を設定読み込み時に自動復号。環境変数または鍵ファイルによる鍵管理。CLI コマンド（`encrypt-value`, `decrypt-value`, `generate-key`, `rotate-key`）を提供
@@ -91,6 +92,7 @@ src/
     health.rs          # ヘルスチェック（ハートビート・メモリ監視）
     metrics.rs         # イベント統計・メトリクス収集
     module_manager.rs  # モジュールマネージャー（モジュール一括管理・設定ホットリロード）
+    module_stats.rs    # モジュール実行統計（モジュール単位の検知数・起動時スキャン結果集計）
     openapi.rs         # OpenAPI 3.0.3 スキーマ生成
     prometheus.rs      # Prometheus メトリクスエクスポーター（HTTP エンドポイント）
     scan_diff.rs       # スキャン状態差分レポート（CLI scan-diff コマンド）

--- a/config.example.toml
+++ b/config.example.toml
@@ -655,6 +655,14 @@ enabled = false
 # サマリーログ出力インターバル（秒）
 interval_secs = 60
 
+[module_stats]
+# モジュール実行統計の有効/無効
+# モジュール単位で検知イベント数（Severity 別）と起動時スキャン結果を収集する。
+# 有効化すると REST API `/api/v1/stats/modules` で統計を取得できる。
+enabled = false
+# サマリーログ出力インターバル（秒）。0 で定期ログを無効化
+log_interval_secs = 300
+
 [event_bus]
 # イベントバスの有効/無効
 enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,10 @@ pub struct AppConfig {
     #[serde(default)]
     pub metrics: MetricsConfig,
 
+    /// モジュール実行統計設定
+    #[serde(default)]
+    pub module_stats: ModuleStatsConfig,
+
     /// ステータスサーバー設定
     #[serde(default)]
     pub status: StatusConfig,
@@ -3317,6 +3321,33 @@ impl Default for MetricsConfig {
         Self {
             enabled: false,
             interval_secs: Self::default_interval_secs(),
+        }
+    }
+}
+
+/// モジュール実行統計の設定
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct ModuleStatsConfig {
+    /// モジュール統計収集の有効/無効
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// サマリーログ出力インターバル（秒）。0 の場合は定期ログを出力しない
+    #[serde(default = "ModuleStatsConfig::default_log_interval_secs")]
+    pub log_interval_secs: u64,
+}
+
+impl ModuleStatsConfig {
+    fn default_log_interval_secs() -> u64 {
+        300
+    }
+}
+
+impl Default for ModuleStatsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            log_interval_secs: Self::default_log_interval_secs(),
         }
     }
 }

--- a/src/core/api.rs
+++ b/src/core/api.rs
@@ -259,6 +259,7 @@ pub struct ApiServer {
     archive_dir: Option<String>,
     archive_config: ArchiveApiConfig,
     shared_action_config: Arc<StdMutex<ActionConfig>>,
+    module_stats_handle: Option<crate::core::module_stats::ModuleStatsHandle>,
 }
 
 /// アーカイブ API 用の設定
@@ -460,6 +461,7 @@ impl ApiServer {
         shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>>,
         event_store_config: Option<&crate::config::EventStoreConfig>,
         action_config: &ActionConfig,
+        module_stats_handle: Option<crate::core::module_stats::ModuleStatsHandle>,
     ) -> Self {
         let rate_limiter = if config.rate_limit.enabled {
             Some(RateLimiter::new(&config.rate_limit))
@@ -543,6 +545,7 @@ impl ApiServer {
                     max_files: 0,
                 }),
             shared_action_config: Arc::new(StdMutex::new(action_config.clone())),
+            module_stats_handle,
         }
     }
 
@@ -595,6 +598,7 @@ impl ApiServer {
         let archive_dir = self.archive_dir;
         let archive_config = self.archive_config;
         let shared_action_config = self.shared_action_config;
+        let module_stats_handle = self.module_stats_handle;
 
         // クリーンアップタスク
         if self.rate_limit_config.enabled {
@@ -654,6 +658,7 @@ impl ApiServer {
                                 let arch_dir = archive_dir.clone();
                                 let arch_cfg = archive_config.clone();
                                 let act_cfg = Arc::clone(&shared_action_config);
+                                let ms_handle = module_stats_handle.clone();
                                 let tls_acc = tls_acceptor.clone();
                                 tokio::spawn(async move {
                                     let maybe_stream = if let Some(ref acceptor) = tls_acc {
@@ -672,7 +677,7 @@ impl ApiServer {
                                         started, &db_path, &cfg_path, &sender, &mc_sender, &toks,
                                         client_ip, &rl, &eb, &wsc, &wsc_count, &cors,
                                         oa_enabled, dps, mps, bms, mrbs, &scoring, &al,
-                                        &arch_dir, &arch_cfg, &act_cfg,
+                                        &arch_dir, &arch_cfg, &act_cfg, &ms_handle,
                                     ).await {
                                         tracing::debug!(error = %e, "API 接続の処理に失敗");
                                     }
@@ -757,7 +762,11 @@ impl ApiServer {
             | (HttpMethod::Get, "/api/v1/events/stream")
             | (HttpMethod::Get, "/api/v1/score")
             | (HttpMethod::Get, "/api/v1/archives")
+            | (HttpMethod::Get, "/api/v1/stats/modules")
             | (HttpMethod::Get, "/api/v1/webhooks") => Some(ApiRole::ReadOnly),
+            (HttpMethod::Get, p) if p.starts_with("/api/v1/stats/modules/") => {
+                Some(ApiRole::ReadOnly)
+            }
             (HttpMethod::Post, "/api/v1/reload") => Some(ApiRole::Admin),
             (HttpMethod::Post, "/api/v1/events/batch/delete") => Some(ApiRole::Admin),
             (HttpMethod::Post, "/api/v1/events/batch/export") => Some(ApiRole::ReadOnly),
@@ -868,6 +877,7 @@ impl ApiServer {
         archive_dir: &Option<String>,
         archive_config: &ArchiveApiConfig,
         shared_action_config: &Arc<StdMutex<ActionConfig>>,
+        module_stats_handle: &Option<crate::core::module_stats::ModuleStatsHandle>,
     ) -> Result<(), io::Error> {
         let request_start = Instant::now();
 
@@ -1217,6 +1227,107 @@ impl ApiServer {
                     .await?;
                 }
             },
+            (HttpMethod::Get, "/api/v1/stats/modules") => match module_stats_handle {
+                Some(handle) => {
+                    let stats = handle.snapshot();
+                    let body = serde_json::json!({
+                        "total": stats.len(),
+                        "modules": stats,
+                    })
+                    .to_string();
+                    resp_status = 200;
+                    resp_size = body.len() as u64;
+                    Self::send_json_response_with_headers(&mut stream, 200, "OK", &body, extra)
+                        .await?;
+                }
+                None => {
+                    let err_body = format!(
+                        r#"{{"error":"{}"}}"#,
+                        Self::escape_json_string("モジュール実行統計が無効です")
+                    );
+                    resp_status = 503;
+                    resp_size = err_body.len() as u64;
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        503,
+                        "Service Unavailable",
+                        &err_body,
+                        extra,
+                    )
+                    .await?;
+                }
+            },
+            (HttpMethod::Get, p) if p.starts_with("/api/v1/stats/modules/") => {
+                let module_name = &p["/api/v1/stats/modules/".len()..];
+                if module_name.is_empty() || module_name.contains('/') {
+                    let err_body = format!(
+                        r#"{{"error":"{}"}}"#,
+                        Self::escape_json_string("モジュール名が不正です")
+                    );
+                    resp_status = 400;
+                    resp_size = err_body.len() as u64;
+                    Self::send_error_with_headers(
+                        &mut stream,
+                        400,
+                        "Bad Request",
+                        &err_body,
+                        extra,
+                    )
+                    .await?;
+                } else {
+                    match module_stats_handle {
+                        Some(handle) => match handle.get(module_name) {
+                            Some(stats) => {
+                                let body = serde_json::to_string(&stats).unwrap_or_else(|_| {
+                                    r#"{"error":"serialize failed"}"#.to_string()
+                                });
+                                resp_status = 200;
+                                resp_size = body.len() as u64;
+                                Self::send_json_response_with_headers(
+                                    &mut stream,
+                                    200,
+                                    "OK",
+                                    &body,
+                                    extra,
+                                )
+                                .await?;
+                            }
+                            None => {
+                                let err_body = format!(
+                                    r#"{{"error":"モジュール '{}' が見つかりません"}}"#,
+                                    Self::escape_json_string(module_name)
+                                );
+                                resp_status = 404;
+                                resp_size = err_body.len() as u64;
+                                Self::send_error_with_headers(
+                                    &mut stream,
+                                    404,
+                                    "Not Found",
+                                    &err_body,
+                                    extra,
+                                )
+                                .await?;
+                            }
+                        },
+                        None => {
+                            let err_body = format!(
+                                r#"{{"error":"{}"}}"#,
+                                Self::escape_json_string("モジュール実行統計が無効です")
+                            );
+                            resp_status = 503;
+                            resp_size = err_body.len() as u64;
+                            Self::send_error_with_headers(
+                                &mut stream,
+                                503,
+                                "Service Unavailable",
+                                &err_body,
+                                extra,
+                            )
+                            .await?;
+                        }
+                    }
+                }
+            }
             (HttpMethod::Get, "/api/v1/score") => match shared_scoring {
                 Some(scoring) => {
                     let body = if let Ok(s) = scoring.lock() {
@@ -4292,6 +4403,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4362,6 +4474,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4432,6 +4545,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4497,6 +4611,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4563,6 +4678,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4625,6 +4741,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4687,6 +4804,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -4837,6 +4955,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -5023,6 +5142,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -5490,6 +5610,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -5725,6 +5846,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -5796,6 +5918,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -5866,6 +5989,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let server_cancel = server.cancel_token();
         let cancel_clone = cancel.clone();
@@ -5932,6 +6056,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -5995,6 +6120,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let cancel = server.cancel_token();
         server.spawn().unwrap();
@@ -6165,6 +6291,7 @@ mod tests {
             None,
             None,
             &ActionConfig::default(),
+            None,
         );
         let flag = server.access_log_flag();
         assert!(!flag.load(Ordering::Relaxed));
@@ -6947,5 +7074,183 @@ mod tests {
         let body = result.unwrap();
         assert!(body.contains("\"severities\""));
         assert!(body.contains("\"total\""));
+    }
+
+    #[tokio::test]
+    async fn test_api_server_stats_modules_endpoint() {
+        use crate::core::event::{SecurityEvent, Severity};
+        use crate::core::module_stats::ModuleStatsHandle;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let (reload_tx, _reload_rx) = mpsc::channel::<()>(1);
+        let config = ApiConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+            tokens: Vec::new(),
+            rate_limit: ApiRateLimitConfig::default(),
+            websocket: WebSocketConfig::default(),
+            cors: CorsConfig::default(),
+            openapi_enabled: true,
+            default_page_size: 50,
+            max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
+            access_log: false,
+            tls: crate::config::ApiTlsConfig::default(),
+        };
+
+        let stats = ModuleStatsHandle::new();
+        stats.ensure("file_integrity");
+        stats.record_event(&SecurityEvent::new(
+            "t",
+            Severity::Warning,
+            "file_integrity",
+            "msg",
+        ));
+        stats.record_initial_scan(
+            "file_integrity",
+            std::time::Duration::from_millis(42),
+            10,
+            1,
+            "10件中1件問題",
+        );
+
+        let server = ApiServer::new(
+            &config,
+            Arc::new(StdMutex::new(Vec::new())),
+            None,
+            Arc::new(StdMutex::new(HashMap::new())),
+            Instant::now(),
+            None,
+            None,
+            reload_tx,
+            mpsc::channel(8).0,
+            None,
+            None,
+            None,
+            &ActionConfig::default(),
+            Some(stats),
+        );
+        let cancel = server.cancel_token();
+        server.spawn().unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // /api/v1/stats/modules を取得
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /api/v1/stats/modules HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"total\":1"));
+        assert!(response.contains("\"module\":\"file_integrity\""));
+        assert!(response.contains("\"events_total\":1"));
+        assert!(response.contains("\"events_warning\":1"));
+        assert!(response.contains("\"initial_scan_duration_ms\":42"));
+
+        // 個別モジュール
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(
+                b"GET /api/v1/stats/modules/file_integrity HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 200 OK"));
+        assert!(response.contains("\"module\":\"file_integrity\""));
+        assert!(response.contains("\"initial_scan_items_scanned\":10"));
+
+        // 存在しないモジュール
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /api/v1/stats/modules/missing_mod HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 404 Not Found"));
+
+        cancel.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    #[tokio::test]
+    async fn test_api_server_stats_modules_disabled_returns_503() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let (reload_tx, _reload_rx) = mpsc::channel::<()>(1);
+        let config = ApiConfig {
+            enabled: true,
+            bind_address: "127.0.0.1".to_string(),
+            port,
+            tokens: Vec::new(),
+            rate_limit: ApiRateLimitConfig::default(),
+            websocket: WebSocketConfig::default(),
+            cors: CorsConfig::default(),
+            openapi_enabled: true,
+            default_page_size: 50,
+            max_page_size: 200,
+            batch_max_size: 1000,
+            max_request_body_size: 1_048_576,
+            access_log: false,
+            tls: crate::config::ApiTlsConfig::default(),
+        };
+
+        let server = ApiServer::new(
+            &config,
+            Arc::new(StdMutex::new(Vec::new())),
+            None,
+            Arc::new(StdMutex::new(HashMap::new())),
+            Instant::now(),
+            None,
+            None,
+            reload_tx,
+            mpsc::channel(8).0,
+            None,
+            None,
+            None,
+            &ActionConfig::default(),
+            None,
+        );
+        let cancel = server.cancel_token();
+        server.spawn().unwrap();
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        stream
+            .write_all(b"GET /api/v1/stats/modules HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        let response = String::from_utf8_lossy(&buf);
+        assert!(response.contains("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.contains("モジュール実行統計が無効です"));
+
+        cancel.cancel();
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/src/core/daemon.rs
+++ b/src/core/daemon.rs
@@ -10,6 +10,7 @@ use crate::core::event_stream::{EventStreamRuntimeConfig, EventStreamServer};
 use crate::core::health::HealthChecker;
 use crate::core::metrics::{MetricsCollector, SharedMetrics};
 use crate::core::module_manager::ModuleManager;
+use crate::core::module_stats::{self, ModuleStatsHandle};
 use crate::core::prometheus::PrometheusExporter;
 use crate::core::scan_state::{self, DiffKind};
 use crate::core::scoring::{ScoringRuntimeConfig, SecurityScorer, SharedSecurityScore};
@@ -53,6 +54,13 @@ impl Daemon {
         // ステータスサーバー用の共有状態
         let shared_module_names: Arc<StdMutex<Vec<String>>> = Arc::new(StdMutex::new(Vec::new()));
         let mut shared_metrics: Option<Arc<StdMutex<SharedMetrics>>> = None;
+        let module_stats_handle: Option<ModuleStatsHandle> = if self.config.module_stats.enabled {
+            let handle = ModuleStatsHandle::new();
+            handle.ensure_all(ModuleManager::known_module_names());
+            Some(handle)
+        } else {
+            None
+        };
         let mut shared_scoring: Option<Arc<StdMutex<SharedSecurityScore>>> = None;
         let mut scoring_config_sender: Option<watch::Sender<ScoringRuntimeConfig>> = None;
         let mut status_cancel_token: Option<CancellationToken> = None;
@@ -114,6 +122,16 @@ impl Daemon {
                 tracing::info!(
                     interval_secs = self.config.metrics.interval_secs,
                     "メトリクスコレクターを起動しました"
+                );
+            }
+
+            // モジュール実行統計コレクターの起動
+            if let Some(ref handle) = module_stats_handle {
+                module_stats::spawn_event_subscriber(handle.clone(), &bus);
+                module_stats::spawn_summary_logger(handle.clone(), &self.config.module_stats);
+                tracing::info!(
+                    log_interval_secs = self.config.module_stats.log_interval_secs,
+                    "モジュール実行統計コレクターを起動しました"
                 );
             }
 
@@ -279,6 +297,19 @@ impl Daemon {
             self.config.startup_scan.enabled,
         )
         .await;
+
+        // モジュール実行統計に起動時スキャン結果を記録
+        if let Some(ref handle) = module_stats_handle {
+            for (name, result) in &scan_report.results {
+                handle.record_initial_scan(
+                    name,
+                    result.duration,
+                    result.items_scanned,
+                    result.issues_found,
+                    &result.summary,
+                );
+            }
+        }
 
         // 起動時スキャンのサマリーイベントを発行
         if self.config.startup_scan.enabled
@@ -450,6 +481,7 @@ impl Daemon {
                 shared_scoring.clone(),
                 event_store_cfg,
                 &self.config.actions,
+                module_stats_handle.clone(),
             );
             api_cancel_token = Some(api_server.cancel_token());
             api_shared_action_config = Some(api_server.shared_action_config());
@@ -856,6 +888,7 @@ impl Daemon {
                                         shared_scoring.clone(),
                                         es_cfg_b,
                                         &new_config.actions,
+                                        module_stats_handle.clone(),
                                     );
                                     api_cancel_token = Some(api_server.cancel_token());
                                     api_shared_action_config =
@@ -899,6 +932,7 @@ impl Daemon {
                                         shared_scoring.clone(),
                                         es_cfg_c,
                                         &new_config.actions,
+                                        module_stats_handle.clone(),
                                     );
                                     api_cancel_token = Some(api_server.cancel_token());
                                     api_shared_action_config =
@@ -938,6 +972,7 @@ impl Daemon {
                                                 shared_scoring.clone(),
                                                 es_cfg_fb,
                                                 &self.config.actions,
+                                                module_stats_handle.clone(),
                                             );
                                             api_cancel_token =
                                                 Some(fallback.cancel_token());

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -11,6 +11,7 @@ pub mod event_stream;
 pub mod health;
 pub mod metrics;
 pub mod module_manager;
+pub mod module_stats;
 pub mod openapi;
 pub mod prometheus;
 pub mod scan_diff;

--- a/src/core/module_manager.rs
+++ b/src/core/module_manager.rs
@@ -699,6 +699,18 @@ impl ModuleManager {
         false
     }
 
+    /// 既知の全モジュール名を返す
+    pub fn known_module_names() -> Vec<&'static str> {
+        let mut names = Vec::new();
+        macro_rules! collect_names {
+            ($names:expr, $field:ident, $ModuleType:ty, $label:expr) => {
+                $names.push($label);
+            };
+        }
+        for_each_module!(collect_names!(names,));
+        names
+    }
+
     /// 指定モジュールが実行中かどうかを確認する
     pub fn is_module_running(&self, name: &str) -> bool {
         self.running_modules.iter().any(|m| m.name == name)

--- a/src/core/module_stats.rs
+++ b/src/core/module_stats.rs
@@ -1,0 +1,445 @@
+//! モジュール実行統計
+//!
+//! 各モジュールのスキャン実行時間、検知イベント数、初期スキャン結果を集計する。
+//! MetricsCollector が全体統計を扱うのに対し、こちらはモジュール単位の粒度で集計し、
+//! パフォーマンスボトルネックや不調モジュールの特定を支援する。
+
+use crate::config::ModuleStatsConfig;
+use crate::core::event::{EventBus, SecurityEvent, Severity};
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock as StdRwLock};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::broadcast;
+
+/// モジュール単位の統計情報
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ModuleStats {
+    /// モジュール名
+    pub module: String,
+    /// 検知された SecurityEvent の総数
+    pub events_total: u64,
+    /// INFO レベルの検知数
+    pub events_info: u64,
+    /// WARNING レベルの検知数
+    pub events_warning: u64,
+    /// CRITICAL レベルの検知数
+    pub events_critical: u64,
+    /// 直近の検知イベントのタイムスタンプ（RFC3339 UTC）
+    pub last_event_at: Option<String>,
+    /// 起動時スキャンの実行時間（ミリ秒）
+    pub initial_scan_duration_ms: Option<u64>,
+    /// 起動時スキャンでのアイテム数
+    pub initial_scan_items_scanned: Option<usize>,
+    /// 起動時スキャンで検知された問題数
+    pub initial_scan_issues_found: Option<usize>,
+    /// 起動時スキャンのサマリーメッセージ
+    pub initial_scan_summary: Option<String>,
+    /// 起動時スキャンを実行した時刻（RFC3339 UTC）
+    pub initial_scan_at: Option<String>,
+}
+
+/// モジュール統計レジストリ
+///
+/// 内部に `Arc<RwLock<HashMap<String, ModuleStats>>>` を持ち、Clone 可能なハンドルとして共有する。
+#[derive(Clone, Default)]
+pub struct ModuleStatsHandle {
+    inner: Arc<StdRwLock<HashMap<String, ModuleStats>>>,
+}
+
+impl ModuleStatsHandle {
+    /// 空のハンドルを作成する
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// モジュール名を事前登録する（未検知でも一覧に現れるようにする）
+    pub fn ensure(&self, module: &str) {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let mut guard = self.inner.write().unwrap();
+        guard
+            .entry(module.to_string())
+            .or_insert_with(|| ModuleStats {
+                module: module.to_string(),
+                ..Default::default()
+            });
+    }
+
+    /// 複数のモジュール名を一度に登録する
+    pub fn ensure_all<I, S>(&self, modules: I)
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let mut guard = self.inner.write().unwrap();
+        for m in modules {
+            let name = m.as_ref();
+            guard
+                .entry(name.to_string())
+                .or_insert_with(|| ModuleStats {
+                    module: name.to_string(),
+                    ..Default::default()
+                });
+        }
+    }
+
+    /// 起動時スキャン結果を記録する
+    pub fn record_initial_scan(
+        &self,
+        module: &str,
+        duration: Duration,
+        items: usize,
+        issues: usize,
+        summary: &str,
+    ) {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let mut guard = self.inner.write().unwrap();
+        let entry = guard
+            .entry(module.to_string())
+            .or_insert_with(|| ModuleStats {
+                module: module.to_string(),
+                ..Default::default()
+            });
+        entry.initial_scan_duration_ms = Some(duration.as_millis() as u64);
+        entry.initial_scan_items_scanned = Some(items);
+        entry.initial_scan_issues_found = Some(issues);
+        entry.initial_scan_summary = Some(summary.to_string());
+        entry.initial_scan_at = Some(current_rfc3339());
+    }
+
+    /// SecurityEvent を記録する（source_module 別の集計）
+    pub fn record_event(&self, event: &SecurityEvent) {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let mut guard = self.inner.write().unwrap();
+        let entry = guard
+            .entry(event.source_module.clone())
+            .or_insert_with(|| ModuleStats {
+                module: event.source_module.clone(),
+                ..Default::default()
+            });
+        entry.events_total = entry.events_total.saturating_add(1);
+        match event.severity {
+            Severity::Info => entry.events_info = entry.events_info.saturating_add(1),
+            Severity::Warning => entry.events_warning = entry.events_warning.saturating_add(1),
+            Severity::Critical => entry.events_critical = entry.events_critical.saturating_add(1),
+        }
+        entry.last_event_at = Some(current_rfc3339());
+    }
+
+    /// 指定モジュールの統計を取得する
+    pub fn get(&self, module: &str) -> Option<ModuleStats> {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let guard = self.inner.read().unwrap();
+        guard.get(module).cloned()
+    }
+
+    /// 全モジュールの統計をモジュール名でソートして返す
+    pub fn snapshot(&self) -> Vec<ModuleStats> {
+        // unwrap safety: RwLock が poisoned になるのはパニック時のみ
+        let guard = self.inner.read().unwrap();
+        let mut list: Vec<ModuleStats> = guard.values().cloned().collect();
+        list.sort_by(|a, b| a.module.cmp(&b.module));
+        list
+    }
+}
+
+/// 現在時刻を RFC3339 形式の文字列で返す（UTC 秒精度）
+fn current_rfc3339() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs() as i64;
+    format_rfc3339_utc(secs)
+}
+
+/// エポック秒を RFC3339 UTC 形式に変換する（外部依存なしの最小実装）
+fn format_rfc3339_utc(epoch_secs: i64) -> String {
+    const SECS_PER_DAY: i64 = 86_400;
+    let days = epoch_secs.div_euclid(SECS_PER_DAY);
+    let time_of_day = epoch_secs.rem_euclid(SECS_PER_DAY);
+    let hour = (time_of_day / 3600) as u32;
+    let minute = ((time_of_day % 3600) / 60) as u32;
+    let second = (time_of_day % 60) as u32;
+    let (year, month, day) = civil_from_days(days);
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, day, hour, minute, second
+    )
+}
+
+/// 1970-01-01 からの経過日数をカレンダー日付に変換する（Howard Hinnant's algorithm）
+fn civil_from_days(days: i64) -> (i32, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+    (y as i32, m, d)
+}
+
+/// EventBus サブスクライバーとして統計を集計するタスクを spawn する
+pub fn spawn_event_subscriber(handle: ModuleStatsHandle, bus: &EventBus) {
+    let mut receiver = bus.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match receiver.recv().await {
+                Ok(event) => handle.record_event(&event),
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(
+                        skipped = n,
+                        "モジュール統計: {} 件のイベントをスキップ（遅延）",
+                        n
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!(
+                        "イベントバスが閉じられました。モジュール統計サブスクライバーを終了します"
+                    );
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// 統計サマリーを定期的にログ出力するタスクを spawn する
+///
+/// `log_interval_secs` が 0 の場合は何もしない。
+pub fn spawn_summary_logger(handle: ModuleStatsHandle, config: &ModuleStatsConfig) {
+    if config.log_interval_secs == 0 {
+        return;
+    }
+    let interval = Duration::from_secs(config.log_interval_secs);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(interval);
+        ticker.tick().await; // 最初の即時 tick をスキップ
+        loop {
+            ticker.tick().await;
+            emit_summary(&handle);
+        }
+    });
+}
+
+fn emit_summary(handle: &ModuleStatsHandle) {
+    let stats = handle.snapshot();
+    if stats.is_empty() {
+        return;
+    }
+
+    let active: Vec<&ModuleStats> = stats.iter().filter(|s| s.events_total > 0).collect();
+    let total_events: u64 = stats.iter().map(|s| s.events_total).sum();
+    let active_modules = active.len();
+    let total_modules = stats.len();
+
+    tracing::info!(
+        total_modules = total_modules,
+        active_modules = active_modules,
+        total_events = total_events,
+        "[ModuleStatsSummary] 全モジュール: {}, 検知ありモジュール: {}, 合計イベント: {}",
+        total_modules,
+        active_modules,
+        total_events
+    );
+
+    if !active.is_empty() {
+        let counts: Vec<String> = active
+            .iter()
+            .map(|s| {
+                format!(
+                    "{}={}(I:{},W:{},C:{})",
+                    s.module, s.events_total, s.events_info, s.events_warning, s.events_critical
+                )
+            })
+            .collect();
+        tracing::info!(
+            modules = %counts.join(", "),
+            "[ModuleStatsSummary] モジュール別検知数"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_handle_ensure_and_snapshot() {
+        let handle = ModuleStatsHandle::new();
+        handle.ensure("file_integrity");
+        handle.ensure("process_monitor");
+        handle.ensure("file_integrity"); // duplicate is a no-op
+
+        let snap = handle.snapshot();
+        assert_eq!(snap.len(), 2);
+        assert_eq!(snap[0].module, "file_integrity");
+        assert_eq!(snap[1].module, "process_monitor");
+        assert_eq!(snap[0].events_total, 0);
+    }
+
+    #[test]
+    fn test_ensure_all() {
+        let handle = ModuleStatsHandle::new();
+        handle.ensure_all(["a", "b", "c"]);
+        let snap = handle.snapshot();
+        assert_eq!(snap.len(), 3);
+        assert_eq!(snap[0].module, "a");
+        assert_eq!(snap[2].module, "c");
+    }
+
+    #[test]
+    fn test_record_event_counts_by_severity() {
+        let handle = ModuleStatsHandle::new();
+        handle.record_event(&SecurityEvent::new(
+            "t",
+            Severity::Info,
+            "mod_a",
+            "info msg",
+        ));
+        handle.record_event(&SecurityEvent::new(
+            "t",
+            Severity::Warning,
+            "mod_a",
+            "warn msg",
+        ));
+        handle.record_event(&SecurityEvent::new(
+            "t",
+            Severity::Critical,
+            "mod_a",
+            "crit msg",
+        ));
+        handle.record_event(&SecurityEvent::new(
+            "t",
+            Severity::Warning,
+            "mod_b",
+            "warn msg",
+        ));
+
+        let a = handle.get("mod_a").expect("mod_a");
+        assert_eq!(a.events_total, 3);
+        assert_eq!(a.events_info, 1);
+        assert_eq!(a.events_warning, 1);
+        assert_eq!(a.events_critical, 1);
+        assert!(a.last_event_at.is_some());
+
+        let b = handle.get("mod_b").expect("mod_b");
+        assert_eq!(b.events_total, 1);
+        assert_eq!(b.events_warning, 1);
+    }
+
+    #[test]
+    fn test_record_initial_scan() {
+        let handle = ModuleStatsHandle::new();
+        handle.record_initial_scan(
+            "file_integrity",
+            Duration::from_millis(1234),
+            500,
+            3,
+            "500 ファイル, 3 問題",
+        );
+        let s = handle.get("file_integrity").expect("file_integrity");
+        assert_eq!(s.initial_scan_duration_ms, Some(1234));
+        assert_eq!(s.initial_scan_items_scanned, Some(500));
+        assert_eq!(s.initial_scan_issues_found, Some(3));
+        assert_eq!(
+            s.initial_scan_summary.as_deref(),
+            Some("500 ファイル, 3 問題")
+        );
+        assert!(s.initial_scan_at.is_some());
+    }
+
+    #[test]
+    fn test_snapshot_sorted() {
+        let handle = ModuleStatsHandle::new();
+        handle.ensure("zeta");
+        handle.ensure("alpha");
+        handle.ensure("mid");
+        let snap = handle.snapshot();
+        assert_eq!(snap[0].module, "alpha");
+        assert_eq!(snap[1].module, "mid");
+        assert_eq!(snap[2].module, "zeta");
+    }
+
+    #[test]
+    fn test_get_missing_returns_none() {
+        let handle = ModuleStatsHandle::new();
+        assert!(handle.get("unknown").is_none());
+    }
+
+    #[test]
+    fn test_concurrent_record_event() {
+        let handle = ModuleStatsHandle::new();
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let h = handle.clone();
+                std::thread::spawn(move || {
+                    for _ in 0..100 {
+                        h.record_event(&SecurityEvent::new("t", Severity::Info, "mod", "msg"));
+                    }
+                })
+            })
+            .collect();
+        for t in handles {
+            t.join().unwrap();
+        }
+        let s = handle.get("mod").expect("mod");
+        assert_eq!(s.events_total, 1000);
+        assert_eq!(s.events_info, 1000);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_event_subscriber() {
+        let bus = EventBus::new(16);
+        let handle = ModuleStatsHandle::new();
+        spawn_event_subscriber(handle.clone(), &bus);
+
+        bus.publish(SecurityEvent::new("t", Severity::Info, "sub_mod", "test"));
+        bus.publish(SecurityEvent::new(
+            "t",
+            Severity::Critical,
+            "sub_mod",
+            "test",
+        ));
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let s = handle.get("sub_mod").expect("sub_mod");
+        assert_eq!(s.events_total, 2);
+        assert_eq!(s.events_info, 1);
+        assert_eq!(s.events_critical, 1);
+    }
+
+    #[test]
+    fn test_format_rfc3339_utc_epoch() {
+        assert_eq!(format_rfc3339_utc(0), "1970-01-01T00:00:00Z");
+        assert_eq!(format_rfc3339_utc(1_700_000_000), "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
+    fn test_serialize_stats_json() {
+        let handle = ModuleStatsHandle::new();
+        handle.ensure("mod_a");
+        handle.record_event(&SecurityEvent::new("t", Severity::Warning, "mod_a", "msg"));
+        let s = handle.get("mod_a").expect("mod_a");
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"module\":\"mod_a\""));
+        assert!(json.contains("\"events_total\":1"));
+        assert!(json.contains("\"events_warning\":1"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_summary_logger_disabled_when_zero() {
+        let handle = ModuleStatsHandle::new();
+        // log_interval_secs = 0 のとき何も spawn しないことを確認（パニックしない）
+        let config = ModuleStatsConfig {
+            enabled: true,
+            log_interval_secs: 0,
+        };
+        spawn_summary_logger(handle, &config);
+    }
+}

--- a/src/core/openapi.rs
+++ b/src/core/openapi.rs
@@ -47,6 +47,8 @@ pub fn generate_openapi_schema() -> Value {
             "/api/v1/modules/{name}/start": module_start_path(),
             "/api/v1/modules/{name}/stop": module_stop_path(),
             "/api/v1/modules/{name}/restart": module_restart_path(),
+            "/api/v1/stats/modules": stats_modules_path(),
+            "/api/v1/stats/modules/{name}": stats_module_path(),
         },
         "components": {
             "securitySchemes": {
@@ -974,6 +976,93 @@ fn module_restart_path() -> Value {
     })
 }
 
+fn stats_modules_path() -> Value {
+    json!({
+        "get": {
+            "summary": "モジュール実行統計一覧",
+            "description": "全モジュールの実行統計（検知イベント数、起動時スキャン結果等）を返す。",
+            "operationId": "listModuleStats",
+            "tags": ["stats"],
+            "security": [{ "BearerAuth": [] }],
+            "responses": {
+                "200": {
+                    "description": "モジュール統計一覧",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "total": { "type": "integer", "example": 70 },
+                                    "modules": {
+                                        "type": "array",
+                                        "items": { "$ref": "#/components/schemas/ModuleStats" }
+                                    }
+                                },
+                                "required": ["total", "modules"]
+                            }
+                        }
+                    }
+                },
+                "503": {
+                    "description": "モジュール実行統計が無効です",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn stats_module_path() -> Value {
+    json!({
+        "get": {
+            "summary": "モジュール実行統計（個別）",
+            "description": "指定したモジュールの実行統計を返す。",
+            "operationId": "getModuleStats",
+            "tags": ["stats"],
+            "security": [{ "BearerAuth": [] }],
+            "parameters": [
+                {
+                    "name": "name",
+                    "in": "path",
+                    "description": "モジュール名",
+                    "required": true,
+                    "schema": { "type": "string" }
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "モジュール統計",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ModuleStats" }
+                        }
+                    }
+                },
+                "404": {
+                    "description": "モジュールが見つかりません",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                },
+                "503": {
+                    "description": "モジュール実行統計が無効です",
+                    "content": {
+                        "application/json": {
+                            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
 fn summary_common_params() -> Value {
     json!([
         {
@@ -1326,6 +1415,49 @@ fn component_schemas() -> Value {
                 }
             },
             "required": ["total_events", "info_count", "warning_count", "critical_count", "module_counts"]
+        },
+        "ModuleStats": {
+            "type": "object",
+            "properties": {
+                "module": { "type": "string", "description": "モジュール名" },
+                "events_total": { "type": "integer", "description": "検知イベント総数" },
+                "events_info": { "type": "integer", "description": "INFO レベル検知数" },
+                "events_warning": { "type": "integer", "description": "WARNING レベル検知数" },
+                "events_critical": { "type": "integer", "description": "CRITICAL レベル検知数" },
+                "last_event_at": {
+                    "type": "string",
+                    "nullable": true,
+                    "format": "date-time",
+                    "description": "直近の検知イベントタイムスタンプ（RFC3339 UTC）"
+                },
+                "initial_scan_duration_ms": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "起動時スキャンの実行時間（ミリ秒）"
+                },
+                "initial_scan_items_scanned": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "起動時スキャンでスキャンしたアイテム数"
+                },
+                "initial_scan_issues_found": {
+                    "type": "integer",
+                    "nullable": true,
+                    "description": "起動時スキャンで検知された問題数"
+                },
+                "initial_scan_summary": {
+                    "type": "string",
+                    "nullable": true,
+                    "description": "起動時スキャンのサマリーメッセージ"
+                },
+                "initial_scan_at": {
+                    "type": "string",
+                    "nullable": true,
+                    "format": "date-time",
+                    "description": "起動時スキャン実行時刻（RFC3339 UTC）"
+                }
+            },
+            "required": ["module", "events_total", "events_info", "events_warning", "events_critical"]
         },
         "ModulesResponse": {
             "type": "object",


### PR DESCRIPTION
## 概要

各モジュールのスキャン実行時間・検知イベント数を集計する **モジュール実行統計コレクター** を実装した。MetricsCollector が全体統計を扱うのに対し、こちらはモジュール粒度で「特定モジュールだけ異常に遅い」「設定ミスでエラーを出し続けている」といった問題を可視化する。

Closes #298

## 変更内容

- **新規 `src/core/module_stats.rs`**
  - `ModuleStats`（モジュール名、検知イベント数 Severity 別、起動時スキャン結果、最終検知時刻）
  - `ModuleStatsHandle`（Clone 可能、内部に `Arc<RwLock<HashMap<String, ModuleStats>>>`）
  - `spawn_event_subscriber` — EventBus サブスクライバーで検知イベントを集計
  - `spawn_summary_logger` — 設定間隔で tracing INFO サマリー出力
- **`src/config.rs`**: `[module_stats]` セクション追加（`enabled` / `log_interval_secs`）
- **`src/core/daemon.rs`**: ハンドル構築 → 全モジュール事前登録 → サブスクライバー起動 → initial_scan 結果記録 → ApiServer に注入
- **`src/core/api.rs`**:
  - `GET /api/v1/stats/modules` — 全モジュール統計（ReadOnly）
  - `GET /api/v1/stats/modules/{name}` — 個別モジュール統計（ReadOnly、404/503 対応）
- **`src/core/openapi.rs`**: `ModuleStats` コンポーネントスキーマと 2 パス追加
- **`src/core/module_manager.rs`**: `known_module_names()` を追加し、検知ゼロのモジュールも一覧に出るように事前登録に活用
- **ドキュメント**: CLAUDE.md（主要コンポーネント・ディレクトリ構成）、config.example.toml に項目追加

## テスト結果

- 単体テスト 11 件追加（基本操作、Severity 別カウント、並行更新、サブスクライバー、シリアライズ、フォーマッタ等）
- REST API 統合テスト 2 件追加（200 / 404 / 503）
- `cargo test --lib`: 2238 passed
- `cargo test --test integration_test`: 38 passed
- `cargo fmt --check`: clean
- `cargo clippy -- -D warnings`: clean

## Test plan

- [x] 単体テストが通る
- [x] REST API 統合テストが通る
- [x] 全テストスイートが通る
- [x] cargo fmt / clippy が通る
- [ ] デーモン起動 → `/api/v1/stats/modules` で初期登録モジュール一覧が取得できる（手動）
- [ ] 起動時スキャン後、initial_scan_* フィールドが埋まる（手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)