### PR TITLE
feat: ntp_config_monitor に maxchange <max> 上限なし（-1）監査を追加 (#365)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ src/
     network_interface_monitor.rs # ネットワークインターフェース監視モジュール
     network_monitor.rs # ネットワーク接続監視モジュール
     network_traffic_monitor.rs # ネットワークトラフィック異常検知モジュール
-    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査対応）
+    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査・maxchange max -1 監査対応）
     pam_monitor.rs     # PAM 設定監視モジュール
     privilege_escalation_monitor.rs # プロセス権限昇格検知モジュール
     proc_environ_monitor.rs # プロセス環境変数スナップショット監視モジュール

--- a/config.example.toml
+++ b/config.example.toml
@@ -1554,6 +1554,10 @@ check_chrony_makestep_threshold = true
 # 未設定だと `makestep` と組み合わさって攻撃者が任意の大きなオフセットを注入可能。
 # 推奨値は `maxchange 1000 1 2`。
 check_chrony_maxchange = true
+# chrony の `maxchange <offset> <start> <max>` の第三引数 `<max>` が -1（上限なし）の場合を検知（Warning）
+# `<max>` が -1 に設定されていると、連続で閾値を超えるオフセットを受けても chronyd が
+# panic-exit しないため、持続的な時刻偽装攻撃を検知できなくなる。
+check_chrony_maxchange_max_unlimited = true
 # chrony の `corrtimeratio` が推奨上限を超えている場合を検知（Warning）
 # slew 補正に割く時間比率が過大に緩められると周波数補正フェーズが長引き、時刻精度が劣化して
 # TLS 有効期限判定・Kerberos/TOTP 時刻窓・ログ整合性に悪影響を与える

--- a/src/config.rs
+++ b/src/config.rs
@@ -6243,6 +6243,12 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_maxchange: bool,
 
+    /// chrony の `maxchange <offset> <start> <max>` の第三引数 `<max>` が `-1`
+    /// （上限なし）に設定されている場合を検知する。連続で閾値を超えるオフセットを
+    /// 受けても chronyd が panic-exit しないため、持続的な時刻偽装攻撃が素通りする
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_maxchange_max_unlimited: bool,
+
     /// chrony の `corrtimeratio` が許容上限を超えている場合を検知
     /// （slew 補正に割く時間比率の過大な緩和は周波数補正フェーズの長期化を招き、
     /// 時刻精度が劣化して TLS 有効期限判定・Kerberos/TOTP 時刻窓に影響する）
@@ -6423,6 +6429,7 @@ impl Default for NtpConfigMonitorConfig {
             check_chrony_maxjitter: true,
             check_chrony_makestep_threshold: true,
             check_chrony_maxchange: true,
+            check_chrony_maxchange_max_unlimited: true,
             check_chrony_corrtimeratio: true,
             check_chrony_maxclockerror: true,
             maxdistance_max_threshold: Self::default_maxdistance_max_threshold(),

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -875,10 +875,17 @@ fn audit_chrony_maxjitter(content: &str, max_threshold: f64) -> Vec<AuditFinding
 /// - `chrony_maxchange_offset_too_large` (Warning) — 第一引数の offset が `offset_max_threshold`
 ///   （秒）を超えている（step 量上限が実質無制限となり `makestep` と組み合わさって大幅な
 ///   時刻偽装を許容する）
+/// - `chrony_maxchange_max_unlimited` (Warning) — 第三引数の `<max>` が `-1`（上限なし）に
+///   設定されており、連続で閾値を超えるオフセットを受けても chronyd が panic-exit せず
+///   持続的な時刻偽装攻撃を検知できない
 ///
 /// 0 以下・パースできない offset トークンは `offset_too_large` 側では無視する
 /// （`unset` 検知とは独立。`unset` は maxchange 行自体の有無で判定）。
-fn audit_chrony_maxchange(content: &str, offset_max_threshold: f64) -> Vec<AuditFinding> {
+fn audit_chrony_maxchange(
+    content: &str,
+    offset_max_threshold: f64,
+    check_max_unlimited: bool,
+) -> Vec<AuditFinding> {
     let mut findings = Vec::new();
 
     let maxchange_present = find_keyword_lines(content, "maxchange").next().is_some();
@@ -907,7 +914,41 @@ fn audit_chrony_maxchange(content: &str, offset_max_threshold: f64) -> Vec<Audit
         });
     }
 
+    if check_max_unlimited
+        && let Some(max_val) = parse_chrony_maxchange_max(content)
+        && max_val <= -1
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_maxchange_max_unlimited".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf の `maxchange <offset> <start> <max>` の max（第三引数）が `{}` に設定されており、連続で閾値を超えるオフセットを受けても chronyd が panic-exit しないため、持続的な時刻偽装攻撃を検知できません（推奨: `maxchange 1000 1 2`）",
+                max_val
+            ),
+        });
+    }
+
     findings
