### PR TITLE
feat: ntp_config_monitor に chrony `log` ディレクティブ監査を追加 (#384)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "zettai-mamorukun"
-version = "1.87.0"
+version = "1.88.0"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zettai-mamorukun"
-version = "1.87.0"
+version = "1.88.0"
 edition = "2024"
 description = "Linux サーバ向けサイバー攻撃防御デーモン"
 license = "MIT"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1579,6 +1579,11 @@ check_chrony_logchange = true
 # ログローテーション後に列ヘッダが欠如することで攻撃者の時刻改竄イベントの文脈復元が
 # 困難になり、フォレンジック妨害につながる
 check_chrony_logbanner = true
+# chrony の `log` ディレクティブがカテゴリ指定（measurements / statistics / tracking / rtc /
+# refclocks / tempcomp 等）なしで記述され、詳細ログ出力が無効化されている場合を検知（Warning）
+# 稼働中 chrony.conf への空 `log` 行挿入で既存の `log measurements tracking` 等を上書き無効化
+# する攻撃、および設定ミスによる observability 喪失を拾う
+check_chrony_log = true
 # chrony の `logdir` が world-writable な一時領域（/tmp/・/var/tmp/・/dev/shm/・/run/user/ 配下）に
 # 設定されている場合を検知する（攻撃者が時刻改竄イベントの監査ログを削除・改竄できるように
 # なり、フォレンジック調査が妨害される）

--- a/src/config.rs
+++ b/src/config.rs
@@ -6281,6 +6281,13 @@ pub struct NtpConfigMonitorConfig {
     #[serde(default = "NtpConfigMonitorConfig::default_true")]
     pub check_chrony_logbanner: bool,
 
+    /// chrony の `log` ディレクティブがカテゴリ指定（measurements / statistics / tracking /
+    /// rtc / refclocks / tempcomp 等）なしで記述され、詳細ログ出力が無効化されている場合を
+    /// 検知（稼働中 chrony.conf への空 `log` 行挿入で既存 `log measurements tracking` 等を
+    /// 上書き無効化する攻撃、および設定ミスによる observability 喪失を拾う）
+    #[serde(default = "NtpConfigMonitorConfig::default_true")]
+    pub check_chrony_log: bool,
+
     /// chrony の `logdir` が world-writable な一時領域に設定されている場合を検知
     /// （攻撃者が時刻改竄イベントの監査ログを削除・改竄できるようになり、
     /// フォレンジック調査が妨害される）
@@ -6516,6 +6523,7 @@ impl Default for NtpConfigMonitorConfig {
             check_chrony_maxclockerror: true,
             check_chrony_logchange: true,
             check_chrony_logbanner: true,
+            check_chrony_log: true,
             check_chrony_logdir: true,
             check_chrony_logdir_metadata: true,
             check_chrony_logdir_symlink: true,

--- a/src/modules/ntp_config_monitor.rs
+++ b/src/modules/ntp_config_monitor.rs
@@ -1179,6 +1179,42 @@ fn audit_chrony_logbanner(content: &str) -> Vec<AuditFinding> {
     findings
 }
 
+/// chrony.conf の `log` ディレクティブがカテゴリ指定無しで記述されている場合を監査する
+///
+/// chrony の `log` ディレクティブは `measurements` / `statistics` / `tracking` / `rtc` /
+/// `refclocks` / `tempcomp` 等のカテゴリを引数に取り、出力するログの種類を選択する
+/// （chrony デフォルトはどのカテゴリも有効化されない、= ログ出力なし）。`log` 行を
+/// カテゴリ引数**なし**で設定ファイルに記述すると、「`log` を書いたが何も出力しない」
+/// という無害な設定として chrony に受理されるが、実運用としては以下のリスクがある:
+///
+/// - 稼働中 chrony.conf に空の `log` 行を差し込むことで、攻撃者が既存ドロップインの
+///   `log measurements tracking` 等を上書き無効化し、時刻ソース切替・step 補正・offset
+///   記録等の監査ログ出力をまるごと抑止できる（フォレンジック妨害）
+/// - 設定ミスとして `log` とだけ書いて意図せず observability を失うケースも拾える
+///
+/// `find_keyword_lines` は行頭トークン一致のみ返すため、`server ... log ...` のような
+/// inline オプション風の誤用には反応しない。複数行ある場合は最終行のみを判定する
+/// （chrony の挙動と同じく「後勝ち」）。
+///
+/// 検知時は `chrony_log_no_categories` Warning を 1 件発行する。
+fn audit_chrony_log(content: &str) -> Vec<AuditFinding> {
+    let mut last_value: Option<&str> = None;
+    for value in find_keyword_lines(content, "log") {
+        last_value = Some(value);
+    }
+    let mut findings = Vec::new();
+    if let Some(value) = last_value
+        && value.split_whitespace().next().is_none()
+    {
+        findings.push(AuditFinding {
+            kind: "chrony_log_no_categories".to_string(),
+            severity: Severity::Warning,
+            message: "chrony.conf の `log` ディレクティブにカテゴリ（measurements / statistics / tracking / rtc / refclocks / tempcomp 等）が指定されておらず、chrony の詳細ログ出力が全て無効化されています（時刻ソース切替・step 補正・offset 記録等の監査ログが残らず、偽装 NTP による時刻改竄の痕跡追跡が困難になります）".to_string(),
+        });
+    }
+    findings
+}
+
 /// chrony.conf の `logdir` が world-writable な一時領域を指している場合を監査する
 ///
 /// `logdir` は `log measurements tracking` 等で出力される chrony のログファイルの
@@ -2021,6 +2057,9 @@ fn audit_by_kind(
             }
             if config.check_chrony_logbanner {
                 findings.extend(audit_chrony_logbanner(content));
+            }
+            if config.check_chrony_log {
+                findings.extend(audit_chrony_log(content));
             }
             if config.check_chrony_logdir {
                 findings.extend(audit_chrony_logdir(content));
@@ -5605,6 +5644,89 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
+    // audit_chrony_log
+    // ------------------------------------------------------------------
+    #[test]
+    fn test_audit_chrony_log_unset_no_finding() {
+        let content = "server ntp.example.com iburst\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_with_categories_no_finding() {
+        let content = "log measurements tracking\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_single_category_no_finding() {
+        let content = "log tracking\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_empty_categories_detects() {
+        // `log` だけで引数が無い（末尾改行のみ）→ カテゴリ指定なしとして Warning
+        let content = "log\n";
+        let findings = audit_chrony_log(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_log_no_categories");
+        assert!(matches!(findings[0].severity, Severity::Warning));
+    }
+
+    #[test]
+    fn test_audit_chrony_log_trailing_whitespace_detects() {
+        // `log ` の後に空白だけ → カテゴリ未指定扱い
+        let content = "log   \n";
+        let findings = audit_chrony_log(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_log_no_categories");
+    }
+
+    #[test]
+    fn test_audit_chrony_log_inline_option_ignored() {
+        // `server ... log` のような inline オプション風の記述は誤反応しない
+        let content = "server ntp.example.com log\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_comment_ignored() {
+        let content = "# log\n# log measurements\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_multiple_last_wins_categories_suppresses() {
+        // 最後にカテゴリ指定の `log` 行が来ると検知しない（chrony 挙動と同じ後勝ち）
+        let content = "log\nlog measurements tracking\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn test_audit_chrony_log_multiple_last_wins_empty_detects() {
+        // 最終行が空 `log` → 検知
+        let content = "log measurements tracking\nlog\n";
+        let findings = audit_chrony_log(content);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].kind, "chrony_log_no_categories");
+    }
+
+    #[test]
+    fn test_audit_chrony_log_logbanner_logchange_logdir_not_confused() {
+        // `log` と類似の直前マッチしないキーワードに誤反応しない
+        let content = "logbanner 32\nlogchange 1.0\nlogdir /var/log/chrony\n";
+        let findings = audit_chrony_log(content);
+        assert!(findings.is_empty());
+    }
+
+    // ------------------------------------------------------------------
     // audit_chrony_logdir
     // ------------------------------------------------------------------
     #[test]
@@ -5835,6 +5957,36 @@ mod tests {
                 .iter()
                 .all(|f| f.kind != "chrony_logbanner_disabled"),
             "disabling check_chrony_logbanner suppresses the finding"
+        );
+    }
+
+    #[test]
+    fn test_audit_by_kind_log_flag_toggle() {
+        // 最終行が空 `log` → `chrony_log_no_categories` Warning が既定で発火
+        let content =
+            "pool foo\nmakestep 1.0 3\nleapsectz right/UTC\nrtcsync\nmaxchange 1000 1 2\nlog\n";
+        let path = Path::new("/etc/chrony/chrony.conf");
+
+        let mut config = NtpConfigMonitorConfig {
+            check_config_owner: false,
+            check_keys_file_owner: false,
+            ..Default::default()
+        };
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.kind == "chrony_log_no_categories"),
+            "log audit should fire by default when `log` has no categories"
+        );
+
+        config.check_chrony_log = false;
+        let findings = audit_by_kind(NtpConfigKind::Chrony, content, &config, path);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.kind != "chrony_log_no_categories"),
+            "disabling check_chrony_log suppresses the finding"
         );
     }
 


