### PR TITLE
feat: ntp_config_monitor に maxdistance / maxjitter 監査を追加 (#357)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.74.0"
+version = "1.75.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.74.0"
+version = "1.75.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1537,6 +1537,18 @@ check_chrony_rtcsync = true
 # 相対パス指定では chronyd の作業ディレクトリ依存となり、RTC ドリフト情報が
 # 意図しない位置に保存される。`driftfile` と同じパターンで監査する。
 check_chrony_rtcfile = true
+# chrony の `maxdistance` が許容上限を超えている場合を検知（Warning）
+# root distance の許容値が緩すぎると劣化した時刻ソースが同期候補に残り、
+# 中間者攻撃や偽装 NTP サーバによる時刻偽装の余地が広がる
+check_chrony_maxdistance = true
+# chrony の `maxjitter` が許容上限を超えている場合を検知（Warning）
+# jitter の許容値が緩すぎるとジッターの大きい時刻ソースが候補に残り、
+# 時刻同期の安定性と偽装耐性が低下する
+check_chrony_maxjitter = true
+# `maxdistance` 監査の許容上限（秒、既定 5.0）。chrony のデフォルトは 3.0 秒
+maxdistance_max_threshold = 5.0
+# `maxjitter` 監査の許容上限（秒、既定 2.0）。chrony のデフォルトは 1.0 秒
+maxjitter_max_threshold = 2.0
 # `maxsamples_too_low` 判定の下限閾値（既定: 4）
 # chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
 # 0 に設定すると maxsamples 過少の検知を事実上無効化できる

--- a/src/config.rs
+++ b/src/config.rs
@@ -6217,6 +6217,28 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_rtcfile: bool,
 
+    /// chrony の `maxdistance` ディレクティブが許容上限を超えている場合を検知
+    /// （root distance の上限が緩すぎると劣化した時刻ソースが同期候補に残り、
+    /// 中間者攻撃や偽装 NTP サーバによる時刻偽装の余地が広がる）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_maxdistance: bool,
+
+    /// chrony の `maxjitter` ディレクティブが許容上限を超えている場合を検知
+    /// （jitter の上限が緩すぎるとジッターの大きい時刻ソースが候補に残り、
+    /// 時刻偽装・不安定な時刻同期の原因となる）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_maxjitter: bool,
+
+    /// `maxdistance` の許容上限（秒、既定 5.0）
+    /// chrony のデフォルトは 3.0 秒なので 5.0 秒超は明示的な緩和設定と判定する
+    #[serde(default = "NtpConfigMonitorConfig::default_maxdistance_max_threshold")]
+    pub maxdistance_max_threshold: f64,
+
+    /// `maxjitter` の許容上限（秒、既定 2.0）
+    /// chrony のデフォルトは 1.0 秒
+    #[serde(default = "NtpConfigMonitorConfig::default_maxjitter_max_threshold")]
+    pub maxjitter_max_threshold: f64,
+
     /// `maxsamples_too_low` 判定の下限閾値（既定: 4）
     /// chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
     #[serde(default = "NtpConfigMonitorConfig::default_maxsamples_min_threshold")]
@@ -6290,6 +6312,14 @@ impl NtpConfigMonitorConfig {
         4
     }
 
+    fn default_maxdistance_max_threshold() -> f64 {
+        5.0
+    }
+
+    fn default_maxjitter_max_threshold() -> f64 {
+        2.0
+    }
+
     fn default_inotify_debounce_ms() -> u64 {
         500
     }
@@ -6324,6 +6354,10 @@ impl Default for NtpConfigMonitorConfig {
             allowed_refclock_drivers: Vec::new(),
             check_chrony_rtcsync: true,
             check_chrony_rtcfile: true,
+            check_chrony_maxdistance: true,
+            check_chrony_maxjitter: true,
+            maxdistance_max_threshold: Self::default_maxdistance_max_threshold(),
+            maxjitter_max_threshold: Self::default_maxjitter_max_threshold(),
             maxsamples_min_threshold: Self::default_maxsamples_min_threshold(),
             allowed_owner_uids: Self::default_allowed_uids(),
             allowed_owner_gids: Self::default_allowed_gids(),

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -37,6 +37,12 @@
 //!   - `chrony.conf`: `rtcfile` が指定されているが絶対パスでない（`driftfile` と同様、
 //!     chronyd の作業ディレクトリ依存の書き込みとなり RTC ドリフト情報が
 //!     意図しない位置に保存される）
+//!   - `chrony.conf`: `maxdistance` が推奨上限を超えている（root distance の許容値が
+//!     緩すぎると劣化した時刻ソースが同期候補に残り、中間者攻撃や偽装 NTP サーバに
+//!     よる時刻偽装の余地が広がる）
+//!   - `chrony.conf`: `maxjitter` が推奨上限を超えている（jitter の許容値が緩すぎると
+//!     ジッターの大きい時刻ソースが同期候補に残り、時刻同期の安定性と偽装耐性が
+//!     低下する）
 //! - **ドロップイン監視** — `chrony.conf` 内の `confdir` / `sourcedir` / `include`
 //!   ディレクティブで参照される追加設定ファイル（例: `/etc/chrony/conf.d/*.conf`、
 //!   `/etc/chrony/sources.d/*.sources`）も監視対象に加え、親ディレクトリも inotify
@@ -729,6 +735,22 @@ fn parse_chrony_top_level_u32(content: &str, keyword: &str) -> Option<u32> {
     last
 }
 
+/// chrony.conf の top-level ディレクティブから f64 値をパースする
+///
+/// `find_keyword_lines` は行頭トークンが一致した行のみ返すため、
+/// `server ... maxdistance N` のような inline オプションには一致せず、top-level 設定だけを拾える。
+/// 複数行がある場合は後者が優先。値として数値でないトークンは無視する。
+fn parse_chrony_top_level_f64(content: &str, keyword: &str) -> Option<f64> {
+    let mut last: Option<f64> = None;
+    for value in find_keyword_lines(content, keyword) {
+        let token = value.split_whitespace().next().unwrap_or("").trim();
+        if let Ok(n) = token.parse::<f64>() {
+            last = Some(n);
+        }
+    }
+    last
+}
+
 /// chrony.conf の `maxsamples` / `minsamples` のサンプル数設定を監査する
 ///
 /// - `maxsamples` が 0（= 無制限）を除き閾値未満 → `chrony_maxsamples_too_low` (Warning)
@@ -769,6 +791,58 @@ fn audit_chrony_sample_counts(content: &str, maxsamples_min_threshold: u32) -> V
         });
     }
 
