### PR TITLE
feat: Prometheus メトリクス可視化用の Grafana ダッシュボード例を追加 (#318)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.55.0"
+version = "1.56.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.55.0"
+version = "1.56.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Linux サーバ上でデーモンとして動作し（systemd で管理）、あ
 
 [Releases](https://github.com/turntuptechnologies-ai/zettai-mamorukun/releases) からバイナリをダウンロードしてください。
 
+## 観測性
+
+Prometheus エクスポーター（`/metrics`）が公開するモジュール統計メトリクスを可視化するための Grafana ダッシュボードを [`grafana/`](grafana/) に用意しています。詳細は [`grafana/README.md`](grafana/README.md) を参照してください。
+
 ## ビルド
 
 ```bash

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,88 @@
+# Grafana ダッシュボード
+
+zettai-mamorukun の Prometheus エクスポーター（`/metrics`）が公開するメトリクスを可視化するためのダッシュボード JSON を提供する。
+
+## 前提
+
+- Grafana 10.0 以降（`schemaVersion: 39`）
+- Prometheus データソースが追加済み
+- zettai-mamorukun で Prometheus エクスポーターが有効化済み（`config.example.toml` の `[prometheus]` セクション参照）
+
+## インポート方法
+
+Grafana の Web UI から:
+
+1. Dashboards → New → Import
+2. `zettai-mamorukun-overview.json` の内容を貼り付け、もしくはファイルをアップロード
+3. `DS_PROMETHEUS` に利用中の Prometheus データソースを選択
+4. Import を押下
+
+または `grafana-cli` / API 経由:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $GRAFANA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @<(jq '{dashboard: ., overwrite: true, inputs: [{name: "DS_PROMETHEUS", type: "datasource", pluginId: "prometheus", value: "prometheus"}]}' grafana/zettai-mamorukun-overview.json) \
+  https://grafana.example.com/api/dashboards/import
+```
+
+## ダッシュボード構成
+
+### 概観
+
+- **総イベント数** — `sum(zettai_events_total)`
+- **Info / Warning / Critical イベント** — `zettai_events_by_severity_total{severity=...}` の現在値
+
+### イベント
+
+- **Severity 別イベント流入レート** — `rate(zettai_events_by_severity_total[5m])` を Severity でスタック表示
+- **モジュール別イベント件数（Top 10）** — `topk(10, sum by (module) (zettai_module_events_total))`
+
+### スキャン所要時間
+
+- **P50/P95/P99** — `zettai_module_scan_duration_seconds{quantile=...}` をモジュール別に時系列表示
+- **平均スキャン所要時間** — `rate(..._sum[5m]) / rate(..._count[5m])`
+- **スキャン実行レート** — `rate(zettai_module_scan_duration_seconds_count[5m])`
+
+### 起動時スキャン
+
+- **所要時間** — `zettai_module_initial_scan_duration_seconds`
+- **アイテム数** — `zettai_module_initial_scan_items_scanned`
+- **検知問題数** — `zettai_module_initial_scan_issues_found`（0 / 1+ / 5+ で色分け）
+
+## テンプレート変数
+
+| 変数名 | 説明 | クエリ |
+|--------|------|--------|
+| `DS_PROMETHEUS` | Prometheus データソース | — |
+| `instance` | 対象ホスト（複数選択可） | `label_values(zettai_events_total, instance)` |
+| `module` | 対象モジュール（複数選択可） | `label_values(zettai_module_scan_duration_seconds{instance=~"$instance"}, module)` |
+
+## 参照メトリクス一覧
+
+| メトリクス | 種類 | ラベル | 説明 |
+|-----------|------|--------|------|
+| `zettai_events_total` | counter | — | 全 SecurityEvent の総数 |
+| `zettai_events_by_severity_total` | counter | `severity` | Severity 別イベント数 |
+| `zettai_events_by_module_total` | counter | `module` | モジュール別イベント数 |
+| `zettai_module_events_total` | counter | `module` | モジュール単位の検知総数 |
+| `zettai_module_events_by_severity_total` | counter | `module`, `severity` | モジュール × Severity 別検知数 |
+| `zettai_module_initial_scan_duration_seconds` | gauge | `module` | 起動時スキャン実行時間（秒） |
+| `zettai_module_initial_scan_items_scanned` | gauge | `module` | 起動時スキャンのアイテム数 |
+| `zettai_module_initial_scan_issues_found` | gauge | `module` | 起動時スキャンで検知した問題数 |
+| `zettai_module_scan_duration_seconds` | summary | `module`, `quantile` | 定期スキャン実行時間 P50/P95/P99（最新 1024 サンプル） |
+| `zettai_module_scan_duration_seconds_count` | counter | `module` | スキャン実行回数（summary のカウンタ部） |
+| `zettai_module_scan_duration_seconds_sum` | counter | `module` | スキャン実行時間の累積（summary のサム部） |
+
+## カスタマイズのヒント
+
+- **モジュールのフィルタ**: テンプレート変数 `module` で複数モジュールを絞り込むと、対象パネル（P50/P95/P99、平均、実行レート）が連動する
+- **アラート連携**: `zettai_events_by_severity_total{severity="critical"}` の増分で Alertmanager にアラートを飛ばすことを推奨
+- **複数インスタンス**: `instance` 変数でインスタンス別の集計・比較が可能
+
+## トラブルシューティング
+
+- **パネルが空**: Prometheus データソースで `up{job="..."}` を確認し、スクレイプが成功しているか確認
+- **起動時スキャン系のパネルが空**: そのモジュールが `initial_scan` を実装していない、もしくは起動直後の値が揮発している可能性あり
+- **P50/P95/P99 が表示されない**: 対象モジュールの `set_module_stats` 連携が未実装の可能性（CLAUDE.md の「Module Stats Collector」節参照）

--- a/grafana/zettai-mamorukun-overview.json
+++ b/grafana/zettai-mamorukun-overview.json
@@ -1,0 +1,622 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "zettai-mamorukun Prometheus エクスポーター（/metrics）が公開するモジュール統計・スキャン性能メトリクスの概観ダッシュボード。",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "概観",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(zettai_events_total{instance=~\"$instance\"})",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "title": "総イベント数",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"fixedColor": "blue", "mode": "fixed"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(zettai_events_by_severity_total{instance=~\"$instance\",severity=\"info\"})",
+          "legendFormat": "info",
+          "refId": "A"
+        }
+      ],
+      "title": "Info イベント",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"fixedColor": "orange", "mode": "fixed"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "orange", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(zettai_events_by_severity_total{instance=~\"$instance\",severity=\"warning\"})",
+          "legendFormat": "warning",
+          "refId": "A"
+        }
+      ],
+      "title": "Warning イベント",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"fixedColor": "red", "mode": "fixed"},
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum(zettai_events_by_severity_total{instance=~\"$instance\",severity=\"critical\"})",
+          "legendFormat": "critical",
+          "refId": "A"
+        }
+      ],
+      "title": "Critical イベント",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+      "id": 101,
+      "panels": [],
+      "title": "イベント",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "opacity",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "normal"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 6},
+      "id": 10,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "sum by (severity) (rate(zettai_events_by_severity_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{severity}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Severity 別イベント流入レート",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "continuous-GrYlRd"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]}
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 6},
+      "id": 11,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "topk(10, sum by (module) (zettai_module_events_total{instance=~\"$instance\"}))",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "モジュール別イベント件数（Top 10）",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 15},
+      "id": 102,
+      "panels": [],
+      "title": "スキャン所要時間",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": {"group": "A", "mode": "none"}
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 16},
+      "id": 20,
+      "options": {
+        "legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_scan_duration_seconds{instance=~\"$instance\",module=~\"$module\",quantile=\"0.5\"}",
+          "legendFormat": "{{module}} p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_scan_duration_seconds{instance=~\"$instance\",module=~\"$module\",quantile=\"0.95\"}",
+          "legendFormat": "{{module}} p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_scan_duration_seconds{instance=~\"$instance\",module=~\"$module\",quantile=\"0.99\"}",
+          "legendFormat": "{{module}} p99",
+          "refId": "C"
+        }
+      ],
+      "title": "モジュール別スキャン所要時間 P50/P95/P99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 26},
+      "id": 21,
+      "options": {
+        "legend": {"calcs": ["mean"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(zettai_module_scan_duration_seconds_sum{instance=~\"$instance\",module=~\"$module\"}[5m]) / clamp_min(rate(zettai_module_scan_duration_seconds_count{instance=~\"$instance\",module=~\"$module\"}[5m]), 1e-9)",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "平均スキャン所要時間（sum/count, 5m）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisLabel": "samples/s",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "showPoints": "never"
+          },
+          "mappings": [],
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 26},
+      "id": 22,
+      "options": {
+        "legend": {"calcs": ["mean"], "displayMode": "list", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "rate(zettai_module_scan_duration_seconds_count{instance=~\"$instance\",module=~\"$module\"}[5m])",
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "スキャン実行レート",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 35},
+      "id": 103,
+      "panels": [],
+      "title": "起動時スキャン",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "axisLabel": "seconds",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 8, "x": 0, "y": 36},
+      "id": 30,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {"mode": "single", "sort": "none"},
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_initial_scan_duration_seconds{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "起動時スキャン所要時間",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true, "__name__": true, "instance": true, "job": true},
+            "indexByName": {},
+            "renameByName": {"Value": "seconds"}
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "axisLabel": "items",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 8, "x": 8, "y": 36},
+      "id": 31,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "groupWidth": 0.7,
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {"mode": "single", "sort": "none"},
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_initial_scan_items_scanned{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "起動時スキャンアイテム数",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true, "__name__": true, "instance": true, "job": true},
+            "renameByName": {"Value": "items"}
+          }
+        }
+      ],
+      "type": "barchart"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "axisLabel": "issues",
+            "fillOpacity": 80,
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 1},
+              {"color": "red", "value": 5}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 9, "w": 8, "x": 16, "y": 36},
+      "id": 32,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.8,
+        "groupWidth": 0.7,
+        "legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false},
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": {"mode": "single", "sort": "none"},
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "10.4.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+          "expr": "zettai_module_initial_scan_issues_found{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{module}}",
+          "refId": "A"
+        }
+      ],
+      "title": "起動時スキャン検知問題数",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true, "__name__": true, "instance": true, "job": true},
+            "renameByName": {"Value": "issues"}
+          }
+        }
+      ],
+      "type": "barchart"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["zettai-mamorukun", "security", "prometheus"],
+  "templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(zettai_events_total, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {"query": "label_values(zettai_events_total, instance)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {"selected": false, "text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(zettai_module_scan_duration_seconds{instance=~\"$instance\"}, module)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Module",
+        "multi": true,
+        "name": "module",
+        "options": [],
+        "query": {"query": "label_values(zettai_module_scan_duration_seconds{instance=~\"$instance\"}, module)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "zettai-mamorukun — 概観",
+  "uid": "zettai-mamorukun-overview",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## 概要

- `grafana/zettai-mamorukun-overview.json`: Grafana v10 以降で使えるダッシュボード JSON（16 パネル / 4 行構成 / テンプレ変数 3）
- `grafana/README.md`: インポート手順・参照メトリクス一覧・カスタマイズ方法
- `README.md`: 観測性セクションで `grafana/` ディレクトリへのリンクを追加

## 構成

| 行 | 内容 |
|----|------|
| 概観 | 総イベント数 / Info / Warning / Critical の Stat |
| イベント | Severity 別流入レート時系列 + モジュール Top 10 バーゲージ |
| スキャン所要時間 | P50/P95/P99 時系列 + 平均 (sum/count) + 実行レート |
| 起動時スキャン | 所要時間 / アイテム数 / 検知問題数のバーチャート |

## 参照メトリクス

- `zettai_events_total`, `zettai_events_by_severity_total`, `zettai_events_by_module_total`
- `zettai_module_events_total`, `zettai_module_events_by_severity_total`
- `zettai_module_initial_scan_{duration_seconds,items_scanned,issues_found}`
- `zettai_module_scan_duration_seconds{quantile="0.5|0.95|0.99"}` + `_count` / `_sum`

## Test plan

- [x] JSON パース検証（`python3 -c "import json; json.load(...)"` で OK）
- [x] `schemaVersion: 39` （Grafana v10 形式）を確認
- [x] パネル数 16、テンプレート変数 `DS_PROMETHEUS` / `instance` / `module` を確認
- [ ] 実際の Grafana 環境でのインポート検証（今回は無し — 参考用ダッシュボード）

Closes #318