### PR DESCRIPTION
Closes #384

## 概要

- `audit_chrony_log` 関数を追加し、chrony.conf の `log` ディレクティブが **カテゴリ指定なし** で書かれている場合に `chrony_log_no_categories` Warning を 1 件発行する
- `find_keyword_lines` ベースで行頭トークン一致のみを対象。`server ... log` のような inline オプション風の誤用には反応しない
- 複数行ある場合は最終行のみを判定（chrony の後勝ち挙動と一致）
- `NtpConfigMonitorConfig::check_chrony_log`（既定 `true`）で監査の ON/OFF 可能
- Cargo.toml を 1.87.0 → 1.88.0 に更新
- 単体テスト 10 本 + フラグ切替テスト 1 本を追加

## 脅威モデル

chrony のログカテゴリ指定を無効化することで、以下の監査ログ出力をまるごと抑止できる:

- 時刻ソース（server / pool / refclock）切替履歴
- `makestep` / `maxchange` による step 補正イベント
- offset / jitter / RMS の経時的な記録

攻撃者が以下のいずれかの経路で log を無効化すると、偽装 NTP による時刻改竄の痕跡追跡が困難になる（フォレンジック妨害）:

- 稼働中 chrony.conf に空の `log` 行を差し込む
- `/etc/chrony/chrony.d/*.conf` 等のドロップインで `log` を空カテゴリで上書き

設定ミスとして `log` とだけ書いて意図せず observability を失うケースもこの監査で拾える。

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (2673 passed)
- [x] `cargo test --test integration_test` (38 passed)
- [x] `config.example.toml` にフラグ記述と説明を追加済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)