### PR TITLE
test: module-stats diff の warn ログ出力を検証するテストを追加 (#333)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -3308,6 +3329,7 @@ dependencies = [
  "tracing",
  "tracing-journald",
  "tracing-subscriber",
+ "tracing-test",
  "walkdir",
  "webpki-roots 0.26.11",
  "wiremock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.62.0"
+version = "1.63.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"
@@ -51,3 +51,4 @@ tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "process"] }
 wiremock = "0.6"
 rcgen = "0.13"
+tracing-test = "0.2"

--- a/src/core/module_stats.rs
+++ b/src/core/module_stats.rs
@@ -1114,4 +1114,68 @@ mod tests {
         };
         spawn_summary_logger(handle, &config);
     }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_u64_diff_logs_warn_on_positive_saturation() {
+        let result = u64_diff(u64::MAX, 0, "mod_x", "events_total");
+        assert_eq!(result, i64::MAX);
+        assert!(logs_contain("module-stats diff saturated at i64::MAX"));
+        assert!(logs_contain("mod_x"));
+        assert!(logs_contain("events_total"));
+        assert!(logs_contain(&u64::MAX.to_string()));
+        assert!(logs_contain("baseline=0"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_u64_diff_logs_warn_on_negative_saturation() {
+        let result = u64_diff(0, u64::MAX, "mod_y", "events_warning");
+        assert_eq!(result, i64::MIN);
+        assert!(logs_contain("module-stats diff saturated at i64::MIN"));
+        assert!(logs_contain("mod_y"));
+        assert!(logs_contain("events_warning"));
+        assert!(logs_contain("current=0"));
+        assert!(logs_contain(&u64::MAX.to_string()));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_u64_diff_no_warn_on_normal_range() {
+        let result = u64_diff(150, 100, "mod_z", "events_total");
+        assert_eq!(result, 50);
+        assert!(!logs_contain("module-stats diff saturated"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_option_diff_logs_warn_on_saturation() {
+        let result = option_diff(Some(u64::MAX), Some(0), "mod_p", "scan_p95_ms");
+        assert_eq!(result, Some(i64::MAX));
+        assert!(logs_contain("module-stats diff saturated at i64::MAX"));
+        assert!(logs_contain("mod_p"));
+        assert!(logs_contain("scan_p95_ms"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_option_diff_no_warn_when_either_side_none() {
+        assert_eq!(option_diff(None, Some(100), "m", "x"), None);
+        assert_eq!(option_diff(Some(100), None, "m", "x"), None);
+        assert_eq!(option_diff(None, None, "m", "x"), None);
+        assert!(!logs_contain("module-stats diff saturated"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn test_compute_diff_logs_warn_with_module_and_metric_context() {
+        // compute_diff 経由でも各メトリック単位で module / metric を持った
+        // warn ログが出力されることを確認する
+        let baseline = vec![mk_stats("alpha_module", 0, None, None)];
+        let current = vec![mk_stats("alpha_module", u64::MAX, None, None)];
+        let _report = compute_diff(&baseline, &current, None, None);
+        assert!(logs_contain("alpha_module"));
+        assert!(logs_contain("events_total"));
+        assert!(logs_contain("module-stats diff saturated at i64::MAX"));
+    }
 }


### PR DESCRIPTION
## 概要

v1.62.0 (#331, PR #332) で `compute_diff` / `u64_diff` / `option_diff` に追加した整数オーバーフロー保護のサチュレーション時 `tracing::warn!` ログ出力に対し、ログメッセージの内容（モジュール名・メトリック名・current / baseline）が期待どおり出力されているかを検証するテストを追加する。

## 変更内容

- `tracing-test = "0.2"` を `dev-dependencies` に追加（MIT ライセンス）
- `src/core/module_stats.rs` に新規ユニットテスト 6 件を追加:
  - `test_u64_diff_logs_warn_on_positive_saturation` — i64::MAX サチュレーション時のログ出力
  - `test_u64_diff_logs_warn_on_negative_saturation` — i64::MIN サチュレーション時のログ出力
  - `test_u64_diff_no_warn_on_normal_range` — 通常範囲では warn ログを出さないこと（false positive 防止）
  - `test_option_diff_logs_warn_on_saturation` — option_diff 経由でも同様にログ出力されること
  - `test_option_diff_no_warn_when_either_side_none` — None のときはログを出さないこと
  - `test_compute_diff_logs_warn_with_module_and_metric_context` — compute_diff 経由でも module / metric コンテキスト付きで warn ログが出ること

## 検証

- [x] `cargo test` 全パス（2340 + 18 + 38 = 2396 件）
- [x] `cargo build --release` 成功
- [x] `cargo fmt --check` パス
- [x] clippy ベースラインに新規 warn を追加していないことを確認（main と同件数）

## バージョン

1.62.0 → 1.63.0

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)