### PR TITLE
chore: clippy ベースライン整備 — Rust 1.95.0 の新規 lint 警告・エラーを全て解消 (#339)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.65.0"
+version = "1.66.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/src/core/action.rs
+++ b/src/core/action.rs
@@ -1164,20 +1164,14 @@ mod tests {
     fn test_action_engine_new_valid() {
         let config = ActionConfig {
             enabled: true,
-            rules: vec![
-                {
-                    let r = make_rule_config("log_all", "log", None);
-                    r
-                },
-                {
-                    let mut r =
-                        make_rule_config("critical_command", "command", Some("echo '{{message}}'"));
-                    r.severity = Some("critical".to_string());
-                    r.module = Some("file_integrity".to_string());
-                    r.timeout_secs = 10;
-                    r
-                },
-            ],
+            rules: vec![{ make_rule_config("log_all", "log", None) }, {
+                let mut r =
+                    make_rule_config("critical_command", "command", Some("echo '{{message}}'"));
+                r.severity = Some("critical".to_string());
+                r.module = Some("file_integrity".to_string());
+                r.timeout_secs = 10;
+                r
+            }],
             rate_limit: None,
             digest: None,
         };
@@ -1245,10 +1239,7 @@ mod tests {
     fn test_webhook_rule_validation() {
         let config = ActionConfig {
             enabled: true,
-            rules: vec![{
-                let r = make_rule_config("bad_webhook", "webhook", None);
-                r
-            }],
+            rules: vec![{ make_rule_config("bad_webhook", "webhook", None) }],
             rate_limit: None,
             digest: None,
         };

--- a/src/core/event_store.rs
+++ b/src/core/event_store.rs
@@ -2719,12 +2719,12 @@ mod tests {
         assert_eq!(runtime.batch_size, 50);
         assert_eq!(runtime.batch_interval_secs, 10);
         assert_eq!(runtime.cleanup_interval_hours, 12);
-        assert_eq!(runtime.archive_enabled, true);
+        assert!(runtime.archive_enabled);
         assert_eq!(runtime.archive_after_days, 7);
         assert_eq!(runtime.archive_dir, "/tmp/archive");
         assert_eq!(runtime.archive_interval_hours, 12);
-        assert_eq!(runtime.archive_compress, false);
-        assert_eq!(runtime.archive_rotation_enabled, true);
+        assert!(!runtime.archive_compress);
+        assert!(runtime.archive_rotation_enabled);
         assert_eq!(runtime.archive_max_age_days, 180);
         assert_eq!(runtime.archive_max_total_mb, 1024);
         assert_eq!(runtime.archive_max_files, 100);
@@ -3039,7 +3039,7 @@ mod tests {
         init_database(&conn).unwrap();
 
         let events: Vec<SecurityEvent> = (0..10)
-            .map(|i| SecurityEvent::new("ev", Severity::Info, "mod", &format!("イベント{}", i)))
+            .map(|i| SecurityEvent::new("ev", Severity::Info, "mod", format!("イベント{}", i)))
             .collect();
         EventStore::insert_events(&mut conn, &events).unwrap();
 
@@ -3063,7 +3063,7 @@ mod tests {
         init_database(&conn).unwrap();
 
         let events: Vec<SecurityEvent> = (0..5)
-            .map(|i| SecurityEvent::new("ev", Severity::Info, "mod", &format!("イベント{}", i)))
+            .map(|i| SecurityEvent::new("ev", Severity::Info, "mod", format!("イベント{}", i)))
             .collect();
         EventStore::insert_events(&mut conn, &events).unwrap();
 

--- a/src/core/metrics.rs
+++ b/src/core/metrics.rs
@@ -328,11 +328,13 @@ mod tests {
 
     #[test]
     fn test_shared_metrics_serialize() {
-        let mut metrics = SharedMetrics::default();
-        metrics.total_events = 10;
-        metrics.info_count = 5;
-        metrics.warning_count = 3;
-        metrics.critical_count = 2;
+        let mut metrics = SharedMetrics {
+            total_events: 10,
+            info_count: 5,
+            warning_count: 3,
+            critical_count: 2,
+            ..Default::default()
+        };
         metrics.module_counts.insert("test_module".to_string(), 10);
 
         let json = serde_json::to_string(&metrics).unwrap();

--- a/src/core/module_manager.rs
+++ b/src/core/module_manager.rs
@@ -1083,8 +1083,8 @@ mod tests {
         let config = ModulesConfig::default();
         let event_bus = None;
         let (_, report) = ModuleManager::start_modules(&config, &event_bus, &None, true).await;
-        // total_duration はゼロ以上
-        assert!(report.total_duration.as_nanos() >= 0);
+        // total_duration は Duration 型の性質上常にゼロ以上
+        let _ = report.total_duration;
     }
 
     #[tokio::test]

--- a/src/core/scoring.rs
+++ b/src/core/scoring.rs
@@ -523,9 +523,11 @@ mod tests {
 
     #[test]
     fn test_shared_security_score_serialize() {
-        let mut score = SharedSecurityScore::default();
-        score.overall_score = 85;
-        score.grade = "B".to_string();
+        let mut score = SharedSecurityScore {
+            overall_score: 85,
+            grade: "B".to_string(),
+            ..Default::default()
+        };
         score.summary.total_events = 10;
         score.summary.critical = 1;
         score.summary.high = 2;

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -228,10 +228,7 @@ pub fn rotate_config_keys(
     let mut errors = Vec::new();
 
     let mut search_start = 0;
-    loop {
-        let Some(start) = result[search_start..].find(ENC_PREFIX) else {
-            break;
-        };
+    while let Some(start) = result[search_start..].find(ENC_PREFIX) {
         let start = search_start + start;
 
         let Some(end_offset) = result[start..].find(ENC_SUFFIX) else {
@@ -299,10 +296,7 @@ pub fn decrypt_config_content(content: &str) -> Result<String, AppError> {
 
     let mut result = content.to_string();
     // ENC[...] パターンを検索して復号
-    loop {
-        let Some(start) = result.find(ENC_PREFIX) else {
-            break;
-        };
+    while let Some(start) = result.find(ENC_PREFIX) {
         let Some(end) = result[start..].find(ENC_SUFFIX) else {
             break;
         };
@@ -504,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_key_wrong_length() {
-        let short_key = BASE64.encode(&[0u8; 16]);
+        let short_key = BASE64.encode([0u8; 16]);
         unsafe { std::env::set_var(ENV_KEY_NAME, &short_key) };
         let result = resolve_key(&None);
         unsafe { std::env::remove_var(ENV_KEY_NAME) };
@@ -739,7 +733,7 @@ plain = "hello"
 
     #[test]
     fn test_resolve_key_from_source_base64_wrong_length() {
-        let short = BASE64.encode(&[0u8; 16]);
+        let short = BASE64.encode([0u8; 16]);
         let result = resolve_key_from_source(&short);
         assert!(result.is_err());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1255,7 +1255,7 @@ fn format_module_stats_list(stats: &[zettai_mamorukun::core::module_stats::Modul
     // 検知イベント数 TOP 10（件数降順、0 件は除外）
     let mut by_events: Vec<&zettai_mamorukun::core::module_stats::ModuleStats> =
         stats.iter().filter(|s| s.events_total > 0).collect();
-    by_events.sort_by(|a, b| b.events_total.cmp(&a.events_total));
+    by_events.sort_by_key(|s| std::cmp::Reverse(s.events_total));
 
     let _ = writeln!(out, "■ 検知イベント数 TOP 10（モジュール別）");
     if by_events.is_empty() {
@@ -1311,7 +1311,7 @@ fn format_module_stats_list(stats: &[zettai_mamorukun::core::module_stats::Modul
     // スキャン実行時間ヒストグラム（P95 降順・サンプルが 1 件以上あるもののみ）
     let mut by_p95: Vec<&zettai_mamorukun::core::module_stats::ModuleStats> =
         stats.iter().filter(|s| s.scan_count > 0).collect();
-    by_p95.sort_by(|a, b| b.scan_p95_ms.unwrap_or(0).cmp(&a.scan_p95_ms.unwrap_or(0)));
+    by_p95.sort_by_key(|s| std::cmp::Reverse(s.scan_p95_ms.unwrap_or(0)));
 
     let _ = writeln!(out, "■ スキャン実行時間ヒストグラム（P95 降順）");
     if by_p95.is_empty() {

--- a/src/modules/bootloader_monitor.rs
+++ b/src/modules/bootloader_monitor.rs
@@ -741,7 +741,7 @@ GRUB_CMDLINE_LINUX="real_param"
         let path = dir.path().join("grub.cfg");
         fs::write(&path, "content").unwrap();
 
-        let snap1 = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let snap1 = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
         let snap2 = BootloaderMonitorModule::take_snapshot(&[path], &[]);
 
         assert!(!BootloaderMonitorModule::detect_changes(
@@ -760,10 +760,10 @@ GRUB_CMDLINE_LINUX="real_param"
         let path = dir.path().join("grub.cfg");
         fs::write(&path, "original content").unwrap();
 
-        let old = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let old = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         fs::write(&path, "modified content").unwrap();
-        let new = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let new = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         assert!(BootloaderMonitorModule::detect_changes(
             &old,
@@ -781,10 +781,10 @@ GRUB_CMDLINE_LINUX="real_param"
         let path = dir.path().join("grub.cfg");
         fs::write(&path, "content").unwrap();
 
-        let old = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let old = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         fs::remove_file(&path).unwrap();
-        let new = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let new = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         assert!(BootloaderMonitorModule::detect_changes(
             &old,
@@ -801,10 +801,10 @@ GRUB_CMDLINE_LINUX="real_param"
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("grub.cfg");
 
-        let old = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let old = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         fs::write(&path, "new content").unwrap();
-        let new = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let new = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         assert!(BootloaderMonitorModule::detect_changes(
             &old,
@@ -822,11 +822,11 @@ GRUB_CMDLINE_LINUX="real_param"
         let path = dir.path().join("grub.cfg");
         fs::write(&path, "content").unwrap();
 
-        let old = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let old = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         // パーミッションを変更
         fs::set_permissions(&path, fs::Permissions::from_mode(0o777)).unwrap();
-        let new = BootloaderMonitorModule::take_snapshot(&[path.clone()], &[]);
+        let new = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&path), &[]);
 
         assert!(BootloaderMonitorModule::detect_changes(
             &old,
@@ -845,10 +845,10 @@ GRUB_CMDLINE_LINUX="real_param"
         fs::create_dir_all(default_grub.parent().unwrap()).unwrap();
         fs::write(&default_grub, "GRUB_CMDLINE_LINUX=\"quiet\"\n").unwrap();
 
-        let old = BootloaderMonitorModule::take_snapshot(&[default_grub.clone()], &[]);
+        let old = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&default_grub), &[]);
 
         fs::write(&default_grub, "GRUB_CMDLINE_LINUX=\"quiet selinux=0\"\n").unwrap();
-        let new = BootloaderMonitorModule::take_snapshot(&[default_grub.clone()], &[]);
+        let new = BootloaderMonitorModule::take_snapshot(std::slice::from_ref(&default_grub), &[]);
 
         assert!(BootloaderMonitorModule::detect_changes(
             &old,

--- a/src/modules/coredump_monitor.rs
+++ b/src/modules/coredump_monitor.rs
@@ -478,8 +478,10 @@ mod tests {
 
     #[test]
     fn test_init_zero_interval() {
-        let mut config = CoredumpMonitorConfig::default();
-        config.scan_interval_secs = 0;
+        let config = CoredumpMonitorConfig {
+            scan_interval_secs: 0,
+            ..Default::default()
+        };
         let mut module = CoredumpMonitorModule::new(config, None);
         assert!(module.init().is_err());
     }

--- a/src/modules/cron_monitor.rs
+++ b/src/modules/cron_monitor.rs
@@ -855,7 +855,7 @@ mod tests {
         let result = CronMonitorModule::setup_inotify(&watch_paths);
         assert!(result.is_ok());
         let (_inotify, watch_map) = result.unwrap();
-        assert!(watch_map.len() >= 1);
+        assert!(!watch_map.is_empty());
     }
 
     #[test]
@@ -924,7 +924,7 @@ mod tests {
         let path = PathBuf::from("/etc/crontab");
 
         let now = Instant::now();
-        assert!(debounce_map.get(&path).is_none());
+        assert!(!debounce_map.contains_key(&path));
         debounce_map.insert(path.clone(), now);
 
         let should_skip = debounce_map

--- a/src/modules/ebpf_monitor.rs
+++ b/src/modules/ebpf_monitor.rs
@@ -645,8 +645,10 @@ mod tests {
 
     #[test]
     fn test_init_zero_interval() {
-        let mut config = EbpfMonitorConfig::default();
-        config.scan_interval_secs = 0;
+        let config = EbpfMonitorConfig {
+            scan_interval_secs: 0,
+            ..Default::default()
+        };
         let mut module = EbpfMonitorModule::new(config, None);
         assert!(module.init().is_err());
     }

--- a/src/modules/fd_monitor.rs
+++ b/src/modules/fd_monitor.rs
@@ -347,8 +347,10 @@ mod tests {
     use std::os::unix::fs::symlink;
     use tempfile::TempDir;
 
+    type TestProcEntry<'a> = (u32, &'a str, &'a [(&'a str, &'a str)]);
+
     /// テスト用の /proc ディレクトリ構造を作成する
-    fn create_test_proc(entries: &[(u32, &str, &[(&str, &str)])]) -> TempDir {
+    fn create_test_proc(entries: &[TestProcEntry<'_>]) -> TempDir {
         let tmp = TempDir::new().unwrap();
         for (pid, comm, fds) in entries {
             let pid_dir = tmp.path().join(pid.to_string());

--- a/src/modules/honeypot_monitor.rs
+++ b/src/modules/honeypot_monitor.rs
@@ -610,7 +610,7 @@ mod tests {
         let file_path = dir.path().join("honeypot.txt");
         fs::write(&file_path, "canary token").unwrap();
 
-        let snapshot = HoneypotMonitorModule::scan_paths(&[file_path.clone()]);
+        let snapshot = HoneypotMonitorModule::scan_paths(std::slice::from_ref(&file_path));
         assert!(snapshot.contains_key(&file_path.display().to_string()));
         let value = &snapshot[&file_path.display().to_string()];
         assert!(value.starts_with("size="));

--- a/src/modules/inotify_monitor.rs
+++ b/src/modules/inotify_monitor.rs
@@ -658,7 +658,7 @@ mod tests {
 
         // 最初のイベントは通過する
         let now = Instant::now();
-        assert!(debounce_map.get(&path).is_none());
+        assert!(!debounce_map.contains_key(&path));
         debounce_map.insert(path.clone(), now);
 
         // debounce 期間内のイベントはスキップされる

--- a/src/modules/ipc_monitor.rs
+++ b/src/modules/ipc_monitor.rs
@@ -784,7 +784,7 @@ mod tests {
     #[test]
     fn test_parse_shm_empty() {
         let dir = make_test_dir();
-        let entries = IpcMonitorModule::parse_shm(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_shm(dir.path());
         assert!(entries.is_empty());
     }
 
@@ -794,7 +794,7 @@ mod tests {
         let content = "       key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime                   rss                  swap\n         0      12345   666              1048576  1234  5678      2  1000   100  1000   100 1700000000 1700000000 1700000000              1048576                     0\n";
         fs::write(dir.path().join("shm"), content).unwrap();
 
-        let entries = IpcMonitorModule::parse_shm(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_shm(dir.path());
         assert_eq!(entries.len(), 1);
         let entry = entries.get(&12345).unwrap();
         assert_eq!(entry.shmid, 12345);
@@ -806,7 +806,7 @@ mod tests {
     #[test]
     fn test_parse_sem_empty() {
         let dir = make_test_dir();
-        let entries = IpcMonitorModule::parse_sem(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_sem(dir.path());
         assert!(entries.is_empty());
     }
 
@@ -816,7 +816,7 @@ mod tests {
         let content = "       key      semid perms      nsems   uid   gid  cuid  cgid      otime      ctime\n         0        100   600          5  1000   100  1000   100 1700000000 1700000000\n";
         fs::write(dir.path().join("sem"), content).unwrap();
 
-        let entries = IpcMonitorModule::parse_sem(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_sem(dir.path());
         assert_eq!(entries.len(), 1);
         let entry = entries.get(&100).unwrap();
         assert_eq!(entry.semid, 100);
@@ -828,7 +828,7 @@ mod tests {
     #[test]
     fn test_parse_msg_empty() {
         let dir = make_test_dir();
-        let entries = IpcMonitorModule::parse_msg(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_msg(dir.path());
         assert!(entries.is_empty());
     }
 
@@ -838,7 +838,7 @@ mod tests {
         let content = "       key      msqid perms      cbytes       qnum lspid lrpid   uid   gid  cuid  cgid      stime      rtime      ctime\n         0        200   644        4096         10  1234  5678  1000   100  1000   100 1700000000 1700000000 1700000000\n";
         fs::write(dir.path().join("msg"), content).unwrap();
 
-        let entries = IpcMonitorModule::parse_msg(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_msg(dir.path());
         assert_eq!(entries.len(), 1);
         let entry = entries.get(&200).unwrap();
         assert_eq!(entry.msqid, 200);
@@ -1219,7 +1219,7 @@ mod tests {
         fs::write(dir.path().join("sem"), sem_content).unwrap();
         fs::write(dir.path().join("msg"), msg_content).unwrap();
 
-        let snapshot = IpcMonitorModule::scan(&dir.path().to_path_buf());
+        let snapshot = IpcMonitorModule::scan(dir.path());
         assert_eq!(snapshot.shm.len(), 1);
         assert_eq!(snapshot.sem.len(), 1);
         assert_eq!(snapshot.msg.len(), 1);
@@ -1231,7 +1231,7 @@ mod tests {
         let content = "       key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime                   rss                  swap\nthis is not a valid line\n         0          1   600              4096  1234  5678      1     0     0     0     0 1700000000 1700000000 1700000000                 4096                     0\n";
         fs::write(dir.path().join("shm"), content).unwrap();
 
-        let entries = IpcMonitorModule::parse_shm(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_shm(dir.path());
         assert_eq!(entries.len(), 1); // 不正行はスキップ、有効行のみパース
     }
 
@@ -1241,7 +1241,7 @@ mod tests {
         let content = "       key      shmid perms                  size  cpid  lpid nattch   uid   gid  cuid  cgid      atime      dtime      ctime                   rss                  swap\n         0          1   600              4096  1234  5678      1     0     0     0     0 1700000000 1700000000 1700000000                 4096                     0\n         0          2   666              8192  2345  6789      2  1000   100  1000   100 1700000000 1700000000 1700000000                 8192                     0\n";
         fs::write(dir.path().join("shm"), content).unwrap();
 
-        let entries = IpcMonitorModule::parse_shm(&dir.path().to_path_buf());
+        let entries = IpcMonitorModule::parse_shm(dir.path());
         assert_eq!(entries.len(), 2);
         assert!(entries.contains_key(&1));
         assert!(entries.contains_key(&2));

--- a/src/modules/kernel_cmdline_monitor.rs
+++ b/src/modules/kernel_cmdline_monitor.rs
@@ -357,7 +357,6 @@ impl Module for KernelCmdlineMonitorModule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write;
 
     fn test_config(dir: &tempfile::TempDir) -> KernelCmdlineMonitorConfig {
         let cmdline_path = dir.path().join("cmdline");

--- a/src/modules/kernel_params.rs
+++ b/src/modules/kernel_params.rs
@@ -440,8 +440,10 @@ mod tests {
 
     #[test]
     fn test_init_zero_interval() {
-        let mut config = KernelParamsConfig::default();
-        config.scan_interval_secs = 0;
+        let config = KernelParamsConfig {
+            scan_interval_secs: 0,
+            ..Default::default()
+        };
         let mut module = KernelParamsModule::new(config, None);
         assert!(module.init().is_err());
     }

--- a/src/modules/keylogger_detector.rs
+++ b/src/modules/keylogger_detector.rs
@@ -313,7 +313,7 @@ mod tests {
         let result = module.initial_scan().await;
         assert!(result.is_ok());
         let scan = result.unwrap();
-        assert!(scan.items_scanned > 0 || scan.items_scanned == 0);
+        let _ = scan.items_scanned;
         assert!(!scan.summary.is_empty());
     }
 

--- a/src/modules/ld_preload_monitor.rs
+++ b/src/modules/ld_preload_monitor.rs
@@ -426,7 +426,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_basic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "/usr/lib/libevil.so\n").unwrap();
+        writeln!(tmpfile, "/usr/lib/libevil.so").unwrap();
         let snapshot = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert!(!snapshot.file_hash.is_empty());
         assert_eq!(snapshot.file_hash.len(), 64);
@@ -435,7 +435,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "/usr/lib/libtest.so\n").unwrap();
+        writeln!(tmpfile, "/usr/lib/libtest.so").unwrap();
         let s1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let s2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(s1.file_hash, s2.file_hash);
@@ -450,9 +450,9 @@ mod tests {
     #[test]
     fn test_scan_files_with_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "content\n").unwrap();
+        writeln!(tmpfile, "content").unwrap();
         let path = tmpfile.path().to_path_buf();
-        let result = LdPreloadMonitorModule::scan_files(&[path.clone()]);
+        let result = LdPreloadMonitorModule::scan_files(std::slice::from_ref(&path));
         assert_eq!(result.files.len(), 1);
         assert!(result.files.contains_key(&path));
     }
@@ -483,9 +483,9 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "content\n").unwrap();
+        writeln!(tmpfile, "content").unwrap();
         let path = tmpfile.path().to_path_buf();
-        let s1 = LdPreloadMonitorModule::scan_files(&[path.clone()]);
+        let s1 = LdPreloadMonitorModule::scan_files(std::slice::from_ref(&path));
         let s2 = LdPreloadMonitorModule::scan_files(&[path]);
         let changed = LdPreloadMonitorModule::detect_and_report(&s1, &s2, &None);
         assert!(!changed);
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_check_dangerous_env_vars_detects_ld_preload() {
-        let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+        let tmpfile = tempfile::NamedTempFile::new().unwrap();
         // ファイル名が "environment" である必要がある
         let tmpdir = tempfile::TempDir::new().unwrap();
         let env_path = tmpdir.path().join("environment");
@@ -626,7 +626,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "content\n").unwrap();
+        writeln!(tmpfile, "content").unwrap();
 
         let config = LdPreloadMonitorConfig {
             enabled: true,

--- a/src/modules/mac_monitor.rs
+++ b/src/modules/mac_monitor.rs
@@ -330,29 +330,30 @@ fn detect_apparmor_changes(
     // プロファイルの弱体化・変更の検知
     for (name, old_mode) in &baseline.apparmor_profiles {
         match current.apparmor_profiles.get(name) {
-            Some(new_mode) if old_mode != new_mode => {
+            Some(new_mode)
+                if old_mode != new_mode
                 // enforce → complain/unconfined は Critical
-                if old_mode == "enforce" && (new_mode == "complain" || new_mode == "unconfined") {
-                    tracing::error!(
-                        profile = %name,
-                        old_mode = %old_mode,
-                        new_mode = %new_mode,
-                        "AppArmor プロファイルが弱体化されました"
+                && old_mode == "enforce" && (new_mode == "complain" || new_mode == "unconfined") =>
+            {
+                tracing::error!(
+                    profile = %name,
+                    old_mode = %old_mode,
+                    new_mode = %new_mode,
+                    "AppArmor プロファイルが弱体化されました"
+                );
+                if let Some(bus) = event_bus {
+                    bus.publish(
+                        SecurityEvent::new(
+                            "mac_apparmor_profile_weakened",
+                            Severity::Critical,
+                            "mac_monitor",
+                            format!(
+                                "AppArmor プロファイル '{}' が {} から {} に変更されました",
+                                name, old_mode, new_mode
+                            ),
+                        )
+                        .with_details(format!("{}: {} -> {}", name, old_mode, new_mode)),
                     );
-                    if let Some(bus) = event_bus {
-                        bus.publish(
-                            SecurityEvent::new(
-                                "mac_apparmor_profile_weakened",
-                                Severity::Critical,
-                                "mac_monitor",
-                                format!(
-                                    "AppArmor プロファイル '{}' が {} から {} に変更されました",
-                                    name, old_mode, new_mode
-                                ),
-                            )
-                            .with_details(format!("{}: {} -> {}", name, old_mode, new_mode)),
-                        );
-                    }
                 }
             }
             None => {
@@ -609,7 +610,7 @@ mod tests {
     #[test]
     fn test_read_selinux_enforce_with_value() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "1\n").unwrap();
+        writeln!(tmpfile, "1").unwrap();
         let result = read_selinux_enforce(tmpfile.path());
         assert_eq!(result, Some("1".to_string()));
     }
@@ -617,7 +618,7 @@ mod tests {
     #[test]
     fn test_read_selinux_enforce_zero() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "0\n").unwrap();
+        writeln!(tmpfile, "0").unwrap();
         let result = read_selinux_enforce(tmpfile.path());
         assert_eq!(result, Some("0".to_string()));
     }

--- a/src/modules/network_interface_monitor.rs
+++ b/src/modules/network_interface_monitor.rs
@@ -494,7 +494,7 @@ impl Module for NetworkInterfaceMonitorModule {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
+
     use tempfile::TempDir;
 
     /// テスト用の /sys/class/net/ ディレクトリ構造を作成する

--- a/src/modules/network_monitor.rs
+++ b/src/modules/network_monitor.rs
@@ -839,13 +839,13 @@ mod tests {
         // 実際には各32bitワードがホストバイトオーダーなのでプラットフォーム依存
         // テストではパース関数の基本動作を確認
         let loopback_hex = format!(
-            "{}{}{}{}",
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 1])),
+            "{:08X}{:08X}{:08X}{:08X}",
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 1]),
         );
-        let field = format!("{}:0050", loopback_hex);
+        let field = format!("{loopback_hex}:0050");
         let result = parse_addr_port_v6(&field);
         assert!(result.is_some());
         let (addr, port) = result.unwrap();
@@ -857,13 +857,13 @@ mod tests {
     fn test_parse_addr_port_v6_loopback() {
         // ::1 のバイト列を直接構築
         let loopback_hex = format!(
-            "{}{}{}{}",
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 1])),
+            "{:08X}{:08X}{:08X}{:08X}",
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 1]),
         );
-        let field = format!("{}:1F90", loopback_hex);
+        let field = format!("{loopback_hex}:1F90");
         let result = parse_addr_port_v6(&field);
         assert!(result.is_some());
         let (addr, port) = result.unwrap();
@@ -887,16 +887,15 @@ mod tests {
     fn test_parse_proc_net_tcp6() {
         // ::1:80 -> :::0 の LISTEN エントリ
         let loopback_hex = format!(
-            "{}{}{}{}",
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 1])),
+            "{:08X}{:08X}{:08X}{:08X}",
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 1]),
         );
         let zero_hex = "00000000000000000000000000000000";
         let content = format!(
-            "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n   0: {}:0050 {}:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0",
-            loopback_hex, zero_hex
+            "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n   0: {loopback_hex}:0050 {zero_hex}:0000 0A 00000000:00000000 00:00000000 00000000     0        0 12345 1 0000000000000000 100 0 0 10 0"
         );
 
         let entries = parse_proc_net(&content, Protocol::Tcp, AddressFamily::V6);
@@ -1227,22 +1226,21 @@ mod tests {
     fn test_parse_proc_net_tcp6_established() {
         // 2001:db8::1:443 -> 2001:db8::2:54321 ESTABLISHED
         let local_hex = format!(
-            "{}{}{}{}",
-            format!("{:08X}", u32::from_ne_bytes([0x20, 0x01, 0x0d, 0xb8])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 1])),
+            "{:08X}{:08X}{:08X}{:08X}",
+            u32::from_ne_bytes([0x20, 0x01, 0x0d, 0xb8]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 1]),
         );
         let remote_hex = format!(
-            "{}{}{}{}",
-            format!("{:08X}", u32::from_ne_bytes([0x20, 0x01, 0x0d, 0xb8])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 0])),
-            format!("{:08X}", u32::from_ne_bytes([0, 0, 0, 2])),
+            "{:08X}{:08X}{:08X}{:08X}",
+            u32::from_ne_bytes([0x20, 0x01, 0x0d, 0xb8]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 0]),
+            u32::from_ne_bytes([0, 0, 0, 2]),
         );
         let content = format!(
-            "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n   0: {}:01BB {}:D431 01 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 100 0 0 10 0",
-            local_hex, remote_hex
+            "  sl  local_address                         remote_address                        st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n   0: {local_hex}:01BB {remote_hex}:D431 01 00000000:00000000 00:00000000 00000000  1000        0 67890 1 0000000000000000 100 0 0 10 0"
         );
 
         let entries = parse_proc_net(&content, Protocol::Tcp, AddressFamily::V6);

--- a/src/modules/pam_monitor.rs
+++ b/src/modules/pam_monitor.rs
@@ -668,7 +668,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "auth required pam_unix.so\n").unwrap();
+        writeln!(tmpfile, "auth required pam_unix.so").unwrap();
         let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
@@ -678,7 +678,7 @@ mod tests {
     #[test]
     fn test_scan_files_with_single_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "auth required pam_unix.so\n").unwrap();
+        writeln!(tmpfile, "auth required pam_unix.so").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path.clone()];
@@ -719,7 +719,7 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "auth required pam_unix.so\n").unwrap();
+        writeln!(tmpfile, "auth required pam_unix.so").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path];
@@ -983,7 +983,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "auth required pam_unix.so\n").unwrap();
+        writeln!(tmpfile, "auth required pam_unix.so").unwrap();
 
         let config = PamMonitorConfig {
             enabled: true,
@@ -1007,7 +1007,7 @@ mod tests {
         std::fs::write(&dir_file, "auth required pam_unix.so\n").unwrap();
 
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "session required pam_loginuid.so\n").unwrap();
+        writeln!(tmpfile, "session required pam_loginuid.so").unwrap();
 
         let watch_paths = vec![tmpfile.path().to_path_buf(), tmpdir.path().to_path_buf()];
         let result = PamMonitorModule::scan_files(&watch_paths);

--- a/src/modules/proc_net_monitor.rs
+++ b/src/modules/proc_net_monitor.rs
@@ -692,8 +692,10 @@ mod tests {
 
     #[test]
     fn test_init_zero_interval() {
-        let mut config = ProcNetMonitorConfig::default();
-        config.scan_interval_secs = 0;
+        let config = ProcNetMonitorConfig {
+            scan_interval_secs: 0,
+            ..Default::default()
+        };
         let mut module = ProcNetMonitorModule::new(config, None);
         assert!(module.init().is_err());
     }

--- a/src/modules/process_exec_monitor.rs
+++ b/src/modules/process_exec_monitor.rs
@@ -697,8 +697,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_initial_scan_returns_processes() {
-        let mut config = ProcessExecMonitorConfig::default();
-        config.scan_interval_secs = 60;
+        let config = ProcessExecMonitorConfig {
+            scan_interval_secs: 60,
+            ..Default::default()
+        };
         let mut module = ProcessExecMonitorModule::new(config, None);
         module.init().unwrap();
 

--- a/src/modules/seccomp_monitor.rs
+++ b/src/modules/seccomp_monitor.rs
@@ -188,9 +188,9 @@ impl SeccompMonitorModule {
                         }
                         has_changes = true;
                     }
-                    None => {
+                    None
                         // 新たに出現した監視対象プロセス
-                        if info.seccomp_mode == 0 {
+                        if info.seccomp_mode == 0 => {
                             let details = format!(
                                 "PID={}, プロセス={}, モード=0(DISABLED)",
                                 info.pid, info.name
@@ -213,7 +213,6 @@ impl SeccompMonitorModule {
                             }
                             has_changes = true;
                         }
-                    }
                     _ => {
                         // モード変更なし
                     }
@@ -338,8 +337,8 @@ impl Module for SeccompMonitorModule {
 
         let scan_snapshot: BTreeMap<String, String> = snapshot
             .processes
-            .iter()
-            .flat_map(|(_, infos)| {
+            .values()
+            .flat_map(|infos| {
                 infos.iter().map(|info| {
                     (
                         format!("{}:{}", info.name, info.pid),

--- a/src/modules/security_files_monitor.rs
+++ b/src/modules/security_files_monitor.rs
@@ -584,7 +584,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "* soft nofile 1024\n").unwrap();
+        writeln!(tmpfile, "* soft nofile 1024").unwrap();
         let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn test_scan_files_with_single_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "* soft nofile 1024\n").unwrap();
+        writeln!(tmpfile, "* soft nofile 1024").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path.clone()];
@@ -635,7 +635,7 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "* soft nofile 1024\n").unwrap();
+        writeln!(tmpfile, "* soft nofile 1024").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path];
@@ -754,7 +754,11 @@ mod tests {
         std::fs::write(&file, "* hard nofile unlimited\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert_eq!(reported.len(), 1);
         assert!(reported.iter().next().unwrap().starts_with("unlimited:"));
     }
@@ -766,7 +770,11 @@ mod tests {
         std::fs::write(&file, "* soft nofile 1024\n* hard nofile 4096\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert!(reported.is_empty());
     }
 
@@ -777,7 +785,11 @@ mod tests {
         std::fs::write(&file, "root hard nofile unlimited\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         // root ユーザー限定なので検出しない
         assert!(reported.is_empty());
     }
@@ -802,7 +814,11 @@ mod tests {
         std::fs::write(&file, "* hard nofile unlimited\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         // access.conf は limits 形式ではないので検出しない
         assert!(reported.is_empty());
     }
@@ -814,7 +830,11 @@ mod tests {
         std::fs::write(&file, "# * hard nofile unlimited\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert!(reported.is_empty());
     }
 
@@ -825,12 +845,20 @@ mod tests {
         std::fs::write(&file, "* hard nofile unlimited\n").unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert_eq!(reported.len(), 1);
 
         // 二回目は新規検出なし
         let before = reported.len();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert_eq!(reported.len(), before);
     }
 
@@ -845,7 +873,11 @@ mod tests {
         .unwrap();
 
         let mut reported = HashSet::new();
-        SecurityFilesMonitorModule::check_dangerous_patterns(&[file.clone()], &mut reported, &None);
+        SecurityFilesMonitorModule::check_dangerous_patterns(
+            std::slice::from_ref(&file),
+            &mut reported,
+            &None,
+        );
         assert_eq!(reported.len(), 3);
     }
 
@@ -876,7 +908,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "* soft nofile 1024\n").unwrap();
+        writeln!(tmpfile, "* soft nofile 1024").unwrap();
 
         let config = SecurityFilesMonitorConfig {
             enabled: true,
@@ -900,7 +932,7 @@ mod tests {
         std::fs::write(&dir_file, "* soft nofile 1024\n").unwrap();
 
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "+ : ALL : LOCAL\n").unwrap();
+        writeln!(tmpfile, "+ : ALL : LOCAL").unwrap();
 
         let watch_paths = vec![tmpfile.path().to_path_buf(), tmpdir.path().to_path_buf()];
         let result = SecurityFilesMonitorModule::scan_files(&watch_paths);
@@ -928,7 +960,7 @@ mod tests {
     #[test]
     fn test_collect_files_to_check_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "test\n").unwrap();
+        writeln!(tmpfile, "test").unwrap();
         let result = collect_files_to_check(&tmpfile.path().to_path_buf());
         assert_eq!(result.len(), 1);
     }

--- a/src/modules/shell_config_monitor.rs
+++ b/src/modules/shell_config_monitor.rs
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        writeln!(tmpfile, "export PATH=/usr/local/bin:$PATH").unwrap();
         let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
@@ -407,7 +407,7 @@ mod tests {
     #[test]
     fn test_scan_files_with_single_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        writeln!(tmpfile, "export PATH=/usr/local/bin:$PATH").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path.clone()];
@@ -433,7 +433,7 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        writeln!(tmpfile, "export PATH=/usr/local/bin:$PATH").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path];
@@ -572,7 +572,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        writeln!(tmpfile, "export PATH=/usr/local/bin:$PATH").unwrap();
 
         let config = ShellConfigMonitorConfig {
             enabled: true,
@@ -593,8 +593,8 @@ mod tests {
     async fn test_initial_scan_with_files() {
         let mut tmpfile1 = tempfile::NamedTempFile::new().unwrap();
         let mut tmpfile2 = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile1, "export PATH=/usr/local/bin:$PATH\n").unwrap();
-        write!(tmpfile2, "export EDITOR=vim\n").unwrap();
+        writeln!(tmpfile1, "export PATH=/usr/local/bin:$PATH").unwrap();
+        writeln!(tmpfile2, "export EDITOR=vim").unwrap();
 
         let config = ShellConfigMonitorConfig {
             enabled: true,
@@ -640,7 +640,7 @@ mod tests {
     #[tokio::test]
     async fn test_periodic_scan_records_scan_duration() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "export PATH=/usr/local/bin:$PATH\n").unwrap();
+        writeln!(tmpfile, "export PATH=/usr/local/bin:$PATH").unwrap();
 
         let config = ShellConfigMonitorConfig {
             enabled: true,

--- a/src/modules/ssh_key_monitor.rs
+++ b/src/modules/ssh_key_monitor.rs
@@ -406,7 +406,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "ssh-rsa AAAAB3... user@host\n").unwrap();
+        writeln!(tmpfile, "ssh-rsa AAAAB3... user@host").unwrap();
         let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
@@ -416,7 +416,7 @@ mod tests {
     #[test]
     fn test_scan_files_with_single_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "ssh-rsa AAAAB3... user@host\n").unwrap();
+        writeln!(tmpfile, "ssh-rsa AAAAB3... user@host").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path.clone()];
@@ -442,7 +442,7 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "ssh-rsa AAAAB3... user@host\n").unwrap();
+        writeln!(tmpfile, "ssh-rsa AAAAB3... user@host").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path];
@@ -581,7 +581,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "ssh-rsa AAAAB3... user@host\n").unwrap();
+        writeln!(tmpfile, "ssh-rsa AAAAB3... user@host").unwrap();
 
         let config = SshKeyMonitorConfig {
             enabled: true,

--- a/src/modules/sshd_config_monitor.rs
+++ b/src/modules/sshd_config_monitor.rs
@@ -211,9 +211,8 @@ fn audit_directives(
         let value_lower = directive.value.to_ascii_lowercase();
 
         match key_lower.as_str() {
-            "permitrootlogin" if config.check_permit_root_login => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            "permitrootlogin" if config.check_permit_root_login && value_lower == "yes" => {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Critical,
@@ -222,12 +221,12 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
-                // without-password, prohibit-password, no は安全
             }
-            "passwordauthentication" if config.check_password_authentication => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            // without-password, prohibit-password, no は安全
+            "passwordauthentication"
+                if config.check_password_authentication && value_lower == "yes" =>
+            {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Warning,
@@ -236,11 +235,11 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
-            "permitemptypasswords" if config.check_permit_empty_passwords => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            "permitemptypasswords"
+                if config.check_permit_empty_passwords && value_lower == "yes" =>
+            {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Critical,
@@ -249,24 +248,20 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
-            "protocol" if config.check_protocol_version => {
-                if value_lower.contains('1') {
-                    findings.push(AuditFinding {
-                        directive: directive.key.clone(),
-                        value: directive.value.clone(),
-                        severity: Severity::Critical,
-                        message: format!(
-                            "Protocol に 1 が含まれています（行 {}）。SSH プロトコル v1 は脆弱です",
-                            directive.line_number
-                        ),
-                    });
-                }
+            "protocol" if config.check_protocol_version && value_lower.contains('1') => {
+                findings.push(AuditFinding {
+                    directive: directive.key.clone(),
+                    value: directive.value.clone(),
+                    severity: Severity::Critical,
+                    message: format!(
+                        "Protocol に 1 が含まれています（行 {}）。SSH プロトコル v1 は脆弱です",
+                        directive.line_number
+                    ),
+                });
             }
-            "x11forwarding" if config.check_x11_forwarding => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            "x11forwarding" if config.check_x11_forwarding && value_lower == "yes" => {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Info,
@@ -275,11 +270,9 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
-            "strictmodes" if config.check_strict_modes => {
-                if value_lower == "no" {
-                    findings.push(AuditFinding {
+            "strictmodes" if config.check_strict_modes && value_lower == "no" => {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Warning,
@@ -288,7 +281,6 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
             "maxauthtries" if config.check_max_auth_tries => {
                 if let Ok(tries) = directive.value.parse::<u32>()
@@ -305,9 +297,8 @@ fn audit_directives(
                     });
                 }
             }
-            "gatewayports" if config.check_gateway_ports => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            "gatewayports" if config.check_gateway_ports && value_lower == "yes" => {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Warning,
@@ -316,11 +307,9 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
-            "permittunnel" if config.check_permit_tunnel => {
-                if value_lower == "yes" {
-                    findings.push(AuditFinding {
+            "permittunnel" if config.check_permit_tunnel && value_lower == "yes" => {
+                findings.push(AuditFinding {
                         directive: directive.key.clone(),
                         value: directive.value.clone(),
                         severity: Severity::Info,
@@ -329,7 +318,6 @@ fn audit_directives(
                             directive.line_number
                         ),
                     });
-                }
             }
             _ => {}
         }

--- a/src/modules/sudoers_monitor.rs
+++ b/src/modules/sudoers_monitor.rs
@@ -415,7 +415,7 @@ mod tests {
     #[test]
     fn test_build_file_snapshot_deterministic() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
         let snapshot1 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         let snapshot2 = build_file_snapshot(&tmpfile.path().to_path_buf()).unwrap();
         assert_eq!(snapshot1.file_hash, snapshot2.file_hash);
@@ -425,7 +425,7 @@ mod tests {
     #[test]
     fn test_scan_files_with_single_file() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path.clone()];
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn test_detect_no_changes() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
         let path = tmpfile.path().to_path_buf();
 
         let watch_paths = vec![path];
@@ -605,7 +605,7 @@ mod tests {
     #[tokio::test]
     async fn test_start_and_stop() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
 
         let config = SudoersMonitorConfig {
             enabled: true,
@@ -629,7 +629,7 @@ mod tests {
         std::fs::write(&dir_file, "user ALL=(ALL) ALL\n").unwrap();
 
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
 
         let watch_paths = vec![tmpfile.path().to_path_buf(), tmpdir.path().to_path_buf()];
         let result = SudoersMonitorModule::scan_files(&watch_paths);
@@ -660,8 +660,8 @@ mod tests {
     async fn test_initial_scan_with_files() {
         let mut tmpfile1 = tempfile::NamedTempFile::new().unwrap();
         let mut tmpfile2 = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile1, "root ALL=(ALL:ALL) ALL\n").unwrap();
-        write!(tmpfile2, "%admin ALL=(ALL) ALL\n").unwrap();
+        writeln!(tmpfile1, "root ALL=(ALL:ALL) ALL").unwrap();
+        writeln!(tmpfile2, "%admin ALL=(ALL) ALL").unwrap();
 
         let config = SudoersMonitorConfig {
             enabled: true,
@@ -707,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn test_periodic_scan_records_scan_duration() {
         let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
-        write!(tmpfile, "root ALL=(ALL:ALL) ALL\n").unwrap();
+        writeln!(tmpfile, "root ALL=(ALL:ALL) ALL").unwrap();
 
         let config = SudoersMonitorConfig {
             enabled: true,


### PR DESCRIPTION
## 概要

Closes #339

Rust 1.95.0 で追加された clippy lint により main ブランチで発生していた **111 件の警告 + 1 件のエラー**（`absurd_extreme_comparisons`）を全て解消。CI で `cargo clippy --all-targets -- -D warnings` を強制できる状態に戻した。

## 変更内容

### 自動修正（`cargo clippy --fix --all-targets`）

- `write_with_newline` 37 件（テストコード中の `write!(f, \"...\n\")` を `writeln!` に置換）
- `collapsible_match` 10 件
- `unnecessary_to_owned` 9 件
- `needless_borrows_for_generic_args` 4 件
- `assert_eq!` with literal bool 3 件
- `let_and_return` 2 件
- `unused_imports` 2 件
- その他の軽微な warning

### 手動修正

| lint | 件数 | 修正内容 |
|------|------|---------|
| `absurd_extreme_comparisons`（error） | 2 | `report.total_duration.as_nanos() >= 0` / `scan.items_scanned >= 0` の常真比較を削除（型の性質上自明） |
| `cloned_ref_to_slice_refs` | 22 | `&[x.clone()]` → `std::slice::from_ref(&x)` |
| `field_reassign_with_default` | 7 | `Default::default()` 後の個別代入を構造体初期化子 + `..Default::default()` に統合 |
| `format_in_format_args` | 5 | ネストした `format!()` を単一の `format!(\"{:08X}...\", ...)` に統合 |
| `unnecessary_get_then_check` | 2 | `debounce_map.get(&path).is_none()` → `!debounce_map.contains_key(&path)` |
| `while_let_loop` | 2 | `loop { let Some(x) = ... else { break }; }` → `while let Some(x) = ...` |
| `unnecessary_sort_by` | 2 | `sort_by(\|a, b\| b.x.cmp(&a.x))` → `sort_by_key(\|s\| Reverse(s.x))` |
| `type_complexity` | 1 | `&[(u32, &str, &[(&str, &str)])]` にテスト専用の型別名を導入 |

### 追加

- `cargo fmt` を実行し `sshd_config_monitor.rs` 等の自動修正後のインデントを整形

## 検証

- [x] `cargo build --release` — 成功
- [x] `cargo clippy --all-targets -- -D warnings` — 警告ゼロ
- [x] `cargo test` — **2439 件全て pass**（0 failed）
  - lib test: 2383 件
  - bin test: 18 件
  - integration test: 38 件
- [x] `cargo fmt --check` — 差分なし

## 機能への影響

**なし**。純粋に lint 対応のみで機能変更は行っていない。

## バージョン

v1.66.0 に更新（`Cargo.toml`）。