### PR TITLE
feat: ntp_config_monitor に logdir 親ディレクトリ symlink 検知を追加 (#378)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ src/
     network_interface_monitor.rs # ネットワークインターフェース監視モジュール
     network_monitor.rs # ネットワーク接続監視モジュール
     network_traffic_monitor.rs # ネットワークトラフィック異常検知モジュール
-    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査・maxchange max -1 / start 過大監査・logbanner / logchange / logdir 監査・logdir 実ディレクトリのメタデータ監査・logdir シンボリックリンク自己検知対応）
+    ntp_config_monitor.rs # NTP / 時刻同期設定監視モジュール（inotify リアルタイム検知・chrony ドロップイン監視・refclock 監査・maxchange max -1 / start 過大監査・logbanner / logchange / logdir 監査・logdir 実ディレクトリのメタデータ監査・logdir シンボリックリンク自己検知・logdir 親ディレクトリ（ancestor）symlink 検知対応）
     pam_monitor.rs     # PAM 設定監視モジュール
     privilege_escalation_monitor.rs # プロセス権限昇格検知モジュール
     proc_environ_monitor.rs # プロセス環境変数スナップショット監視モジュール

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.84.0"
+version = "1.85.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.84.0"
+version = "1.85.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1594,6 +1594,13 @@ check_chrony_logdir_metadata = true
 # 回避手法を lstat(2) 相当の symlink_metadata で検知する。攻撃者が symlink 差し替えで
 # ログ出力先を任意ディレクトリに誘導する攻撃の足場となる）
 check_chrony_logdir_symlink = true
+# chrony の `logdir` に指定されたパスの「親コンポーネント（ancestor）」が
+# シンボリックリンクである場合を検知する（check_chrony_logdir_symlink は最終コンポーネント
+# 自身のみを対象とするため、途中の親ディレクトリが symlink に差し替えられているケース
+# （例: /var/log -> /tmp/fakelog で logdir /var/log/chrony）を補完的に検知する。ancestor を
+# 順次 lstat(2) で検査し、symlink が見つかった場合に Warning を発行することで、中間パスを
+# 経由したログ出力先誘導攻撃の足場を塞ぐ）
+check_chrony_logdir_ancestor_symlink = true
 # `maxdistance` 監査の許容上限（秒、既定 5.0）。chrony のデフォルトは 3.0 秒
 maxdistance_max_threshold = 5.0
 # `maxjitter` 監査の許容上限（秒、既定 2.0）。chrony のデフォルトは 1.0 秒

--- a/src/config.rs
+++ b/src/config.rs
@@ -6302,6 +6302,15 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_logdir_symlink: bool,
 
+    /// chrony の `logdir` に指定されたパスの**親コンポーネント（ancestor）** が
+    /// シンボリックリンクである場合を検知する（`check_chrony_logdir_symlink` は
+    /// 最終コンポーネント自身のみを対象とするため、途中の親ディレクトリが symlink に
+    /// 差し替えられているケース（例: `/var/log -> /tmp/fakelog` で `logdir /var/log/chrony`）を
+    /// 補完的に検知する。ancestor を順次 `lstat(2)` で検査し、symlink が見つかった場合に
+    /// Warning を発行することで、中間パスを経由したログ出力先誘導攻撃の足場を塞ぐ）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_logdir_ancestor_symlink: bool,
+
     /// `maxdistance` の許容上限（秒、既定 5.0）
     /// chrony のデフォルトは 3.0 秒なので 5.0 秒超は明示的な緩和設定と判定する
     #[serde(default = "NtpConfigMonitorConfig::default_maxdistance_max_threshold")]
@@ -6500,6 +6509,7 @@ impl Default for NtpConfigMonitorConfig {
             check_chrony_logdir: true,
             check_chrony_logdir_metadata: true,
             check_chrony_logdir_symlink: true,
+            check_chrony_logdir_ancestor_symlink: true,
             maxdistance_max_threshold: Self::default_maxdistance_max_threshold(),
             maxjitter_max_threshold: Self::default_maxjitter_max_threshold(),
             makestep_threshold_max: Self::default_makestep_threshold_max(),

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -85,6 +85,12 @@
 //!     パス**そのもの**が symlink であることを別 kind (`chrony_logdir_is_symlink`) で
 //!     報告する。攻撃者が symlink を差し替えることでログ出力先を任意ディレクトリに
 //!     誘導し、監査ログ改竄・フォレンジック妨害の足場とする攻撃を検知する）
+//!   - `chrony.conf`: `logdir` が指すパスの**親コンポーネント（ancestor）** が
+//!     シンボリックリンクである（`chrony_logdir_is_symlink` が最終コンポーネント自身の
+//!     symlink のみ検知するのに対し、本監査は途中の親ディレクトリ（例: `logdir
+//!     /var/log/chrony` における `/var/log`）が symlink に差し替えられているケースを
+//!     `chrony_logdir_ancestor_is_symlink` kind で報告する。中間パスを経由したログ出力先
+//!     誘導攻撃の足場を塞ぐ）
 //! - **ドロップイン監視** — `chrony.conf` 内の `confdir` / `sourcedir` / `include`
 //!   ディレクティブで参照される追加設定ファイル（例: `/etc/chrony/conf.d/*.conf`、
 //!   `/etc/chrony/sources.d/*.sources`）も監視対象に加え、親ディレクトリも inotify
@@ -1363,6 +1369,89 @@ fn audit_chrony_logdir_symlink(content: &str, config_path: &Path) -> Vec<AuditFi
     findings
 }
 
+/// chrony.conf の `logdir` ディレクティブで指定されたパスの**親コンポーネント（ancestor）**
+/// がシンボリックリンクである場合を監査する
+///
+/// `audit_chrony_logdir_symlink` は `logdir` の**最終コンポーネント自身**が symlink である
+/// 場合のみを検知する。これに対し本関数は、最終コンポーネントは通常ディレクトリであっても、
+/// 途中の親ディレクトリが symlink に差し替えられているケースを補完的に検知する。
+/// 例: `logdir /var/log/chrony` と設定されていて `/var/log/chrony` 自体は通常ディレクトリ
+/// でも、`/var/log` が `/tmp/fakelog` への symlink に差し替えられている場合、chrony が
+/// 実際にログを書き込む先は攻撃者の制御下となる。
+///
+/// アルゴリズム:
+///
+/// - `logdir` 値の先頭トークンを path として扱い、空ならスキップ
+/// - 相対パスは `config_path.parent()` 基準で解決（`audit_chrony_logdir_symlink` と同じ規則）
+/// - `resolved.ancestors().skip(1)` で最終コンポーネントを除く親コンポーネントを列挙し、
+///   **ルートから深い方へ向かって**順次検査する（`ancestors()` は深→浅の順序で返すため
+///   `.collect()` してから `.rev()` で反転する）。`parent()` が `None` となるルート (`/` 等)
+///   は検査対象外
+/// - 各 ancestor で `std::fs::symlink_metadata` を呼び出し:
+///   - symlink の場合、`read_link` で終端解決先を取得し Warning を発行
+///   - 通常ディレクトリなら次の（より深い）ancestor へ進む
+///   - Err（例: ENOENT）なら以降（より深い）ancestor は存在しえないので break する
+///     （浅い方の ancestor は反転順の先頭で既に検査済みなので取りこぼさない）
+///
+/// 検知時は以下の kind を発行する:
+///
+/// - `chrony_logdir_ancestor_is_symlink`（Warning）— 親コンポーネントに symlink を検出
+///
+/// 終端解決先の取得に失敗した場合は `<unreadable>` プレースホルダ。
+/// 最終コンポーネント自身の symlink 検知は `audit_chrony_logdir_symlink` の責務であり、
+/// 本関数は重複検知しない（`ancestors().skip(1)` で最終コンポーネントを除外）。
+fn audit_chrony_logdir_ancestor_symlink(content: &str, config_path: &Path) -> Vec<AuditFinding> {
+    let mut findings = Vec::new();
+    let base_dir = config_path.parent();
+
+    for value in find_keyword_lines(content, "logdir") {
+        let trimmed = value.split_whitespace().next().unwrap_or("").trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let candidate = std::path::PathBuf::from(trimmed);
+        let resolved = if candidate.is_absolute() {
+            candidate
+        } else if let Some(dir) = base_dir {
+            dir.join(candidate)
+        } else {
+            candidate
+        };
+
+        // ancestors() は深→浅の順で返すため、反転してルート側から深い方へ進める
+        let ancestors: Vec<&Path> = resolved.ancestors().skip(1).collect();
+        for ancestor in ancestors.iter().rev() {
+            if ancestor.parent().is_none() {
+                continue;
+            }
+            let metadata = match std::fs::symlink_metadata(ancestor) {
+                Ok(m) => m,
+                Err(_) => break,
+            };
+            if !metadata.file_type().is_symlink() {
+                continue;
+            }
+
+            let target = std::fs::read_link(ancestor)
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+
+            findings.push(AuditFinding {
+                kind: "chrony_logdir_ancestor_is_symlink".to_string(),
+                severity: Severity::Warning,
+                message: format!(
+                    "chrony.conf の `logdir {}` の親コンポーネント `{}` がシンボリックリンクです（終端解決先: {}）。攻撃者が途中パスの symlink を差し替えることでログ出力先を任意のディレクトリに誘導できるため、監査ログ改竄・フォレンジック妨害の足場となりえます",
+                    trimmed,
+                    ancestor.display(),
+                    target
+                ),
+            });
+        }
+    }
+
+    findings
+}
+
 /// chrony.conf の `makestep <threshold> <limit>` の第一引数（threshold）が過大な場合を監査する
 ///
 /// `makestep` はオフセットが `threshold` 秒を超えた場合に限りクロックを step（瞬時修正）
@@ -1834,6 +1923,9 @@ fn audit_by_kind(
             }
             if config.check_chrony_logdir_symlink {
                 findings.extend(audit_chrony_logdir_symlink(content, config_path));
+            }
+            if config.check_chrony_logdir_ancestor_symlink {
+                findings.extend(audit_chrony_logdir_ancestor_symlink(content, config_path));
             }
         }
         NtpConfigKind::Ntp => {
@@ -5935,6 +6027,188 @@ mod tests {
         );
     }
 