+    findings
+}
+
+/// chrony.conf の `maxdistance` が許容上限を超えている場合を監査する
+///
+/// `maxdistance` は時刻ソースの root distance の上限値（秒）。chrony の既定は 3.0 秒で、
+/// この閾値を超えた時刻ソースは同期候補から除外される。値を過度に緩めると劣化した
+/// NTP サーバ（中間者攻撃で遅延された応答、意図的に root distance を大きく返す偽装サーバ等）
+/// が候補に残り、時刻偽装耐性が低下する。
+///
+/// 0 以下の値は設定ミス扱いとし、本監査の対象外とする（chrony 側で拒否される値域）。
+fn audit_chrony_maxdistance(content: &str, max_threshold: f64) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    if let Some(v) = parse_chrony_top_level_f64(content, "maxdistance")
+        && v > 0.0
+        && v > max_threshold
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_maxdistance_too_large".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf の `maxdistance {}` は推奨上限（{} 秒）を超えています（root distance の許容値が緩すぎると劣化した時刻ソースが同期候補に残り、中間者攻撃や偽装 NTP サーバによる時刻偽装の余地が広がります）",
+                v, max_threshold
+            ),
+        });
+    }
+    findings
+}
+
+/// chrony.conf の `maxjitter` が許容上限を超えている場合を監査する
+///
+/// `maxjitter` は時刻ソースの推定ジッターの上限値（秒）。chrony の既定は 1.0 秒で、
+/// この閾値を超えた時刻ソースは候補から外される。値を過度に緩めるとジッターの大きい
+/// 時刻ソース（低品質ソース、攻撃者が意図的にジッターを増やしたソース）が候補に残り、
+/// 時刻同期の安定性と偽装耐性が低下する。
+///
+/// 0 以下の値は設定ミス扱いとし、本監査の対象外とする（chrony 側で拒否される値域）。
+fn audit_chrony_maxjitter(content: &str, max_threshold: f64) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    if let Some(v) = parse_chrony_top_level_f64(content, "maxjitter")
+        && v > 0.0
+        && v > max_threshold
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_maxjitter_too_large".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf の `maxjitter {}` は推奨上限（{} 秒）を超えています（jitter の許容値が緩すぎるとジッターの大きい時刻ソースが同期候補に残り、時刻同期の安定性と偽装耐性が低下します）",
+                v, max_threshold
+            ),
+        });
+    }
     findings
 }
 