+}
+
+/// `maxchange <offset> <start> <max>` 行の第三引数 `<max>` を整数として抽出する
+///
+/// 複数行ある場合は最後の行を採用する。トークンが 3 個未満または第三トークンが
+/// 整数としてパースできない場合は last を None へリセットする（非数値・欠損は
+/// 検知対象外）。
+fn parse_chrony_maxchange_max(content: &str) -> Option<i64> {
+    let mut last: Option<i64> = None;
+    for value in find_keyword_lines(content, "maxchange") {
+        let mut tokens = value.split_whitespace();
+        // 第1 (offset) と第2 (start) を読み飛ばす
+        let _ = tokens.next();
+        let _ = tokens.next();
+        match tokens.next().and_then(|t| t.parse::<i64>().ok()) {
+            Some(n) => last = Some(n),
+            None => last = None,
+        }
+    }
+    last
 }
 
 /// chrony.conf の `corrtimeratio` が許容上限を超えている場合を監査する
@@ -1407,6 +1448,7 @@ fn audit_by_kind(
                 findings.extend(audit_chrony_maxchange(
                     content,
                     config.maxchange_offset_max_threshold,
+                    config.check_chrony_maxchange_max_unlimited,
                 ));
             }
             if config.check_chrony_corrtimeratio {
@@ -4208,7 +4250,7 @@ mod tests {
     fn test_audit_chrony_maxchange_unset_detects() {
         // maxchange が設定されていない場合 → Warning
         let content = "pool foo\nmakestep 1.0 3\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, false);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, "chrony_maxchange_unset");
         assert!(matches!(findings[0].severity, Severity::Warning));
@@ -4219,7 +4261,7 @@ mod tests {
     fn test_audit_chrony_maxchange_recommended_no_finding() {
         // 推奨値 `maxchange 1000 1 2` は 1000 秒上限以下なので検知しない
         let content = "maxchange 1000 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert!(findings.is_empty());
     }
 
@@ -4227,7 +4269,7 @@ mod tests {
     fn test_audit_chrony_maxchange_small_offset_no_finding() {
         // 推奨値より小さな offset は正常扱い
         let content = "maxchange 500 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert!(findings.is_empty());
     }
 
@@ -4235,7 +4277,7 @@ mod tests {
     fn test_audit_chrony_maxchange_offset_too_large_detects() {
         // 2000 秒 offset は 1000 秒上限を大幅超過 → Warning
         let content = "maxchange 2000 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, "chrony_maxchange_offset_too_large");
         assert!(matches!(findings[0].severity, Severity::Warning));
@@ -4246,7 +4288,7 @@ mod tests {
     fn test_audit_chrony_maxchange_boundary_equal_no_finding() {
         // 境界値: 閾値ちょうどは検知しない（strict greater-than）
         let content = "maxchange 1000.0 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert!(findings.is_empty());
     }
 
@@ -4255,7 +4297,7 @@ mod tests {
         // offset のパース不能トークンは offset_too_large 側では無視するが、
         // maxchange 行は存在するため unset は発火しない
         let content = "maxchange abc 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, false);
         assert!(findings.is_empty());
     }
 
@@ -4264,7 +4306,7 @@ mod tests {
         // 0 以下は設定ミス扱いで offset_too_large の対象外。
         // maxchange 行自体は存在するため unset も発火しない
         let content = "maxchange 0 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert!(findings.is_empty());
     }
 
@@ -4272,7 +4314,7 @@ mod tests {
     fn test_audit_chrony_maxchange_negative_no_finding() {
         // 負値は設定ミス扱いで offset_too_large の対象外
         let content = "maxchange -1 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert!(findings.is_empty());
     }
 
@@ -4281,7 +4323,7 @@ mod tests {
         // server ディレクティブの inline トークンは top-level として認識されないため
         // maxchange 未設定扱い → chrony_maxchange_unset が発火
         let content = "server ntp.example.com maxchange 2000\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, false);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, "chrony_maxchange_unset");
     }
@@ -4289,8 +4331,9 @@ mod tests {
     #[test]
     fn test_audit_chrony_maxchange_multiple_last_wins() {
         // 複数行ある場合は後者の値が採用される
+        // check_max_unlimited=false で新ルールは抑止され、offset のみ検知
         let content = "maxchange 500 1 2\nmaxchange 5000 1 -1\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, false);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, "chrony_maxchange_offset_too_large");
         assert!(findings[0].message.contains("5000"));
@@ -4300,9 +4343,113 @@ mod tests {
     fn test_audit_chrony_maxchange_comment_does_not_count() {
         // コメント行は未設定と同等に扱われる
         let content = "# maxchange 1000 1 2\n";
-        let findings = audit_chrony_maxchange(content, 1000.0);
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
         assert_eq!(findings.len(), 1);
         assert_eq!(findings[0].kind, "chrony_maxchange_unset");
+    }
+
+    // ------------------------------------------------------------------
+    // audit_chrony_maxchange — chrony_maxchange_max_unlimited
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_maxchange_max_minus_one_detects() {
+        // 第三引数 -1（上限なし）は chronyd が連続超過しても panic-exit しない
+        let content = "maxchange 1000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxchange_max_unlimited");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("-1"));
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_minus_five_detects() {
+        // -1 以下（-5 など）も上限なし扱いとして検知する
+        let content = "maxchange 1000 1 -5\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxchange_max_unlimited");
+        assert!(findings[0].message.contains("-5"));
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_positive_no_finding() {
+        // 推奨値 2 は検知しない（1 以上は対象外）
+        let content = "maxchange 1000 1 2\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_zero_no_finding() {
+        // 0 は検知対象外（-1 以下のみ検知）
+        let content = "maxchange 1000 1 0\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_non_numeric_no_finding() {
+        // 非数値トークンは検知対象外
+        let content = "maxchange 1000 1 abc\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_missing_no_finding() {
+        // 第三引数が欠損している場合は検知対象外
+        let content = "maxchange 1000 1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_commented_no_finding() {
+        // コメント行は未設定扱い → unset のみ発火し、新ルールは発火しない
+        let content = "# maxchange 1000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxchange_unset");
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_multiple_last_wins_detects() {
+        // 複数行で最後の行の max=-1 を検知。offset=5000 も閾値超過で両方発火
+        let content = "maxchange 500 1 2\nmaxchange 5000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        let kinds: Vec<&str> = findings.iter().map(|f| f.kind.as_str()).collect();
+        assert!(kinds.contains(&"chrony_maxchange_offset_too_large"));
+        assert!(kinds.contains(&"chrony_maxchange_max_unlimited"));
+        assert_eq!(findings.len(), 2);
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_offset_ok_only_max_fires() {
+        // offset が閾値以下なら offset_too_large は発火せず、max=-1 のみ発火
+        let content = "maxchange 1000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_maxchange_max_unlimited");
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_both_fire_when_offset_too_large_and_max_unlimited() {
+        // offset が閾値超過かつ max=-1 の場合は両方発火
+        let content = "maxchange 2000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, true);
+        let kinds: Vec<&str> = findings.iter().map(|f| f.kind.as_str()).collect();
+        assert!(kinds.contains(&"chrony_maxchange_offset_too_large"));
+        assert!(kinds.contains(&"chrony_maxchange_max_unlimited"));
+        assert_eq!(findings.len(), 2);
+    }
+
+    #[test]
+    fn test_audit_chrony_maxchange_max_flag_suppresses() {
+        // フラグを false にすると新ルールは抑止される
+        let content = "maxchange 1000 1 -1\n";
+        let findings = audit_chrony_maxchange(content, 1000.0, false);
+        assert!(findings.is_empty());
     }
 
     // ------------------------------------------------------------------
@@ -4595,8 +4742,39 @@ mod tests {
         let findings = audit_by_kind(NtpConfigKind::Ntp, content, &config, path);
         assert!(
             findings.iter().all(|f| f.kind != "chrony_maxchange_unset"
-                && f.kind != "chrony_maxchange_offset_too_large"),
+                && f.kind != "chrony_maxchange_offset_too_large"
+                && f.kind != "chrony_maxchange_max_unlimited"),
             "ntp.conf path should not dispatch chrony-specific maxchange audits"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_maxchange_max_unlimited_flag_toggle() {
+        // 他の新規ルールを発火させない最小 chrony 設定に max=-1 を指定
+        let content =
+            "pool foo\nmakestep 1.0 3\nleapsectz right/UTC\nrtcsync\nmaxchange 1000 1 -1\n";
+        let path = Path::new("/etc/chrony/chrony.conf");
+
+        let mut config = NtpConfigMonitorConfig {
+            check_config_owner: false,
+            check_keys_file_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_maxchange_max_unlimited"),
+            "max=-1 finding should fire by default"
+        );
+
+        config.check_chrony_maxchange_max_unlimited = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_maxchange_max_unlimited"),
+            "disabling check_chrony_maxchange_max_unlimited suppresses the finding"
         );
     }
 


### PR DESCRIPTION
## Summary

- chrony.conf の `maxchange <offset> <start> <max>` ディレクティブの第三引数 `<max>` が `-1`（上限なし）の場合を `chrony_maxchange_max_unlimited` (Warning) として検知
- `<max>` を `-1` にすると、連続で閾値を超えるオフセットを受けても chronyd が panic-exit しないため、持続的な時刻偽装攻撃を検知できなくなる（推奨: `maxchange 1000 1 2`）
- 新設フラグ `check_chrony_maxchange_max_unlimited`（既定 `true`）で個別 ON/OFF 可能

Closes #365

## 変更内容

| ファイル | 内容 |
|---|---|
| `src/modules/ntp_config_monitor.rs` | `audit_chrony_maxchange` に第三引数解析ロジックを追加、`parse_chrony_maxchange_max` ヘルパ新設、11 件のテストを追加 |
| `src/config.rs` | `NtpConfigMonitorConfig::check_chrony_maxchange_max_unlimited` 追加（`#[serde(default = ...)]`）+ `Default` 実装に反映 |
| `config.example.toml` | 対応するサンプル設定を追加 |
| `CLAUDE.md` | `ntp_config_monitor.rs` の説明行に「maxchange max -1 監査」を追記 |

## 検知ルール

- `<max>` が `-1` 以下の整数 → Warning 発火
- `<max>` が 0 / 正の整数 / 非数値 / 欠損 → 発火しない
- 既存の `chrony_maxchange_offset_too_large` と独立に動作（両方同時発火しうる）
- `check_chrony_maxchange_max_unlimited = false` で個別抑止可能

## Test plan

- [x] `cargo fmt --check` 通過
- [x] `cargo clippy --all-targets -- -D warnings` 通過
- [x] `cargo test --lib`: 2575 passed
- [x] `cargo test --test integration_test`: 38 passed
- [x] 11 件の新規ユニットテストで下記ケースを網羅: `-1` 検知 / `-5` 検知 / `0` 非発火 / 非数値 非発火 / 欠損 非発火 / コメント 非発火 / 複数行 last-wins / offset と同時発火 / フラグ抑止 / `NtpConfigKind::Ntp` では非発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)