### PR TITLE
feat: ntp_config_monitor に logbanner / logchange 監査を追加 (#367)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -183,12 +183,13 @@
 - [x] **ntp_config_monitor の maxchange 監査** — v1.77.0 (#361, PR #362)
 - [x] **ntp_config_monitor の corrtimeratio / maxclockerror 閾値監査** — v1.78.0 (#363, PR #364)
 - [x] **ntp_config_monitor の maxchange `<max>` 上限なし（-1）監査** — v1.79.0 (#365, PR #366)
+- [x] **ntp_config_monitor の `logbanner` / `logchange` 監査** — v1.80.0 (#367, PR #368)
 
 ## 候補
 
-1. **chrony 閾値監査のパターン共通化リファクタ** — v1.70.0 (maxsamples)・v1.75.0 (maxdistance/maxjitter)・v1.76.0 (makestep)・v1.77.0 (maxchange)・v1.78.0 (corrtimeratio/maxclockerror)・v1.79.0 (maxchange max=-1) で増えた「top-level 整数/浮動小数ディレクティブの閾値超過検知」パターンを汎用ヘルパー（例: `audit_threshold_too_large<T>`）に抽出し、今後の同種監査追加時の重複を抑える
-2. **ntp_config_monitor の `logbanner` / `logchange` 監査** — chrony のログ設定系ディレクティブを監査し、攻撃者が時刻ずれをログ出力から隠蔽するために `logchange` を極端に大きな値に設定していないか（推奨は 0.5 秒前後、1000 秒超は警告）、および `logbanner 0` でバナー出力を無効化していないかを検知する
-3. **ntp_config_monitor の maxchange `<start>` フィールド監査** — v1.79.0 で第三引数 `<max>` の監査が入ったため、第二引数 `<start>`（大きなステップ補正の適用開始回数）が過大（例: 10 以上）に設定されている場合を Warning として検知する。`start` が大きいと初期の偽装時刻攻撃が検知されずに受け入れられるリスクがある
+1. **chrony 閾値監査のパターン共通化リファクタ** — v1.70.0 (maxsamples)・v1.75.0 (maxdistance/maxjitter)・v1.76.0 (makestep)・v1.77.0 (maxchange)・v1.78.0 (corrtimeratio/maxclockerror)・v1.79.0 (maxchange max=-1)・v1.80.0 (logchange) で増えた「top-level 整数/浮動小数ディレクティブの閾値超過検知」パターンを汎用ヘルパー（例: `audit_threshold_too_large<T>`）に抽出し、今後の同種監査追加時の重複を抑える
+2. **ntp_config_monitor の maxchange `<start>` フィールド監査** — v1.79.0 で第三引数 `<max>` の監査が入ったため、第二引数 `<start>`（大きなステップ補正の適用開始回数）が過大（例: 10 以上）に設定されている場合を Warning として検知する。`start` が大きいと初期の偽装時刻攻撃が検知されずに受け入れられるリスクがある
+3. **ntp_config_monitor の `log` ディレクティブ監査** — v1.80.0 で `logchange` / `logbanner` 監査が入ったため、次段として chrony の `log` ディレクティブ（`measurements`・`statistics`・`tracking`・`rtc`・`refclocks`・`tempcomp` 等のサブカテゴリ）が空設定されている場合（= 全ログカテゴリ無効化）や、ドロップインで `log` ディレクティブが上書きされて既定カテゴリが欠落している場合を検知する
 4. **ntp_config_monitor のドロップイン動的ホットリロード** — 稼働中に chrony.conf へ `confdir` / `include` が追加された場合、SIGHUP または再起動なしに inotify watch へディレクトリを追加する仕組みを整備する（現状は v1.72.0 で再起動まで反映されない制約あり）
 5. **ntp_config_monitor の refclock SHM セグメント実権限監査** — v1.73.0 で chrony.conf 上の `refclock SHM` 宣言を検知できるようになったため、次段として `SHM <id>` で参照される実 SysV SHM セグメント（`0x4e545030 + id`）の書き込み権限（`ipcs -m`）を検査し、非 root 書き込み可の場合を Critical 扱いにする
 6. **inotify リアルタイム検知の他モジュールへの展開** — cron_monitor / ntp_config_monitor で確立した inotify パターンを sshd_config_monitor / pam_monitor / sudoers_monitor / dns_monitor / security_files_monitor / shell_config_monitor など他の設定ファイル系モジュールに展開する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ src/
     network_interface_monitor.rs # ネットワークインターフェース監視モジュール
     network_monitor.rs # ネットワーク接続監視モジュール
     network_traffic_monitor.rs # ネットワークトラフィック異常検知モジュール
-    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査・maxchange max -1 監査対応）
+    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査・maxchange max -1 監査・logbanner / logchange 監査対応）
     pam_monitor.rs     # PAM 設定監視モジュール
     privilege_escalation_monitor.rs # プロセス権限昇格検知モジュール
     proc_environ_monitor.rs # プロセス環境変数スナップショット監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.79.0"
+version = "1.80.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.79.0"
+version = "1.80.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1566,6 +1566,14 @@ check_chrony_corrtimeratio = true
 # ローカルクロックの誤差許容が過大だと外部時刻ソースとの差分を「自クロックのドリフト」と
 # 誤認しやすくなり、偽装 NTP サーバへの追従が緩慢になって中間者攻撃の緩衝材として働く
 check_chrony_maxclockerror = true
+# chrony の `logchange` が推奨上限を超えている場合を検知（Warning）
+# 時刻ステップ補正ログのトリガー閾値が過大に緩められると、偽装 NTP による時刻改竄が
+# 監査ログに記録されなくなり、時刻ずれの可観測性が低下する
+check_chrony_logchange = true
+# chrony の `logbanner` が 0 以下に設定されバナー出力が無効化されている場合を検知（Warning）
+# ログローテーション後に列ヘッダが欠如することで攻撃者の時刻改竄イベントの文脈復元が
+# 困難になり、フォレンジック妨害につながる
+check_chrony_logbanner = true
 # `maxdistance` 監査の許容上限（秒、既定 5.0）。chrony のデフォルトは 3.0 秒
 maxdistance_max_threshold = 5.0
 # `maxjitter` 監査の許容上限（秒、既定 2.0）。chrony のデフォルトは 1.0 秒
@@ -1585,6 +1593,10 @@ corrtimeratio_max_threshold = 10.0
 # chrony のデフォルトは 1.0 ppm。通常運用で 10 ppm を超える値を設定する必要はなく、
 # 超過値は偽装 NTP サーバへの追従を緩慢にする緩衝材として悪用されうる
 maxclockerror_max_threshold = 10.0
+# `logchange` 監査の許容上限（秒、既定 10.0）
+# chrony のデフォルトは 1.0 秒。通常運用で 10 秒を超える値を設定する必要はなく、
+# 超過値は攻撃者が時刻改竄の可観測性を下げるための緩和設定として悪用されうる
+logchange_max_threshold = 10.0
 # `maxsamples_too_low` 判定の下限閾値（既定: 4）
 # chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
 # 0 に設定すると maxsamples 過少の検知を事実上無効化できる

--- a/src/config.rs
+++ b/src/config.rs
@@ -6261,6 +6261,18 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_maxclockerror: bool,
 
+    /// chrony の `logchange` が許容上限を超えている場合を検知
+    /// （時刻ステップ補正ログをトリガーする閾値が過大に緩められると、偽装 NTP による
+    /// 時刻改竄が監査ログに記録されなくなり、時刻ずれの可観測性が低下する）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_logchange: bool,
+
+    /// chrony の `logbanner` が 0 以下に設定されバナー出力が無効化されている場合を検知
+    /// （ログローテーション後に列ヘッダが欠如することで攻撃者の時刻改竄イベントの
+    /// 文脈復元が困難になり、フォレンジック妨害につながる）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_logbanner: bool,
+
     /// `maxdistance` の許容上限（秒、既定 5.0）
     /// chrony のデフォルトは 3.0 秒なので 5.0 秒超は明示的な緩和設定と判定する
     #[serde(default = "NtpConfigMonitorConfig::default_maxdistance_max_threshold")]
@@ -6293,6 +6305,12 @@ pub struct NtpConfigMonitorConfig {
     /// 超過値は偽装 NTP サーバへの追従を緩慢にする緩衝材として悪用されうる
     #[serde(default = "NtpConfigMonitorConfig::default_maxclockerror_max_threshold")]
     pub maxclockerror_max_threshold: f64,
+
+    /// `logchange` 監査の許容上限（秒、既定 10.0）
+    /// chrony のデフォルトは 1.0 秒。通常運用で 10 秒を超える値を設定する必要はなく、
+    /// 超過値は攻撃者が時刻改竄の可観測性を下げるための緩和設定として悪用されうる
+    #[serde(default = "NtpConfigMonitorConfig::default_logchange_max_threshold")]
+    pub logchange_max_threshold: f64,
 
     /// `maxsamples_too_low` 判定の下限閾値（既定: 4）
     /// chrony の NTP フィルタアルゴリズムは通常 4 以上のサンプルで安定動作する
@@ -6391,6 +6409,10 @@ impl NtpConfigMonitorConfig {
         10.0
     }
 
+    fn default_logchange_max_threshold() -> f64 {
+        10.0
+    }
+
     fn default_inotify_debounce_ms() -> u64 {
         500
     }
@@ -6432,12 +6454,15 @@ impl Default for NtpConfigMonitorConfig {
             check_chrony_maxchange_max_unlimited: true,
             check_chrony_corrtimeratio: true,
             check_chrony_maxclockerror: true,
+            check_chrony_logchange: true,
+            check_chrony_logbanner: true,
             maxdistance_max_threshold: Self::default_maxdistance_max_threshold(),
             maxjitter_max_threshold: Self::default_maxjitter_max_threshold(),
             makestep_threshold_max: Self::default_makestep_threshold_max(),
             maxchange_offset_max_threshold: Self::default_maxchange_offset_max_threshold(),
             corrtimeratio_max_threshold: Self::default_corrtimeratio_max_threshold(),
             maxclockerror_max_threshold: Self::default_maxclockerror_max_threshold(),
+            logchange_max_threshold: Self::default_logchange_max_threshold(),
             maxsamples_min_threshold: Self::default_maxsamples_min_threshold(),
             allowed_owner_uids: Self::default_allowed_uids(),
             allowed_owner_gids: Self::default_allowed_gids(),

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -58,6 +58,12 @@
 //!     誤差率 ppm が過大に緩められると、外部時刻ソースとの差分を「ローカルクロックの
 //!     ドリフトで説明できる」と判定しやすくなり、偽装 NTP サーバへの追従が緩慢になって
 //!     中間者攻撃の緩衝材として働く）
+//!   - `chrony.conf`: `logchange` が推奨上限を超える（時刻ステップ補正ログを
+//!     トリガーする閾値が過大に緩められると、偽装 NTP による時刻改竄が監査ログに
+//!     記録されなくなり、時刻ずれの可観測性が低下する）
+//!   - `chrony.conf`: `logbanner 0` 等でバナー出力が無効化されている（ログローテーション
+//!     後に列ヘッダが欠如することで攻撃者の時刻改竄イベントの文脈復元が困難になり、
+//!     フォレンジック妨害につながる）
 //! - **ドロップイン監視** — `chrony.conf` 内の `confdir` / `sourcedir` / `include`
 //!   ディレクティブで参照される追加設定ファイル（例: `/etc/chrony/conf.d/*.conf`、
 //!   `/etc/chrony/sources.d/*.sources`）も監視対象に加え、親ディレクトリも inotify
@@ -766,6 +772,23 @@ fn parse_chrony_top_level_f64(content: &str, keyword: &str) -> Option<f64> {
     last
 }
 
+/// chrony.conf の top-level ディレクティブから i64 値をパースする
+///
+/// `find_keyword_lines` は行頭トークンが一致した行のみ返すため、
+/// `server ... logbanner N` のような inline オプションには一致せず、top-level 設定だけを拾える。
+/// 複数行がある場合は後者が優先。値として整数でないトークンは無視する。
+/// 負の値（例: `logbanner -1`）を扱う必要があるため u32 ではなく i64 を返す。
+fn parse_chrony_top_level_i64(content: &str, keyword: &str) -> Option<i64> {
+    let mut last: Option<i64> = None;
+    for value in find_keyword_lines(content, keyword) {
+        let token = value.split_whitespace().next().unwrap_or("").trim();
+        if let Ok(n) = token.parse::<i64>() {
+            last = Some(n);
+        }
+    }
+    last
+}
+
 /// chrony.conf の `maxsamples` / `minsamples` のサンプル数設定を監査する
 ///
 /// - `maxsamples` が 0（= 無制限）を除き閾値未満 → `chrony_maxsamples_too_low` (Warning)
@@ -1005,6 +1028,64 @@ fn audit_chrony_maxclockerror(content: &str, max_threshold: f64) -> Vec<AuditFin
             message: format!(
                 "chrony.conf の `maxclockerror {}` は推奨上限（{} ppm）を超えています（ローカルクロックの誤差許容が過大だと、外部時刻ソースとの差分を「自クロックのドリフト」と誤認しやすくなり、偽装 NTP サーバへの追従が緩慢になって中間者攻撃の緩衝材として働きます）",
                 v, max_threshold
+            ),
+        });
+    }
+    findings
+}
+
+/// chrony.conf の `logchange` が許容上限を超えている場合を監査する
+///
+/// `logchange` は chrony がシステム時刻の補正量を syslog へ記録する際の閾値（秒）を
+/// 指定するディレクティブ。chrony のデフォルトは 1.0 秒で、絶対値でこれを超える時刻
+/// ステップ補正が検出されたときに警告ログが出る。値を極端に大きく設定されていると、
+/// 攻撃者が偽装 NTP サーバや refclock 経由でシステム時刻を改竄しても補正ログに
+/// 記録されなくなり、時刻ずれの可観測性が著しく低下する（フォレンジック妨害）。
+///
+/// `max_threshold`（秒）を超える値を Warning として報告する。
+/// 0 以下・パースできないトークンは無視する（未設定は chrony デフォルトの 1.0 秒で
+/// 動作するため検知対象外）。
+fn audit_chrony_logchange(content: &str, max_threshold: f64) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    if let Some(v) = parse_chrony_top_level_f64(content, "logchange")
+        && v > 0.0
+        && v > max_threshold
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_logchange_too_large".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf の `logchange {}` は推奨上限（{} 秒）を超えています（攻撃者が時刻ステップ補正ログをトリガーする閾値を極端に大きく設定することで、偽装 NTP による時刻改竄が監査ログに記録されなくなり、時刻ずれの可観測性が低下します）",
+                v, max_threshold
+            ),
+        });
+    }
+    findings
+}
+
+/// chrony.conf の `logbanner` がバナー出力無効化（0 以下）に設定されている場合を監査する
+///
+/// `logbanner` は chrony がログファイルに列ヘッダ（バナー）を再出力する行数間隔を
+/// 指定するディレクティブ（chrony のデフォルトは 32）。`logbanner 0`（または負値）に
+/// 設定するとバナー出力が実質的に無効化される。ログローテーション後に列ヘッダが
+/// 欠如するため、後日フォレンジック調査で各列の意味（時刻・オフセット・遅延・推定
+/// 誤差等）を復元することが困難になり、攻撃者による時刻改竄イベントの文脈解析が
+/// 妨害される。
+///
+/// `logbanner` が `0` 以下に明示設定されている場合のみ Warning として報告する。
+/// 未設定・正の整数値・パースできないトークンは無視する（chrony デフォルトの 32 で
+/// 動作するため検知対象外）。
+fn audit_chrony_logbanner(content: &str) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    if let Some(v) = parse_chrony_top_level_i64(content, "logbanner")
+        && v <= 0
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_logbanner_disabled".to_string(),
+            severity: Severity::Warning,
+            message: format!(
+                "chrony.conf の `logbanner {}` はバナー（列ヘッダ）出力を無効化しています（ログローテーション後に列ヘッダが欠如することで攻撃者の時刻改竄イベントの文脈復元が困難になり、フォレンジック妨害につながります。推奨: 既定値 32 以上の正の整数）",
+                v
             ),
         });
     }