+    // ------------------------------------------------------------------
+    // audit_chrony_logdir_ancestor_symlink
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_detects_middle_symlink() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real_parent");
+        std::fs::create_dir(&real_parent).unwrap();
+        let link_parent = dir.path().join("link_parent");
+        symlink(&real_parent, &link_parent).unwrap();
+        // logdir の最終コンポーネントとなる実ディレクトリを real_parent 側に作成
+        // （link_parent 経由でも同じ実体を指す）
+        std::fs::create_dir(real_parent.join("chrony_logs")).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = format!("logdir {}/chrony_logs\n", link_parent.display());
+
+        let findings = audit_chrony_logdir_ancestor_symlink(&content, &config_path);
+        let finding = findings
+            .iter()
+            .find(|f| f.kind == "chrony_logdir_ancestor_is_symlink")
+            .expect("親コンポーネントの symlink が検知される");
+        assert!(
+            finding.message.contains(&link_parent.display().to_string()),
+            "message に symlink の ancestor パスが含まれる (got {:?})",
+            finding.message
+        );
+        assert!(
+            finding.message.contains(&real_parent.display().to_string()),
+            "message に symlink の終端解決先が含まれる (got {:?})",
+            finding.message
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_plain_tree_no_finding() {
+        let dir = tempfile::tempdir().unwrap();
+        let deep = dir.path().join("a").join("b").join("c");
+        std::fs::create_dir_all(&deep).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = format!("logdir {}\n", deep.display());
+
+        let findings = audit_chrony_logdir_ancestor_symlink(&content, &config_path);
+        assert!(
+            findings.is_empty(),
+            "通常ディレクトリツリーでは検知しない (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_empty_value_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = "logdir \n";
+
+        let findings = audit_chrony_logdir_ancestor_symlink(content, &config_path);
+        assert!(
+            findings.is_empty(),
+            "空値はスキップ (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_relative_path_resolved() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real_parent");
+        std::fs::create_dir(&real_parent).unwrap();
+        let link_parent = dir.path().join("link_parent");
+        symlink(&real_parent, &link_parent).unwrap();
+        std::fs::create_dir(real_parent.join("chrony_logs")).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = "logdir link_parent/chrony_logs\n";
+
+        let findings = audit_chrony_logdir_ancestor_symlink(content, &config_path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_logdir_ancestor_is_symlink"),
+            "相対パスでも ancestor の symlink が検知される (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_detects_despite_missing_deep_component() {
+        // /tmpdir/link_parent -> /tmpdir/real_parent（通常ディレクトリ）
+        // logdir /tmpdir/link_parent/nonexistent/deeper と書いても、
+        // link_parent 自体は symlink として検知されなければならない。
+        // （深い方に ENOENT があっても、浅い方の ancestor symlink は取りこぼさない）
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real_parent");
+        std::fs::create_dir(&real_parent).unwrap();
+        let link_parent = dir.path().join("link_parent");
+        symlink(&real_parent, &link_parent).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        // `nonexistent/deeper` は実在しない
+        let content = format!("logdir {}/nonexistent/deeper\n", link_parent.display());
+
+        let findings = audit_chrony_logdir_ancestor_symlink(&content, &config_path);
+        let finding = findings
+            .iter()
+            .find(|f| f.kind == "chrony_logdir_ancestor_is_symlink")
+            .expect("深い方が ENOENT でも、浅い方の ancestor symlink は検知される");
+        assert!(
+            finding.message.contains(&link_parent.display().to_string()),
+            "message に symlink の ancestor パスが含まれる (got {:?})",
+            finding.message
+        );
+    }
+
+    #[test]
+    fn test_audit_chrony_logdir_ancestor_symlink_final_component_not_reported() {
+        // 最終コンポーネント自身が symlink（親は通常ディレクトリ）の場合、
+        // ancestor 監査では発火しない（audit_chrony_logdir_symlink の責務のため重複回避）
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real_logs");
+        std::fs::create_dir(&real_dir).unwrap();
+        let link_path = dir.path().join("logs_link");
+        symlink(&real_dir, &link_path).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = format!("logdir {}\n", link_path.display());
+
+        let findings = audit_chrony_logdir_ancestor_symlink(&content, &config_path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_logdir_ancestor_is_symlink"),
+            "最終コンポーネント自身の symlink は ancestor 監査では発火しない (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_logdir_ancestor_symlink_flag_toggle() {
+        use std::os::unix::fs::symlink;
+        let dir = tempfile::tempdir().unwrap();
+        let real_parent = dir.path().join("real_parent");
+        std::fs::create_dir(&real_parent).unwrap();
+        let link_parent = dir.path().join("link_parent");
+        symlink(&real_parent, &link_parent).unwrap();
+        std::fs::create_dir(real_parent.join("chrony_logs")).unwrap();
+        let config_path = dir.path().join("chrony.conf");
+        let content = format!(
+            "pool foo\nmakestep 1.0 3\nleapsectz right/UTC\nrtcsync\nmaxchange 1000 1 2\nlogdir {}/chrony_logs\n",
+            link_parent.display()
+        );
+
+        // 最終コンポーネント監査・メタデータ監査は無効化し、ancestor のみ対象にする
+        let mut config = NtpConfigMonitorConfig {
+            check_config_owner: false,
+            check_keys_file_owner: false,
+            check_chrony_logdir_symlink: false,
+            check_chrony_logdir_metadata: false,
+            allowed_owner_uids: Vec::new(),
+            allowed_owner_gids: Vec::new(),
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, &content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_logdir_ancestor_is_symlink"),
+            "既定で ancestor symlink 監査が発火する (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+
+        config.check_chrony_logdir_ancestor_symlink = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, &content, &config, &config_path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_logdir_ancestor_is_symlink"),
+            "check_chrony_logdir_ancestor_symlink=false で ancestor symlink 監査が抑止される (got {:?})",
+            findings.iter().map(|f| &f.kind).collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn test_audit_by_kind_ntp_does_not_trigger_chrony_logchange_or_logbanner() {
         // NtpConfigKind::Ntp アームでは chrony 専用の監査はディスパッチされない
@@ -5955,7 +6229,8 @@ mod tests {
                     && f.kind != "chrony_logdir_world_writable"
                     && f.kind != "chrony_logdir_insecure_owner"
                     && f.kind != "chrony_logdir_insecure_group"
-                    && f.kind != "chrony_logdir_is_symlink"),
+                    && f.kind != "chrony_logdir_is_symlink"
+                    && f.kind != "chrony_logdir_ancestor_is_symlink"),
             "ntp.conf path should not dispatch chrony-specific logchange/logbanner/logdir audits"
         );
     }


### PR DESCRIPTION
## 概要

chrony.conf の `logdir` 値について、最終コンポーネント自身ではなく、**途中の親ディレクトリ（ancestor）** がシンボリックリンクに差し替えられているケースを検知する機能を追加する（BACKLOG 候補 3）。

v1.84.0 (#376, PR #377) の `audit_chrony_logdir_symlink` は `symlink_metadata(logdir_path)` で最終コンポーネントのみを検査するため、`logdir /var/log/chrony` に対して `/var/log` が `/tmp/fakelog` への symlink に差し替えられるようなケースを見逃していた。本 PR で ancestor 経路を補完的に検査し、ログ出力先誘導攻撃の足場を塞ぐ。

## 実装内容

- `audit_chrony_logdir_ancestor_symlink(content, config_path)` を追加
  - `logdir` 値の path を `ancestors().skip(1)` で列挙し、**ルート側→深い方の順**に `symlink_metadata(2)` で検査
  - symlink を見つけたら `chrony_logdir_ancestor_is_symlink`（Warning）を発行し、ancestor パスと `read_link` 結果（取得失敗時は `<unreadable>`）をメッセージに含める
  - 相対パスは設定ファイル親ディレクトリ基準で解決
  - 最終コンポーネント自身の symlink は報告しない（既存関数の責務のため重複回避）
  - ENOENT でそれ以降の（より深い）ancestor の検査を打ち切る（反転順のため浅い側は取りこぼさない）
  - ルート (`/`) は検査対象外
- `NtpConfigMonitorConfig::check_chrony_logdir_ancestor_symlink`（既定 `true`）を追加
- `config.example.toml` にフィールドと説明コメントを追加
- `audit_by_kind` の `NtpConfigKind::Chrony` アームから新フラグに応じてディスパッチ
- モジュールのファイルヘッダコメントに新 kind を追加
- `CLAUDE.md` の ntp_config_monitor 項目に機能を追記
- `Cargo.toml` を v1.85.0 に bump

## テスト

- `test_audit_chrony_logdir_ancestor_symlink_detects_middle_symlink` — 中間 symlink を検知
- `test_audit_chrony_logdir_ancestor_symlink_plain_tree_no_finding` — 通常ディレクトリツリーでは無発火
- `test_audit_chrony_logdir_ancestor_symlink_empty_value_skipped` — 空値スキップ
- `test_audit_chrony_logdir_ancestor_symlink_relative_path_resolved` — 相対パスも設定ディレクトリ基準で解決・検知
- `test_audit_chrony_logdir_ancestor_symlink_detects_despite_missing_deep_component` — 深い方が ENOENT でも浅い ancestor symlink を検知（要件 #5）
- `test_audit_chrony_logdir_ancestor_symlink_final_component_not_reported` — 最終コンポーネント symlink は本監査で非報告
- `test_audit_by_kind_logdir_ancestor_symlink_flag_toggle` — `check_chrony_logdir_ancestor_symlink=false` で抑止される

既存の chrony 用 logdir 監査系テスト・統合テスト全 2649 件（lib）・38 件（integration）とも pass。`cargo fmt --check` / `cargo clippy -- -D warnings` / `cargo build --release` もクリーン。

## 関連

- #373, PR #374 — v1.83.0 logdir 実ディレクトリのメタデータ監査
- #376, PR #377 — v1.84.0 logdir シンボリックリンク自己検知（最終コンポーネント）
- BACKLOG 候補 3

Closes #378