@@ -1153,6 +1227,18 @@ fn audit_by_kind(
             }
             if config.check_chrony_rtcfile {
                 findings.extend(audit_chrony_rtcfile_absolute(content));
+            }
+            if config.check_chrony_maxdistance {
+                findings.extend(audit_chrony_maxdistance(
+                    content,
+                    config.maxdistance_max_threshold,
+                ));
+            }
+            if config.check_chrony_maxjitter {
+                findings.extend(audit_chrony_maxjitter(
+                    content,
+                    config.maxjitter_max_threshold,
+                ));
             }
         }
         NtpConfigKind::Ntp => {
@@ -3755,6 +3841,102 @@ mod tests {
                 .iter()
                 .all(|f| f.kind == "chrony_rtcfile_not_absolute")
         );
+    }
+
+    // ------------------------------------------------------------------
+    // audit_chrony_maxdistance
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_maxdistance_detects_over_threshold() {
+        let content = "maxdistance 10.0\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxdistance_too_large");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("maxdistance"));
+    }
+
+    #[test]
+    fn test_audit_chrony_maxdistance_respects_threshold() {
+        // 境界値: 閾値ちょうどは検知しない（strict greater-than）
+        let content = "maxdistance 5.0\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxdistance_default_value_no_finding() {
+        // chrony の既定値 3.0 秒は閾値 5.0 秒以下なので検知しない
+        let content = "maxdistance 3.0\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxdistance_unset_no_finding() {
+        let content = "server foo\nmakestep 1.0 3\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxdistance_negative_no_finding() {
+        // 負値は設定ミス扱いで監査対象外
+        let content = "maxdistance -1.0\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxdistance_inline_server_option_ignored() {
+        // server ディレクティブの inline オプションは top-level 監査では拾わない
+        let content = "server ntp.example.com maxdistance 100\n";
+        let findings = audit_chrony_maxdistance(content, 5.0);
+        assert!(findings.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // audit_chrony_maxjitter
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_maxjitter_detects_over_threshold() {
+        let content = "maxjitter 5.0\n";
+        let findings = audit_chrony_maxjitter(content, 2.0);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxjitter_too_large");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("maxjitter"));
+    }
+
+    #[test]
+    fn test_audit_chrony_maxjitter_respects_threshold() {
+        // 境界値: 閾値ちょうどは検知しない
+        let content = "maxjitter 2.0\n";
+        let findings = audit_chrony_maxjitter(content, 2.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxjitter_default_value_no_finding() {
+        // chrony の既定値 1.0 秒は閾値 2.0 秒以下なので検知しない
+        let content = "maxjitter 1.0\n";
+        let findings = audit_chrony_maxjitter(content, 2.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxjitter_unset_no_finding() {
+        let content = "server foo\nmakestep 1.0 3\n";
+        let findings = audit_chrony_maxjitter(content, 2.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxjitter_inline_server_option_ignored() {
+        // server ディレクティブの inline オプションは top-level 監査では拾わない
+        let content = "server ntp.example.com maxjitter 100\n";
+        let findings = audit_chrony_maxjitter(content, 2.0);
+        assert!(findings.is_empty());
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## 概要

`ntp_config_monitor` モジュールに chrony の `maxdistance` / `maxjitter` 閾値の監査を追加する。

Closes #357

## 変更内容

- **`chrony_maxdistance_too_large`** (Severity: Warning) — `maxdistance` が `maxdistance_max_threshold`（既定 5.0 秒）を超過している場合に検知。chrony の既定値は 3.0 秒のため、5.0 秒超は明示的な緩和設定と判定する
- **`chrony_maxjitter_too_large`** (Severity: Warning) — `maxjitter` が `maxjitter_max_threshold`（既定 2.0 秒）を超過している場合に検知。chrony の既定値は 1.0 秒
- `parse_chrony_top_level_f64` ヘルパー関数を追加（既存の `parse_chrony_top_level_u32` の f64 版）。inline オプション（`server ... maxdistance N`）を誤検知しないよう、top-level 行のみを対象とする
- 設定フラグで個別無効化が可能: `check_chrony_maxdistance` / `check_chrony_maxjitter`（既定 true）
- 閾値は TOML でカスタマイズ可能: `maxdistance_max_threshold` / `maxjitter_max_threshold`

## セキュリティ動機

`maxdistance` / `maxjitter` が過度に緩められると、劣化した時刻ソース（中間者攻撃で遅延させられた NTP 応答、偽装 NTP サーバ、ジッターの大きい低品質ソース）が同期候補から除外されず、時刻偽装耐性が低下する。時刻偽装はログタイムスタンプ改ざん・TLS 証明書検証エラー・TOTP/Kerberos 失敗などの二次被害に直結する。

## テスト

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (warnings: 0)
- `cargo test` ✅ 2574 passing (+11 新規ユニットテスト)
- `cargo build --release` ✅

追加したユニットテスト:
- `test_audit_chrony_maxdistance_detects_over_threshold`
- `test_audit_chrony_maxdistance_respects_threshold`（境界: 等値は検知しない）
- `test_audit_chrony_maxdistance_default_value_no_finding`
- `test_audit_chrony_maxdistance_unset_no_finding`
- `test_audit_chrony_maxdistance_negative_no_finding`
- `test_audit_chrony_maxdistance_inline_server_option_ignored`
- `maxjitter` の同系列テスト 5 件

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)