### PR TITLE
test: Grafana アラートルールの promtool ユニットテストを追加 (#324)

### DIFF
--- a/grafana/alerts/README.md
+++ b/grafana/alerts/README.md
@@ -86,7 +86,74 @@ spec:
 promtool check rules grafana/alerts/prometheus_alerts.yaml
 ```
 
-単体テスト用のユニットテストを書く場合は `promtool test rules` を活用可能。
+## ユニットテスト
+
+`grafana/alerts/tests/` に promtool 用のユニットテスト (`*_test.yaml`) を収録している。
+10 個のアラートそれぞれについて、発火ケースと非発火ケースを最低 2 件ずつ検証する。
+
+| テストファイル | 対象グループ | アラート数 |
+|----------------|--------------|-----------|
+| `events_test.yaml` | `zettai-mamorukun.events` | 3 |
+| `scans_test.yaml` | `zettai-mamorukun.scans` | 5 |
+| `availability_test.yaml` | `zettai-mamorukun.availability` | 2 |
+
+ローカル実行:
+
+```bash
+# promtool を入手していない場合は Prometheus リリースから取得
+# https://github.com/prometheus/prometheus/releases
+
+promtool test rules grafana/alerts/tests/*.yaml
+```
+
+全テストが `SUCCESS` になることを確認する。
+
+各テストは以下をカバーする:
+
+- **発火ケース**: `for` 期間を超えた時刻でアラートが発火すること、およびラベル・アノテーションが期待値と一致すること
+- **非発火ケース**: 閾値未満の入力、あるいは `for` 期間経過前の時刻でアラートが発火しないこと
+- **ラベル条件**: `ZettaiExporterDown` の `job=~".*zettai.*"` のような正規表現マッチの分岐確認
+
+### CI への組み込み例
+
+GitHub Actions で自動検証する場合のワークフロー例を示す。
+`.github/workflows/promtool.yaml` として配置すれば、`grafana/alerts/**` の変更があった
+push / PR で自動実行される。
+
+```yaml
+name: promtool
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'grafana/alerts/**'
+      - '.github/workflows/promtool.yaml'
+  pull_request:
+    paths:
+      - 'grafana/alerts/**'
+      - '.github/workflows/promtool.yaml'
+
+jobs:
+  promtool:
+    runs-on: ubuntu-latest
+    env:
+      PROMETHEUS_VERSION: 2.55.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: promtool をダウンロード
+        run: |
+          set -euo pipefail
+          curl -sSL -o prometheus.tar.gz \
+            "https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz"
+          tar -xzf prometheus.tar.gz "prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool"
+          sudo install -m 0755 "prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool" /usr/local/bin/promtool
+          promtool --version
+      - name: アラートルールの静的検証
+        run: promtool check rules grafana/alerts/prometheus_alerts.yaml
+      - name: アラートルールのユニットテスト
+        run: promtool test rules grafana/alerts/tests/*.yaml
+```
 
 ## カスタマイズのヒント
 

--- a/grafana/alerts/tests/availability_test.yaml
+++ b/grafana/alerts/tests/availability_test.yaml
@@ -1,0 +1,104 @@
+# promtool 用ユニットテスト: zettai-mamorukun.availability グループ
+#
+# 対象アラート:
+#   - ZettaiExporterDown         (発火 / 非発火)
+#   - ZettaiNoEventsReceived     (発火 / 非発火)
+#
+# 実行:
+#   promtool test rules grafana/alerts/tests/availability_test.yaml
+---
+rule_files:
+  - ../prometheus_alerts.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # --------------------------------------------------------------------------
+  # ZettaiExporterDown: up == 0 を 2 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 30s
+    name: ZettaiExporterDown が up==0 で発火する
+    input_series:
+      - series: 'up{job="zettai-mamorukun-exporter",instance="host1"}'
+        values: '0x20'
+    alert_rule_test:
+      # for (2m) 経過前は発火しない
+      - eval_time: 1m
+        alertname: ZettaiExporterDown
+        exp_alerts: []
+      # for (2m) を超えて発火
+      - eval_time: 5m
+        alertname: ZettaiExporterDown
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: zettai-mamorukun
+              instance: host1
+              job: zettai-mamorukun-exporter
+            exp_annotations:
+              summary: "zettai-mamorukun エクスポーターがダウン (instance=host1)"
+              description: |
+                Prometheus スクレイプが 2 分間失敗しています。
+                デーモン停止・ネットワーク障害・TLS 証明書エラー等の可能性があります。
+
+  - interval: 30s
+    name: ZettaiExporterDown は up==1 では発火しない
+    input_series:
+      - series: 'up{job="zettai-mamorukun-exporter",instance="host1"}'
+        values: '1x20'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ZettaiExporterDown
+        exp_alerts: []
+
+  - interval: 30s
+    name: ZettaiExporterDown は zettai を含まない job では発火しない
+    input_series:
+      # job 名に zettai を含まないためルールのセレクタにマッチしない
+      - series: 'up{job="node-exporter",instance="host1"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ZettaiExporterDown
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiNoEventsReceived: rate(total[30m])==0 かつ total>0 を 30 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiNoEventsReceived がイベント停止で発火
+    input_series:
+      # 最初 10 までカウントアップしたあと、以降ずっと 10 を 90 分維持
+      - series: 'zettai_events_total{instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '1 2 3 4 5 6 7 8 9 10 10x90'
+    alert_rule_test:
+      # 停止直後は rate ウィンドウ (30m) に古い増加が残るため rate != 0
+      - eval_time: 30m
+        alertname: ZettaiNoEventsReceived
+        exp_alerts: []
+      # 停止から 90 分経過 (rate==0 を 30m 維持後 for=30m 経過) で発火
+      - eval_time: 90m
+        alertname: ZettaiNoEventsReceived
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: zettai-mamorukun
+              instance: host1
+              job: zettai-mamorukun-exporter
+            exp_annotations:
+              summary: "イベントが 30 分間まったく発生していません"
+              description: |
+                過去 30 分間 SecurityEvent が 0 件です。
+                検知モジュールが正常動作しているか確認してください
+                （無音は平時の可能性もあるが、全モジュール停止の兆候の可能性もあり）。
+
+  - interval: 1m
+    name: ZettaiNoEventsReceived はイベント継続中では発火しない
+    input_series:
+      # 継続的に増加
+      - series: 'zettai_events_total{instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+1x90'
+    alert_rule_test:
+      - eval_time: 90m
+        alertname: ZettaiNoEventsReceived
+        exp_alerts: []

--- a/grafana/alerts/tests/events_test.yaml
+++ b/grafana/alerts/tests/events_test.yaml
@@ -1,0 +1,132 @@
+# promtool 用ユニットテスト: zettai-mamorukun.events グループ
+#
+# 対象アラート:
+#   - ZettaiCriticalEventSurge   (発火 / 非発火)
+#   - ZettaiWarningEventSurge    (発火 / 非発火)
+#   - ZettaiModuleEventSpike     (発火 / 非発火)
+#
+# 実行:
+#   promtool test rules grafana/alerts/tests/events_test.yaml
+---
+rule_files:
+  - ../prometheus_alerts.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # --------------------------------------------------------------------------
+  # ZettaiCriticalEventSurge: rate(...) > 0.05/sec を 5 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiCriticalEventSurge が高レートで発火する
+    input_series:
+      # 1 分あたり 10 件増加 = 0.1667/sec > 0.05
+      - series: 'zettai_events_by_severity_total{severity="critical",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+10x15'
+    alert_rule_test:
+      # 5 分の for 期間経過前は発火しない
+      - eval_time: 5m
+        alertname: ZettaiCriticalEventSurge
+        exp_alerts: []
+      # 10 分時点では for (5m) を超えて発火する
+      - eval_time: 12m
+        alertname: ZettaiCriticalEventSurge
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: zettai-mamorukun
+            exp_annotations:
+              summary: "Critical セキュリティイベントが急増しています (instance=)"
+              description: |
+                過去 5 分間の Critical イベント発生レートが 0.05/sec
+                （= 15 件/5 分）を超過しています。
+                攻撃の兆候か誤検知の可能性があるため、速やかにイベント詳細を確認してください。
+                現在値: 0.1667 events/sec
+
+  - interval: 1m
+    name: ZettaiCriticalEventSurge は低レートでは発火しない
+    input_series:
+      # 1 分あたり 1 件増加 = 0.0167/sec < 0.05
+      - series: 'zettai_events_by_severity_total{severity="critical",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+1x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: ZettaiCriticalEventSurge
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiWarningEventSurge: rate(...) > 0.5/sec を 10 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiWarningEventSurge が高レートで発火する
+    input_series:
+      # 1 分あたり 60 件増加 = 1/sec > 0.5
+      - series: 'zettai_events_by_severity_total{severity="warning",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+60x20'
+    alert_rule_test:
+      # for (10m) 経過前は発火しない
+      - eval_time: 10m
+        alertname: ZettaiWarningEventSurge
+        exp_alerts: []
+      # for (10m) を超えて発火
+      - eval_time: 18m
+        alertname: ZettaiWarningEventSurge
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: zettai-mamorukun
+            exp_annotations:
+              summary: "Warning セキュリティイベントが継続的に増加しています"
+              description: |
+                過去 5 分間の Warning イベント発生レートが 0.5/sec
+                （= 150 件/5 分）を 10 分間継続して超過しています。
+                現在値: 1.0000 events/sec
+
+  - interval: 1m
+    name: ZettaiWarningEventSurge は中レートでは発火しない
+    input_series:
+      # 1 分あたり 10 件増加 = 0.1667/sec < 0.5
+      - series: 'zettai_events_by_severity_total{severity="warning",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+10x20'
+    alert_rule_test:
+      - eval_time: 18m
+        alertname: ZettaiWarningEventSurge
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiModuleEventSpike: モジュール別 rate(...) > 1/sec を 5 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiModuleEventSpike が特定モジュールで発火する
+    input_series:
+      # 1 分あたり 120 件増加 = 2/sec > 1
+      - series: 'zettai_module_events_total{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+120x15'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ZettaiModuleEventSpike
+        exp_alerts: []
+      - eval_time: 12m
+        alertname: ZettaiModuleEventSpike
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: zettai-mamorukun
+              module: file_integrity
+            exp_annotations:
+              summary: "モジュール file_integrity の検知件数が急増しています"
+              description: |
+                モジュール file_integrity の検知レートが 1/sec を超えています。
+                特定モジュールに異常なイベントが集中している可能性があります。
+                現在値: 2.0000 events/sec
+
+  - interval: 1m
+    name: ZettaiModuleEventSpike は閾値以下では発火しない
+    input_series:
+      # 1 分あたり 30 件増加 = 0.5/sec < 1
+      - series: 'zettai_module_events_total{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+30x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: ZettaiModuleEventSpike
+        exp_alerts: []

--- a/grafana/alerts/tests/scans_test.yaml
+++ b/grafana/alerts/tests/scans_test.yaml
@@ -1,0 +1,207 @@
+# promtool 用ユニットテスト: zettai-mamorukun.scans グループ
+#
+# 対象アラート:
+#   - ZettaiInitialScanIssuesFound     (発火 / 非発火)
+#   - ZettaiInitialScanIssuesCritical  (発火 / 非発火)
+#   - ZettaiScanDurationP95High        (発火 / 非発火)
+#   - ZettaiScanDurationP99Critical    (発火 / 非発火)
+#   - ZettaiScanStalled                (発火 / 非発火)
+#
+# 実行:
+#   promtool test rules grafana/alerts/tests/scans_test.yaml
+---
+rule_files:
+  - ../prometheus_alerts.yaml
+
+evaluation_interval: 30s
+
+tests:
+  # --------------------------------------------------------------------------
+  # ZettaiInitialScanIssuesFound: gauge > 0 を 1 分継続で発火
+  # ZettaiInitialScanIssuesCritical: gauge >= 5 を 1 分継続で発火
+  # （同じメトリクスを値 3 で与えると Found のみ発火、5 で両方発火）
+  # --------------------------------------------------------------------------
+  - interval: 30s
+    name: ZettaiInitialScanIssuesFound のみ発火（値=3）
+    input_series:
+      - series: 'zettai_module_initial_scan_issues_found{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '3x10'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: ZettaiInitialScanIssuesFound
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: zettai-mamorukun
+              module: file_integrity
+              instance: host1
+              job: zettai-mamorukun-exporter
+            exp_annotations:
+              summary: "起動時スキャンで問題を検知: file_integrity"
+              description: |
+                モジュール file_integrity の起動時スキャンで
+                3 件の問題が検知されました。
+                監視対象ファイル・設定の改ざんや異常の可能性があります。
+      # Critical 側は値 3 では発火しない
+      - eval_time: 3m
+        alertname: ZettaiInitialScanIssuesCritical
+        exp_alerts: []
+
+  - interval: 30s
+    name: ZettaiInitialScanIssuesCritical が発火（値=7）
+    input_series:
+      - series: 'zettai_module_initial_scan_issues_found{module="sudoers_monitor",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '7x10'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: ZettaiInitialScanIssuesCritical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: zettai-mamorukun
+              module: sudoers_monitor
+              instance: host1
+              job: zettai-mamorukun-exporter
+            exp_annotations:
+              summary: "起動時スキャンで多数の問題を検知: sudoers_monitor"
+              description: |
+                モジュール sudoers_monitor の起動時スキャンで
+                7 件（閾値 5）以上の問題が検知されました。
+                即時の調査対応が必要です。
+
+  - interval: 30s
+    name: ZettaiInitialScanIssuesFound が値=0 では発火しない
+    input_series:
+      - series: 'zettai_module_initial_scan_issues_found{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: ZettaiInitialScanIssuesFound
+        exp_alerts: []
+      - eval_time: 3m
+        alertname: ZettaiInitialScanIssuesCritical
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiScanDurationP95High: quantile="0.95" が 5 秒超を 15 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiScanDurationP95High が発火する
+    input_series:
+      - series: 'zettai_module_scan_duration_seconds{module="process_monitor",quantile="0.95",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '7x20'
+    alert_rule_test:
+      # for (15m) 経過前は発火しない
+      - eval_time: 14m
+        alertname: ZettaiScanDurationP95High
+        exp_alerts: []
+      # for (15m) を超えて発火
+      - eval_time: 17m
+        alertname: ZettaiScanDurationP95High
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: zettai-mamorukun
+              module: process_monitor
+              instance: host1
+              job: zettai-mamorukun-exporter
+              quantile: "0.95"
+            exp_annotations:
+              summary: "モジュール process_monitor のスキャン P95 が 5 秒を超過"
+              description: |
+                モジュール process_monitor の定期スキャン実行時間
+                P95 が 15 分間継続して 5 秒を超えています。
+                パフォーマンス劣化・リソース枯渇の兆候の可能性があります。
+                現在値: 7.00 sec
+
+  - interval: 1m
+    name: ZettaiScanDurationP95High は閾値以下では発火しない
+    input_series:
+      - series: 'zettai_module_scan_duration_seconds{module="process_monitor",quantile="0.95",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '3x20'
+    alert_rule_test:
+      - eval_time: 17m
+        alertname: ZettaiScanDurationP95High
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiScanDurationP99Critical: quantile="0.99" が 30 秒超を 15 分継続で発火
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiScanDurationP99Critical が発火する
+    input_series:
+      - series: 'zettai_module_scan_duration_seconds{module="package_verify",quantile="0.99",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '35x20'
+    alert_rule_test:
+      - eval_time: 14m
+        alertname: ZettaiScanDurationP99Critical
+        exp_alerts: []
+      - eval_time: 17m
+        alertname: ZettaiScanDurationP99Critical
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: zettai-mamorukun
+              module: package_verify
+              instance: host1
+              job: zettai-mamorukun-exporter
+              quantile: "0.99"
+            exp_annotations:
+              summary: "モジュール package_verify のスキャン P99 が 30 秒を超過"
+              description: |
+                モジュール package_verify の定期スキャン実行時間
+                P99 が 15 分間継続して 30 秒を超えています。
+                即時の調査が必要です（I/O 遅延・大量ファイル増加等）。
+                現在値: 35.00 sec
+
+  - interval: 1m
+    name: ZettaiScanDurationP99Critical は閾値以下では発火しない
+    input_series:
+      - series: 'zettai_module_scan_duration_seconds{module="package_verify",quantile="0.99",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '10x20'
+    alert_rule_test:
+      - eval_time: 17m
+        alertname: ZettaiScanDurationP99Critical
+        exp_alerts: []
+
+  # --------------------------------------------------------------------------
+  # ZettaiScanStalled: rate(count[10m])==0 かつ count > 0 を 15 分継続で発火
+  # カウンタが増加後に停止したケースを模擬する
+  # --------------------------------------------------------------------------
+  - interval: 1m
+    name: ZettaiScanStalled がカウンタ停止で発火
+    input_series:
+      # 初期に 5 までカウントアップしたあと、以降はずっと同じ値（停止）を 40 分間維持
+      - series: 'zettai_module_scan_duration_seconds_count{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '1 2 3 4 5 5x35'
+    alert_rule_test:
+      # 停止直後は rate ウィンドウ (10m) に古いサンプルが残るため rate != 0
+      - eval_time: 10m
+        alertname: ZettaiScanStalled
+        exp_alerts: []
+      # 停止後 25 分経過 (rate 10m=0 が 15m 継続) で発火
+      - eval_time: 30m
+        alertname: ZettaiScanStalled
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: zettai-mamorukun
+              module: file_integrity
+              instance: host1
+              job: zettai-mamorukun-exporter
+            exp_annotations:
+              summary: "モジュール file_integrity の定期スキャンが停止しています"
+              description: |
+                モジュール file_integrity の定期スキャン実行回数が
+                過去 10 分間増加していません。モジュール停止またはハング中の可能性があります。
+
+  - interval: 1m
+    name: ZettaiScanStalled はカウンタ増加中では発火しない
+    input_series:
+      # カウンタは継続的に増加
+      - series: 'zettai_module_scan_duration_seconds_count{module="file_integrity",instance="host1",job="zettai-mamorukun-exporter"}'
+        values: '0+1x40'
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: ZettaiScanStalled
+        exp_alerts: []


### PR DESCRIPTION
## Summary

- `grafana/alerts/tests/` に `promtool test rules` 用のユニットテストを追加（events / scans / availability の 3 ファイル）
- 10 個のアラートそれぞれについて**発火ケース**と**非発火ケース**を最低 2 件ずつ検証（ラベル・アノテーションの完全一致を含む）
- `grafana/alerts/README.md` に「ユニットテスト」セクションと CI ワークフロー例を追記

## 実装判断

- **ワークフローファイル本体ではなく README にサンプル掲載**: 現行環境の push 権限制約により `.github/workflows/` 配下を直接追加できないため、ワークフロー YAML を README にそのまま転載。必要に応じて手動で配置すれば自動化できる形にした。
- **アノテーション完全一致**: `exp_alerts` を指定する以上 `exp_annotations` は完全一致での比較になるため、`{{ $value | printf "%.4f" }}` 等の書式を展開した期待文字列を明記。
- **Stall 系アラートのテスト時刻設計**: `ZettaiScanStalled` / `ZettaiNoEventsReceived` は `rate() == 0` の検証にカウンタ停止を模擬する必要があり、停止前の増加 + 停止後の十分な期間で発火を検証。

## ローカル検証結果

```
$ promtool check rules grafana/alerts/prometheus_alerts.yaml
  SUCCESS: 10 rules found

$ promtool test rules grafana/alerts/tests/*.yaml
  SUCCESS (events_test.yaml)
  SUCCESS (scans_test.yaml)
  SUCCESS (availability_test.yaml)
```

## Test plan

- [x] `promtool check rules` がローカルで成功
- [x] `promtool test rules grafana/alerts/tests/*.yaml` がローカルで成功
- [x] 10 アラートについて発火・非発火の 2 ケースをカバー
- [x] README 更新

Closes #324