@@ -1462,6 +1543,15 @@ fn audit_by_kind(
                     content,
                     config.maxclockerror_max_threshold,
                 ));
+            }
+            if config.check_chrony_logchange {
+                findings.extend(audit_chrony_logchange(
+                    content,
+                    config.logchange_max_threshold,
+                ));
+            }
+            if config.check_chrony_logbanner {
+                findings.extend(audit_chrony_logbanner(content));
             }
         }
         NtpConfigKind::Ntp => {
@@ -4621,6 +4711,163 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
+    // audit_chrony_logchange
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_logchange_unset_no_finding() {
+        // 未設定は chrony デフォルト 1.0 秒で動作するため検知対象外
+        let content = "pool foo\nmakestep 1.0 3\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_default_no_finding() {
+        // chrony デフォルト値 1.0 秒は 10.0 上限以下なので検知しない
+        let content = "logchange 1.0\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_too_large_detects() {
+        // 1000 秒は 10 秒上限を超過 → Warning
+        let content = "logchange 1000\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_logchange_too_large");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("1000"));
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_boundary_equal_no_finding() {
+        let content = "logchange 10.0\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_non_numeric_no_finding() {
+        let content = "logchange abc\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_zero_no_finding() {
+        let content = "logchange 0\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_negative_no_finding() {
+        let content = "logchange -5\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_inline_option_ignored() {
+        let content = "server ntp.example.com logchange 1000\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_multiple_last_wins() {
+        let content = "logchange 1.0\nlogchange 1000\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_logchange_too_large");
+        assert!(findings[0].message.contains("1000"));
+    }
+
+    #[test]
+    fn test_audit_chrony_logchange_comment_does_not_count() {
+        let content = "# logchange 1000\n";
+        let findings = audit_chrony_logchange(content, 10.0);
+        assert!(findings.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // audit_chrony_logbanner
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_logbanner_unset_no_finding() {
+        // 未設定は chrony デフォルト 32 で動作するため検知対象外
+        let content = "pool foo\nmakestep 1.0 3\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_default_positive_no_finding() {
+        // chrony デフォルト値 32 は正の整数なので検知しない
+        let content = "logbanner 32\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_zero_detects() {
+        // logbanner 0 はバナー出力無効化 → Warning
+        let content = "logbanner 0\n";
+        let findings = audit_chrony_logbanner(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_logbanner_disabled");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("0"));
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_negative_detects() {
+        // logbanner -1 もバナー無効化扱いとして Warning
+        let content = "logbanner -1\n";
+        let findings = audit_chrony_logbanner(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_logbanner_disabled");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+        assert!(findings[0].message.contains("-1"));
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_non_numeric_no_finding() {
+        let content = "logbanner abc\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_inline_option_ignored() {
+        let content = "server ntp.example.com logbanner 0\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_multiple_last_wins() {
+        // 最後の値 0 が採用され Warning
+        let content = "logbanner 32\nlogbanner 0\n";
+        let findings = audit_chrony_logbanner(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_logbanner_disabled");
+
+        // 逆順（最後が 32）は検知しない
+        let content = "logbanner 0\nlogbanner 32\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_logbanner_comment_does_not_count() {
+        let content = "# logbanner 0\n";
+        let findings = audit_chrony_logbanner(content);
+        assert!(findings.is_empty());
+    }
+
+    // ------------------------------------------------------------------
     // audit_by_kind: corrtimeratio / maxclockerror フラグの有効/無効切替
     // ------------------------------------------------------------------
     #[test]
@@ -4697,6 +4944,86 @@ mod tests {
                 .all(|f| f.kind != "chrony_corrtimeratio_too_large"
                     && f.kind != "chrony_maxclockerror_too_large"),
             "ntp.conf path should not dispatch chrony-specific audits"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // audit_by_kind: logchange / logbanner フラグの有効/無効切替
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_by_kind_logchange_flag_toggle() {
+        // 新規ルールだけを発火させる最小 chrony 設定
+        let content = "pool foo\nmakestep 1.0 3\nleapsectz right/UTC\nrtcsync\nmaxchange 1000 1 2\nlogchange 1000\n";
+        let path = Path::new("/etc/chrony/chrony.conf");
+
+        let mut config = NtpConfigMonitorConfig {
+            check_config_owner: false,
+            check_keys_file_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_logchange_too_large"),
+            "logchange audit should fire by default when above threshold"
+        );
+
+        config.check_chrony_logchange = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_logchange_too_large"),
+            "disabling check_chrony_logchange suppresses the finding"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_logbanner_flag_toggle() {
+        let content = "pool foo\nmakestep 1.0 3\nleapsectz right/UTC\nrtcsync\nmaxchange 1000 1 2\nlogbanner 0\n";
+        let path = Path::new("/etc/chrony/chrony.conf");
+
+        let mut config = NtpConfigMonitorConfig {
+            check_config_owner: false,
+            check_keys_file_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_logbanner_disabled"),
+            "logbanner audit should fire by default when set to 0"
+        );
+
+        config.check_chrony_logbanner = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_logbanner_disabled"),
+            "disabling check_chrony_logbanner suppresses the finding"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_ntp_does_not_trigger_chrony_logchange_or_logbanner() {
+        // NtpConfigKind::Ntp アームでは chrony 専用の両監査はディスパッチされない
+        let content = "server 0.pool.ntp.org iburst\nrestrict default ignore\ndriftfile /var/ntp.drift\nlogchange 1000\nlogbanner 0\n";
+        let path = Path::new("/etc/ntp.conf");
+        let config = NtpConfigMonitorConfig {
+            check_keys_file_owner: false,
+            check_config_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Ntp, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_logchange_too_large"
+                    && f.kind != "chrony_logbanner_disabled"),
+            "ntp.conf path should not dispatch chrony-specific logchange/logbanner audits"
         );
     }
 


### PR DESCRIPTION
## Summary

- chrony の `logchange <seconds>` が閾値（既定 10 秒）を超える場合に Warning で検知
- chrony の `logbanner <entries>` が 0 以下でバナー出力無効化されている場合に Warning で検知
- 設定フラグ `check_chrony_logchange` / `check_chrony_logbanner` / `logchange_max_threshold` を追加

## 背景

攻撃者が偽装 NTP や refclock 経由で時刻を改竄した際、`logchange` を過大値に設定すると
ステップ補正ログが記録されず、時刻ずれの可観測性が低下する。
また `logbanner 0` でバナー出力を無効化すると、ログローテーション後に列ヘッダが欠如し
フォレンジック調査で各列の意味復元が困難になる（文脈妨害）。

## 実装内容

- `parse_chrony_top_level_i64` ヘルパー追加（負値対応のため u32 ではなく i64）
- `audit_chrony_logchange` / `audit_chrony_logbanner` を追加し `audit_by_kind` の Chrony アームでディスパッチ
- ntp モードでは発火しないことをテストで担保
- 20 件の単体テストを追加（未設定・デフォルト値・境界値・閾値超過・非数値・負数・重複時の last wins・コメント行・インラインオプション除外・フラグ切替・ntp モード不発火）

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] `cargo test`（2652 件全合格）

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)