### PR TITLE
feat: ntp_config_monitor に refclock 監査を追加 (#353)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ src/
     network_interface_monitor.rs # ネットワークインターフェース監視モジュール
     network_monitor.rs # ネットワーク接続監視モジュール
     network_traffic_monitor.rs # ネットワークトラフィック異常検知モジュール
-    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視対応）
+    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査対応）
     pam_monitor.rs     # PAM 設定監視モジュール
     privilege_escalation_monitor.rs # プロセス権限昇格検知モジュール
     proc_environ_monitor.rs # プロセス環境変数スナップショット監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.72.0"
+version = "1.73.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.72.0"
+version = "1.73.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1520,6 +1520,15 @@ check_chrony_leapsectz = true
 # - `0 < maxsamples < maxsamples_min_threshold` の過少設定 → Warning
 # - `minsamples > maxsamples`（maxsamples != 0）の設定矛盾 → Warning
 check_chrony_sample_counts = true
+# chrony の `refclock` ディレクティブを監査し、`allowed_refclock_drivers` に
+# 含まれないドライバが使われていれば Warning。特に `SHM` は /dev/shm 経由の
+# 時刻注入攻撃に利用されうるため、明示的に許可されていない場合は追加の警告文を付与する。
+check_chrony_refclock = true
+# `check_chrony_refclock` で許容する refclock ドライバ名（大文字小文字無視）。
+# 既定は空配列 = refclock の使用を一切許可しない（refclock を設定していない環境向け）。
+# PTP / GPS / PPS を正規に使っている環境では該当ドライバを明示的に列挙する。
+# 例: allowed_refclock_drivers = ["PHC", "PPS", "SOCK"]
+allowed_refclock_drivers = []
 # `maxsamples_too_low` 判定の下限閾値（既定: 4）
 # chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
 # 0 に設定すると maxsamples 過少の検知を事実上無効化できる

--- a/src/config.rs
+++ b/src/config.rs
@@ -6192,6 +6192,19 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_sample_counts: bool,
 
+    /// chrony の `refclock` ディレクティブを監査し、`allowed_refclock_drivers` に
+    /// 含まれないドライバが使われていれば Warning を発行する
+    /// （特に `SHM` は共有メモリ経由の時刻注入攻撃の足場になりうるため、
+    /// 明示的に許可されていない限り必ず警告する）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_refclock: bool,
+
+    /// `check_chrony_refclock` で許容する refclock ドライバ名一覧
+    /// （大文字小文字は無視して比較する。既定は空 = refclock の使用を一切許可しない）
+    /// 例: `["PHC", "PPS", "SOCK"]`
+    #[serde(default)]
+    pub allowed_refclock_drivers: Vec<String>,
+
     /// `maxsamples_too_low` 判定の下限閾値（既定: 4）
     /// chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
     #[serde(default = "NtpConfigMonitorConfig::default_maxsamples_min_threshold")]
@@ -6295,6 +6308,8 @@ impl Default for NtpConfigMonitorConfig {
             check_keys_file_owner: true,
             check_chrony_leapsectz: true,
             check_chrony_sample_counts: true,
+            check_chrony_refclock: true,
+            allowed_refclock_drivers: Vec::new(),
             maxsamples_min_threshold: Self::default_maxsamples_min_threshold(),
             allowed_owner_uids: Self::default_allowed_uids(),
             allowed_owner_gids: Self::default_allowed_gids(),

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -28,6 +28,9 @@
 //!     サンプル数不足による時刻精度・外れ値耐性低下）
 //!   - `chrony.conf`: `minsamples > maxsamples`（同期に必要なサンプル数が採取できない
 //!     設定矛盾）
+//!   - `chrony.conf`: `refclock` ディレクティブで `allowed_refclock_drivers` に
+//!     含まれないドライバが使われている（特に `SHM` は /dev/shm 経由の時刻注入攻撃
+//!     の足場となりうる）
 //! - **ドロップイン監視** — `chrony.conf` 内の `confdir` / `sourcedir` / `include`
 //!   ディレクティブで参照される追加設定ファイル（例: `/etc/chrony/conf.d/*.conf`、
 //!   `/etc/chrony/sources.d/*.sources`）も監視対象に加え、親ディレクトリも inotify
@@ -763,6 +766,53 @@ fn audit_chrony_sample_counts(content: &str, maxsamples_min_threshold: u32) -> V
     findings
 }
 
+/// chrony.conf の `refclock` ディレクティブを監査する
+///
+/// 各 `refclock <driver> <parameters>` 行からドライバ名を抽出し、
+/// `allowed_drivers`（大文字小文字無視）に含まれないドライバが使われていれば
+/// Warning を発行する。特に `SHM` ドライバは /dev/shm 配下の共有メモリセグメントを
+/// 時刻ソースとして参照するため、攻撃者が SHM セグメントへの書き込み権限を得ていれば
+/// 任意の時刻を注入可能になる。明示的に許可されていない場合は SHM 固有の
+/// 追加メッセージを付与する。
+fn audit_chrony_refclock(content: &str, allowed_drivers: &[String]) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    let allowed_upper: BTreeSet<String> = allowed_drivers
+        .iter()
+        .map(|d| d.trim().to_ascii_uppercase())
+        .filter(|d| !d.is_empty())
+        .collect();
+    let mut reported: BTreeSet<String> = BTreeSet::new();
+
+    for value in find_keyword_lines(content, "refclock") {
+        let driver = match value.split_whitespace().next() {
+            Some(d) if !d.is_empty() => d,
+            _ => continue,
+        };
+        let driver_upper = driver.to_ascii_uppercase();
+        if allowed_upper.contains(&driver_upper) {
+            continue;
+        }
+        if !reported.insert(driver_upper.clone()) {
+            continue;
+        }
+        let suffix = if driver_upper == "SHM" {
+            "（SHM refclock is a known time-injection attack vector — 書き込み可能な SHM セグメントを共有するプロセスから時刻を偽装される恐れがあります）"
+        } else {
+            ""
+        };
+        findings.push(AuditFinding {
+            kind: "chrony_refclock_unexpected".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf に想定外の refclock ドライバ `{}` が設定されています。\
+                 `allowed_refclock_drivers` に明示的に追加されていないドライバは外部時刻ソース偽装の原因になりうるため確認してください{}",
+                driver, suffix
+            ),
+        });
+    }
+    findings
+}
+
 /// chrony のドロップイン取り込みディレクティブ
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ChronyDropinSpec {
@@ -1038,6 +1088,12 @@ fn audit_by_kind(
                 findings.extend(audit_chrony_sample_counts(
                     content,
                     config.maxsamples_min_threshold,
+                ));
+            }
+            if config.check_chrony_refclock {
+                findings.extend(audit_chrony_refclock(
+                    content,
+                    &config.allowed_refclock_drivers,
                 ));
             }
         }
@@ -3376,6 +3432,162 @@ mod tests {
                 .iter()
                 .all(|f| f.kind != "chrony_maxsamples_too_low"
                     && f.kind != "chrony_minsamples_exceeds_maxsamples")
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // audit_chrony_refclock
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_refclock_unexpected_driver_warns() {
+        let content = "pool foo\nrefclock SHM 0 refid SHM0\n";
+        let findings = audit_chrony_refclock(content, &[]);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_refclock_unexpected");
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert!(
+            findings[0].message.contains("SHM"),
+            "message should identify the driver: {}",
+            findings[0].message
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_shm_has_attack_vector_note() {
+        let content = "refclock SHM 0\n";
+        let findings = audit_chrony_refclock(content, &[]);
+        assert_eq!(findings.len(), 1);
+        assert!(
+            findings[0].message.contains("time-injection attack vector"),
+            "SHM should carry the explicit attack-vector note: {}",
+            findings[0].message
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_non_shm_omits_shm_note() {
+        let content = "refclock PHC /dev/ptp0 poll 0\n";
+        let findings = audit_chrony_refclock(content, &[]);
+        assert_eq!(findings.len(), 1);
+        assert!(
+            !findings[0].message.contains("time-injection"),
+            "non-SHM drivers should not include the SHM-specific note: {}",
+            findings[0].message
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_allowed_driver_not_reported() {
+        let content = "refclock PHC /dev/ptp0 poll 0\n";
+        let findings = audit_chrony_refclock(content, &["phc".to_string()]);
+        assert!(
+            findings.is_empty(),
+            "allowed driver match is case-insensitive"
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_allow_list_mixes_ok_and_bad() {
+        let content = "refclock PHC /dev/ptp0 poll 0\nrefclock SHM 0 refid SHM0\n";
+        let findings = audit_chrony_refclock(content, &["PHC".to_string()]);
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].message.contains("SHM"));
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_deduplicates_same_driver() {
+        let content = "refclock SHM 0\nrefclock SHM 1\n";
+        let findings = audit_chrony_refclock(content, &[]);
+        assert_eq!(findings.len(), 1, "same driver reported only once per scan");
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_ignores_comments_and_empty_lines() {
+        let content = "# refclock SHM 0\n; refclock SHM 1\n\nrefclock\nrefclock  \n";
+        let findings = audit_chrony_refclock(content, &[]);
+        assert!(
+            findings.is_empty(),
+            "comments and empty driver tokens should be ignored: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_refclock_allow_list_empty_string_ignored() {
+        // 空文字列エントリ（TOML での `allowed_refclock_drivers = [""]` 等）は
+        // 許可リストに含まれないとして扱う
+        let content = "refclock SHM 0\n";
+        let findings = audit_chrony_refclock(content, &["".to_string(), "  ".to_string()]);
+        assert_eq!(findings.len(), 1);
+    }
+
+    #[test]
+    fn test_audit_by_kind_refclock_flag_toggle() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = "pool 2.pool.ntp.org iburst\nmakestep 1.0 3\nleapsectz right/UTC\nrefclock SHM 0 refid SHM0\n";
+
+        let mut config = NtpConfigMonitorConfig {
+            check_keys_file_owner: false,
+            check_config_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_refclock_unexpected"),
+            "refclock audit should fire by default"
+        );
+
+        config.check_chrony_refclock = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_refclock_unexpected"),
+            "disabling check_chrony_refclock suppresses the finding"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_refclock_honors_allow_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = "pool 2.pool.ntp.org iburst\nmakestep 1.0 3\nleapsectz right/UTC\nrefclock PHC /dev/ptp0 poll 0\n";
+
+        let config = NtpConfigMonitorConfig {
+            check_keys_file_owner: false,
+            check_config_owner: false,
+            allowed_refclock_drivers: vec!["PHC".to_string()],
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_refclock_unexpected"),
+            "allowed drivers must not produce findings"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_ntp_does_not_trigger_chrony_refclock() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("ntp.conf");
+        let content = "server 0.pool.ntp.org iburst\nrestrict default ignore\ndriftfile /var/ntp.drift\nrefclock SHM 0\n";
+
+        let config = NtpConfigMonitorConfig {
+            check_keys_file_owner: false,
+            check_config_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Ntp, content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_refclock_unexpected"),
+            "ntp.conf path should not dispatch chrony-specific refclock audit"
         );
     }
 


### PR DESCRIPTION
Closes #353

## Summary

- chrony の `refclock` ディレクティブを監査し、`allowed_refclock_drivers` に含まれないドライバが設定されていれば Warning を発行する `audit_chrony_refclock` を追加
- 特に `SHM` ドライバは共有メモリ経由の時刻注入攻撃（time-injection attack vector）に使われうるため、許可リストに含まれない場合は明示的な警告文を付与
- `check_chrony_refclock: bool`（既定 true）および `allowed_refclock_drivers: Vec<String>`（既定 []、比較は大文字小文字無視）を設定に追加
- ドロップイン経由（`confdir` / `sourcedir` / `include`）で取り込まれた chrony 設定ファイルも、既存 `audit_by_kind` の dispatch 経由で自動的に対象となる
- 単体テスト 11 本追加（ドライバ未許可 / 許可 / SHM メッセージ / 重複排除 / フラグ切替 / ntp.conf では非発火 / コメント行の無視 / 空文字列エントリの無視 / 許可リストと未許可の混在）

## Test plan

- [x] `cargo build`
- [x] `cargo test` (2495 + 18 + 38 すべて pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `config.example.toml` / CLAUDE.md 更新